### PR TITLE
Merged download scripts and added schism options to configuration

### DIFF
--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/atlgulf.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/atlgulf.yaml
@@ -1,0 +1,8 @@
+# This file is intended to be an example of how one could list domains available to run
+domain:
+  - name: atlgulf
+    path: ..\..\..\coastalmodels\schism\atlgulf\ # path to base model files
+    region: atlgulf   # General region or basin group
+    epsg: 32615
+    notes: >
+      Example SCHISM domain 

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/atlgulf.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/atlgulf.yaml
@@ -1,7 +1,7 @@
 # This file is intended to be an example of how one could list domains available to run
 domain:
   - name: atlgulf
-    path: ..\..\..\coastalmodels\schism\atlgulf\ # path to base model files
+    path: .\atlgulf\ # path to base model files
     region: atlgulf   # General region or basin group
     epsg: 32615
     notes: >

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/hawaii.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/hawaii.yaml
@@ -1,0 +1,8 @@
+# This file is intended to be an example of how one could list domains available to run
+domain:
+  - name: hawaii
+    path: ..\..\..\coastalmodels\schism\hawaii\ # path to base model files
+    region: hawaii   # General region or basin group
+    epsg: 32615
+    notes: >
+      Example SCHISM domain 

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/hawaii.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/hawaii.yaml
@@ -1,7 +1,7 @@
 # This file is intended to be an example of how one could list domains available to run
 domain:
   - name: hawaii
-    path: ..\..\..\coastalmodels\schism\hawaii\ # path to base model files
+    path: .\hawaii\ # path to base model files
     region: hawaii   # General region or basin group
     epsg: 32615
     notes: >

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/pacific.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/pacific.yaml
@@ -1,7 +1,7 @@
 # This file is intended to be an example of how one could list domains available to run
 domain:
   - name: pacific
-    path: \contrib\Zhengtao.Cui\home\ngwpc\NgenForcing_Sfincs_Forcing_Mohammed\coastal\SFINCS\Testing\coastalforcing\domain_lists\schism\pacific\ # path to base model files
+    path: .\pacific\ # path to base model files
     region: pacific   # General region or basin group
     epsg: 32615
     notes: >

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/pacific.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/pacific.yaml
@@ -1,0 +1,8 @@
+# This file is intended to be an example of how one could list domains available to run
+domain:
+  - name: pacific
+    path: \contrib\Zhengtao.Cui\home\ngwpc\NgenForcing_Sfincs_Forcing_Mohammed\coastal\SFINCS\Testing\coastalforcing\domain_lists\schism\pacific\ # path to base model files
+    region: pacific   # General region or basin group
+    epsg: 32615
+    notes: >
+      Example SCHISM domain 

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/prvi.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/prvi.yaml
@@ -1,0 +1,8 @@
+# This file is intended to be an example of how one could list domains available to run
+domain:
+  - name: prvi
+    path: ..\..\..\coastalmodels\schism\prvi\ # path to base model files
+    region: prvi   # General region or basin group
+    epsg: 32615
+    notes: >
+      Example SCHISM domain 

--- a/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/prvi.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/domain_lists/schism/prvi.yaml
@@ -1,7 +1,7 @@
 # This file is intended to be an example of how one could list domains available to run
 domain:
   - name: prvi
-    path: ..\..\..\coastalmodels\schism\prvi\ # path to base model files
+    path: .\prvi\ # path to base model files
     region: prvi   # General region or basin group
     epsg: 32615
     notes: >

--- a/coastal/SFINCS/Testing/coastalforcing/download_data/data_downloader.py
+++ b/coastal/SFINCS/Testing/coastalforcing/download_data/data_downloader.py
@@ -338,8 +338,11 @@ class DataDownloader:
             print("\n[coastal:stofs]")
             self._download_stofs()
         elif self.coastal == "tpxo":
-            print("\n[coastal:tpxo]")
-            self._download_tpxo()
+            if self.coastal_model == "sfincs" : 
+              print("\n[coastal:tpxo]")
+              self._download_tpxo()
+            else:
+              pass
         elif self.coastal == "glofs":
             print("[coastal:glofs]")
             # self._download_glofs()

--- a/coastal/SFINCS/Testing/coastalforcing/download_data/data_downloader.py
+++ b/coastal/SFINCS/Testing/coastalforcing/download_data/data_downloader.py
@@ -14,12 +14,14 @@ class DataDownloader:
 
     def __init__(
         self,
+        coastal_model: str,
         start_time: str,
         end_time: str,
         meteo_source: str,
         hydrology_source: str,
         coastal_water_level_source: str,
         raw_download_dir: str,
+        nwm_domain: str,
         # optional: provide local paths for sources that already exist on disk
         # local_paths: dict | None = None,
         local_paths: Optional[Dict] = None,
@@ -33,6 +35,8 @@ class DataDownloader:
         self.raw_root = os.path.normpath(raw_download_dir)
         self.local_paths = local_paths or {}
         self.domain_info = domain_info
+        self.coastal_model = coastal_model.lower() 
+        self.domain = nwm_domain.lower() 
 
     # ---------- Public API ----------
     def download_all(self):
@@ -75,14 +79,26 @@ class DataDownloader:
         base = "https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com"
         outdir = self._ensure_dir("meteo", "nwm_retro")
 
+        domain_str= 'CONUS' if self.domain == 'conus' \
+                    else 'Hawaii' if self.domain == 'hawaii' else 'PR'    \
+                    if self.domain == "prvi"  else 'UNKNOWN'
+
         for dt in self._iter_hours():
             year = dt.strftime("%Y")
-            stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # minute is always 00 in this product
-            url = f"{base}/CONUS/netcdf/FORCING/{year}/{stamp_ymdhm}.LDASIN_DOMAIN1"
+            if domain_str == 'CONUS':
+                stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # minute is always 00 in this product
+            else:
+                stamp_ymdhm = dt.strftime("%Y%m%d%H")
+
+            url = f"{base}/{domain_str}/netcdf/FORCING/{year}/{stamp_ymdhm}.LDASIN_DOMAIN1"
 
             date_str = dt.strftime("%Y%m%d")
             hour_str = f"{dt.hour:02d}"
-            dest = os.path.join(outdir, f"{stamp_ymdhm}.LDASIN_DOMAIN1.nc")
+            stamp_ymdh = dt.strftime("%Y%m%d%H")
+
+            dest = os.path.join(outdir, f"{stamp_ymdhm}.LDASIN_DOMAIN1.nc") if  \
+                  self.coastal_model == "sfincs" else  \
+                   os.path.join(outdir, f"{stamp_ymdh}.LDASIN_DOMAIN1")
 
             self._safe_download(url, dest)
 
@@ -116,7 +132,8 @@ class DataDownloader:
         base = "https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com"
         outdir = self._ensure_dir("streamflow", "nwm_retro")
 
-        for dt in self._iter_hours():
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
             year = dt.strftime("%Y")
             stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # always minute 00
             url = f"{base}/CONUS/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
@@ -127,6 +144,33 @@ class DataDownloader:
 
             self._safe_download(url, dest)
 
+        else:
+          domain_str= 'CONUS' if self.domain == 'conus' \
+                    else 'Hawaii' if self.domain == 'hawaii' else 'PR'    \
+                    if self.domain == "prvi"  else 'UNKNOWN'
+
+          for dt in self._iter_hours():
+            year = dt.strftime("%Y")
+            stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # always minute 00
+            url = f"{base}/{domain_str}/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
+
+            date_str = dt.strftime("%Y%m%d")
+            hour_str = f"{dt.hour:02d}"
+
+            dest = os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1.nc") if \
+                           self.coastal_model == "sfincs" else  \
+                         os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1")
+            self._safe_download(url, dest)
+
+            if self.domain == 'hawaii':
+                for t in {15,30,45}:
+                    stamp_ymdhm = dt.strftime("%Y%m%d%H") + f"{t:02d}"  
+                    url = f"{base}/Hawaii/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
+                    dest = os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1.nc") if \
+                           self.coastal_model == "sfincs" else  \
+                           os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1")
+
+                    self._safe_download(url, dest)
 
     # --- STOFS ---
     def _download_stofs(self):
@@ -139,12 +183,20 @@ class DataDownloader:
         Note: STOFS publishes 4 cycles/day (00, 06, 12, 18 Z). We only attempt those
         to avoid noisy 404s.
         """
+        date_name_changed = datetime(2023, 1, 8, 0, 0, 0) #1/8/2023 uses new naming
         base = "https://noaa-gestofs-pds.s3.amazonaws.com"
-        product = "stofs_2d_glo"
-        region = "conus.east.cwl"
+        if self.start_dt < date_name_changed:
+           product = "estofs"
+        else:
+           product = "stofs_2d_glo"
+
+        region = "conus.east.cwl" if  \
+                 self.coastal_model == "sfincs" else "fields.cwl"
+
         outdir = self._ensure_dir("coastal", "stofs")
 
-        for dt in self._iter_hours():
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
             # Only try valid STOFS cycles
             if dt.hour not in (0, 6, 12, 18):
                 continue
@@ -159,6 +211,17 @@ class DataDownloader:
             dest = os.path.join(outdir, fname)
 
             self._safe_download(url, dest)
+        else:
+
+          date_str = self.start_dt.strftime("%Y%m%d")
+          hour = f"{( self.start_dt.hour ) % 6 * 6:02d}"
+          url = f"{base}/{product}.{date_str}/{product}.t{hour}z.{region}.nc"
+
+          # Keep the original filename from the URL
+          fname = os.path.basename(url)
+          dest = os.path.join(outdir, fname)
+          self._safe_download(url, dest)
+
 
     # --- TPXO ---
     def _download_tpxo(self):
@@ -294,11 +357,28 @@ class DataDownloader:
         base = "https://storage.googleapis.com/national-water-model"
         outdir = self._ensure_dir("meteo", "nwm_ana")
 
-        for dt in self._iter_hours():
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
             date_str = dt.strftime("%Y%m%d")
             hour_str = f"{dt.hour:02d}"
             url = f"{base}/nwm.{date_str}/forcing_analysis_assim/nwm.t{hour_str}z.analysis_assim.forcing.tm00.conus.nc"
             filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
+            dest = os.path.join(outdir, filename)
+            self._safe_download(url, dest)
+
+        else:
+          for dt in self._iter_hours():
+            temp_dt = dt + timedelta(hours = 2)
+            date_str = temp_dt.strftime("%Y%m%d")
+            hour_str = f"{temp_dt.hour:02d}"
+            domain_str= '' if self.domain == 'conus' \
+                    else "_puertorico" if self.domain == 'prvi' else f"_{self.domain}"
+            domain_str2= 'conus' if self.domain == 'conus' \
+                    else "puertorico" if self.domain == 'prvi' else f"{self.domain}"
+
+            url = f"{base}/nwm.{date_str}/forcing_analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.forcing.tm02.{domain_str2}.nc"
+            #filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
+            filename = f"{date_str}{dt.hour:02d}.LDASIN_DOMAIN1"
             dest = os.path.join(outdir, filename)
             self._safe_download(url, dest)
 
@@ -310,7 +390,8 @@ class DataDownloader:
         base = "https://storage.googleapis.com/national-water-model"
         outdir = self._ensure_dir("hydro", "nwm")
 
-        for dt in self._iter_hours():
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
             date_str = dt.strftime("%Y%m%d")
             hour_str = f"{dt.hour:02d}"
             url = f"{base}/nwm.{date_str}/analysis_assim/nwm.t{hour_str}z.analysis_assim.channel_rt.tm00.conus.nc"
@@ -318,13 +399,390 @@ class DataDownloader:
             dest = os.path.join(outdir, filename)
             self._safe_download(url, dest)
 
+        else:
+          for dt in self._iter_hours():
+            temp_dt = dt + timedelta(hours = 2)
+            date_str = temp_dt.strftime("%Y%m%d")
+            hour_str = f"{temp_dt.hour:02d}"
+            domain_str= '' if self.domain == 'conus' \
+                    else "_puertorico" if self.domain == 'prvi' else f"_{self.domain}"
+            domain_str2= 'conus' if self.domain == 'conus' \
+                    else "puertorico" if self.domain == 'prvi' else f"{self.domain}"
+
+            if self.domain == 'hawaii':
+               date_str = dt.strftime("%Y%m%d")
+               url = f"{base}/nwm.{date_str}/analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.channel_rt.tm0200.{domain_str2}.nc"
+               filename = f"{date_str}{dt.hour:02d}00.CHRTOUT_DOMAIN1"
+               dest = os.path.join(outdir, filename)
+               self._safe_download(url, dest)
+               for t in [45, 30, 15, 00]:
+                  temp_dt = dt + timedelta(hours = 1)
+                  temp_dt = temp_dt - timedelta( minutes = t)
+                  temp_date_str = temp_dt.strftime("%Y%m%d")
+                  url = f"{base}/nwm.{temp_date_str}/analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.channel_rt.tm01{t:02d}.{domain_str2}.nc"
+                  filename = f"{date_str}{temp_dt.hour:02d}{(60-t)%60:02d}.CHRTOUT_DOMAIN1"
+                  dest = os.path.join(outdir, filename)
+                  self._safe_download(url, dest)
+            else:
+               url = f"{base}/nwm.{date_str}/analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.channel_rt.tm02.{domain_str2}.nc"
+               #filename = f"nwm_channel_rt_{date_str}_{hour_str}.nc"
+               temp_date_str = dt.strftime("%Y%m%d")
+               filename = f"{temp_date_str}{dt.hour:02d}00.CHRTOUT_DOMAIN1"
+               dest = os.path.join(outdir, filename)
+               self._safe_download(url, dest)
 
 
     # ---------- Utilities ----------
     def _iter_hours(self):
         """Yield datetimes at hourly steps: [start_dt, end_dt)"""
         current = self.start_dt
-        while current < self.end_dt:
+        if self.coastal_model == "schism":
+            end_time = self.end_dt + timedelta(hours=1)
+        else:
+            end_time = self.end_dt
+
+        while current < end_time:
+            yield current
+            current += timedelta(hours=1)
+
+    # --- Hydro retrospective ---
+    def _download_nwm_channel_rt_retrospective_orig(self):
+        """
+        Analogous to _download_nwm_channel_rt_ana, but retrospective path.
+        """
+        base = "https://<RETRO_ENDPOINT>"  # TODO
+        outdir = self._ensure_dir("hydro", "nwm_retro")
+        for dt in self._iter_hours():
+            date_str = dt.strftime("%Y%m%d")
+            hour_str = f"{dt.hour:02d}"
+            url = f"{base}/nwm.{date_str}/.../nwm.t{hour_str}z....channel_rt...nc"  # TODO confirm
+            dest = os.path.join(outdir, f"nwm_channel_rt_{date_str}_{hour_str}.nc")
+            self._safe_download(url, dest)
+
+    # --- Streamflow retrospective (NWM R3 CHRTOUT) ---
+    def _download_nwm_channel_rt_retrospective(self):
+        """
+        Download NWM Retrospective 3.0 CONUS CHRTOUT hourly files.
+
+        Source pattern (no .nc extension in the object name):
+          https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com/
+              CONUS/netcdf/CHRTOUT/{YYYY}/{YYYYMMDDHHMM}.CHRTOUT_DOMAIN1
+
+        We save them as:
+          data/raw/streamflow/nwm_retro/CHRTOUT_{YYYYMMDD}_{HH}.nc
+        """
+        base = "https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com"
+        outdir = self._ensure_dir("streamflow", "nwm_retro")
+
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
+            year = dt.strftime("%Y")
+            stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # always minute 00
+            url = f"{base}/CONUS/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
+
+            date_str = dt.strftime("%Y%m%d")
+            hour_str = f"{dt.hour:02d}"
+            dest = os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1.nc")
+
+            self._safe_download(url, dest)
+
+        else:
+          domain_str= 'CONUS' if self.domain == 'conus' \
+                    else 'Hawaii' if self.domain == 'hawaii' else 'PR'    \
+                    if self.domain == "prvi"  else 'UNKNOWN'
+
+          for dt in self._iter_hours():
+            year = dt.strftime("%Y")
+            stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # always minute 00
+            url = f"{base}/{domain_str}/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
+
+            date_str = dt.strftime("%Y%m%d")
+            hour_str = f"{dt.hour:02d}"
+
+            dest = os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1.nc") if \
+                           self.coastal_model == "sfincs" else  \
+                         os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1")
+            self._safe_download(url, dest)
+
+            if self.domain == 'hawaii':
+                for t in {15,30,45}:
+                    stamp_ymdhm = dt.strftime("%Y%m%d%H") + f"{t:02d}"  
+                    url = f"{base}/Hawaii/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
+                    dest = os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1.nc") if \
+                           self.coastal_model == "sfincs" else  \
+                           os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1")
+
+                    self._safe_download(url, dest)
+
+    # --- STOFS ---
+    def _download_stofs(self):
+        """
+        Download STOFS CONUS East combined surge+tide (cwl) GRIB2 files.
+
+        S3 layout (no listing page):
+          https://noaa-gestofs-pds.s3.amazonaws.com/stofs_2d_glo.YYYYMMDD/stofs_2d_glo.tHHz.conus.east.cwl.grib2
+
+        Note: STOFS publishes 4 cycles/day (00, 06, 12, 18 Z). We only attempt those
+        to avoid noisy 404s.
+        """
+        date_name_changed = datetime(2023, 1, 8, 0, 0, 0) #1/8/2023 uses new naming
+        base = "https://noaa-gestofs-pds.s3.amazonaws.com"
+        if self.start_dt < date_name_changed:
+           product = "estofs"
+        else:
+           product = "stofs_2d_glo"
+
+        region = "conus.east.cwl" if  \
+                 self.coastal_model == "sfincs" else "fields.cwl"
+
+        outdir = self._ensure_dir("coastal", "stofs")
+
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
+            # Only try valid STOFS cycles
+            if dt.hour not in (0, 6, 12, 18):
+                continue
+
+            date_str = dt.strftime("%Y%m%d")
+            hour = f"{dt.hour:02d}"
+
+            url = f"{base}/{product}.{date_str}/{product}.t{hour}z.{region}.grib2"
+
+            # Keep the original filename from the URL
+            fname = os.path.basename(url)
+            dest = os.path.join(outdir, fname)
+
+            self._safe_download(url, dest)
+        else:
+
+          date_str = self.start_dt.strftime("%Y%m%d")
+          hour = f"{( self.start_dt.hour ) % 6 * 6:02d}"
+          url = f"{base}/{product}.{date_str}/{product}.t{hour}z.{region}.nc"
+
+          # Keep the original filename from the URL
+          fname = os.path.basename(url)
+          dest = os.path.join(outdir, fname)
+          self._safe_download(url, dest)
+
+
+    # --- TPXO ---
+    def _download_tpxo(self):
+        """
+        TPXO is typically licensed/data-managed; often distributed as static files (binary/NetCDF).
+        For now: support a 'local mirror' copy pattern so the workflow is uniform.
+        """
+        local = self.local_paths.get("tpxo")
+        outdir = self._ensure_dir("coastal", "tpxo")
+        if local:
+            self._copy_tree(local, outdir)
+        else:
+            print("[coastal:tpxo] no remote download; set local_paths['tpxo']")
+
+
+    def _download_glofs(self):
+        """
+        Download GLOFS forecast/nowcast files over the configured time window
+        using download_glofs_range().
+        """
+        from .glofs_downloader import download_glofs_range
+
+        outdir = self._ensure_dir("coastal", "glofs")
+
+        access_area = self.domain_info["domain"][0].get("access_area", "lake-erie-operational-forecast-system-leofs")
+
+        try:
+            files = download_glofs_range(
+                start=self.start_dt,
+                end=self.end_dt,
+                step=timedelta(hours=1),
+                outdir=outdir,
+                access_area=access_area,
+                base_url=os.environ.get(
+                    "GLOFS_BASE_URL",
+                    "https://www.ncei.noaa.gov/data/"
+                    "operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access",
+                ),
+                allow_cached=True,
+            )
+            print(f"[coastal:glofs] wrote {len(files)} files to {outdir}")
+        except Exception as e:
+            print(f"[coastal:glofs] failed: {e}")
+
+
+
+    def _download_glofs_schism(self):
+        """
+        Download GLOFS files for the configured [start_dt, end_dt) range.
+
+        - Groups hourly window into unique UTC dates and calls `download_glofs`
+          once per day.
+        - Output goes under: <raw_download_dir>/coastal/glofs/<domain>/
+        - Domains default to all ("leofs,lmhofs,loofs,lsofs"), override via:
+              GLOFS_DOMAINS="leofs,lsofs"
+        - Overwrite behavior defaults to False, override via:
+              GLOFS_OVERWRITE=1
+        """
+        outdir = self._ensure_dir("coastal", "glofs")
+
+        # Domains from env or default to all four
+
+        '''
+        domains_env = os.environ.get("GLOFS_DOMAINS", "")
+        if domains_env.strip():
+            domains = [d.strip() for d in domains_env.split(",") if d.strip()]
+        else:
+            domains = ["leofs", "lmhofs", "loofs", "lsofs"]
+
+        # Overwrite flag from env (0/1, false/true)
+        overwrite_env = os.environ.get("GLOFS_OVERWRITE", "").strip().lower()
+        overwrite = overwrite_env in ("1", "true", "yes", "y")
+        '''
+
+        # Collect unique yyyymmdd strings across the hourly window
+        unique_dates = sorted({dt.strftime("%Y%m%d") for dt in self._iter_hours()})
+
+        for ymd in unique_dates:
+            try:
+                download_glofs(
+                    utcdate=ymd,
+                    domains=["leofs"],
+                    output_dir=outdir,
+                    overwrite=False,
+                )
+            except Exception as e:
+                print(f"[coastal:glofs] date {ymd} failed: {e}")
+
+
+    # ---------- Internals ----------
+    def _download_meteo(self):
+        if self.meteo == "nwm_ana":
+            print("\ndownload_nwm_meteo_ana:")
+            self._download_nwm_meteo_ana()
+        elif self.meteo == "nwm_retro":
+            print("\ndownload_nwm_meteo_retrospective")
+            self._download_nwm_meteo_retrospective()
+        else:
+            print(f"[meteo] Unhandled meteo source '{self.meteo}'")
+
+    def _download_hydro(self):
+        if self.hydro == "nwm" and self.meteo == "nwm_ana":
+            print("\ndownload_nwm_channel_rt_ana:")
+            self._download_nwm_channel_rt_ana()
+        elif self.hydro == "nwm" and self.meteo == "nwm_retro":
+            print("\ndownload_nwm_channel_rt_ana:")
+            self._download_nwm_channel_rt_retrospective()
+        elif self.hydro == "ngen":
+            print(f"[hydro:ngen] not available yet")
+            # TODO: link to ngen - not a priority right now
+
+    def _download_coastal(self):
+        if self.coastal == "stofs":
+            print("\n[coastal:stofs]")
+            self._download_stofs()
+        elif self.coastal == "tpxo":
+            print("\n[coastal:tpxo]")
+            self._download_tpxo()
+        elif self.coastal == "glofs":
+            print("[coastal:glofs]")
+            # self._download_glofs()
+        else:
+            print(f"[hydro] Unhandled hydro source '{self.hydro}'")
+
+    # ---------- Concrete downloaders ----------
+    def _download_nwm_meteo_ana(self):
+        """
+        Example URL pattern (provided):
+        https://storage.googleapis.com/national-water-model/nwm.{date}/forcing_analysis_assim/nwm.t{hour:02d}z.analysis_assim.forcing.tm00.conus.nc
+        - date as YYYYMMDD
+        - hour as 00..23
+        """
+        base = "https://storage.googleapis.com/national-water-model"
+        outdir = self._ensure_dir("meteo", "nwm_ana")
+
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
+            date_str = dt.strftime("%Y%m%d")
+            hour_str = f"{dt.hour:02d}"
+            url = f"{base}/nwm.{date_str}/forcing_analysis_assim/nwm.t{hour_str}z.analysis_assim.forcing.tm00.conus.nc"
+            filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
+            dest = os.path.join(outdir, filename)
+            self._safe_download(url, dest)
+
+        else:
+          for dt in self._iter_hours():
+            temp_dt = dt + timedelta(hours = 2)
+            date_str = temp_dt.strftime("%Y%m%d")
+            hour_str = f"{temp_dt.hour:02d}"
+            domain_str= '' if self.domain == 'conus' \
+                    else "_puertorico" if self.domain == 'prvi' else f"_{self.domain}"
+            domain_str2= 'conus' if self.domain == 'conus' \
+                    else "puertorico" if self.domain == 'prvi' else f"{self.domain}"
+
+            url = f"{base}/nwm.{date_str}/forcing_analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.forcing.tm02.{domain_str2}.nc"
+            #filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
+            filename = f"{date_str}{dt.hour:02d}.LDASIN_DOMAIN1"
+            dest = os.path.join(outdir, filename)
+            self._safe_download(url, dest)
+
+    def _download_nwm_channel_rt_ana(self):
+        """
+        Example URL pattern (provided):
+        https://storage.googleapis.com/national-water-model/nwm.{date}/analysis_assim/nwm.t{hour:02d}z.analysis_assim.channel_rt.tm00.conus.nc
+        """
+        base = "https://storage.googleapis.com/national-water-model"
+        outdir = self._ensure_dir("hydro", "nwm")
+
+        if self.coastal_model == "sfincs" : 
+          for dt in self._iter_hours():
+            date_str = dt.strftime("%Y%m%d")
+            hour_str = f"{dt.hour:02d}"
+            url = f"{base}/nwm.{date_str}/analysis_assim/nwm.t{hour_str}z.analysis_assim.channel_rt.tm00.conus.nc"
+            filename = f"nwm_channel_rt_{date_str}_{hour_str}.nc"
+            dest = os.path.join(outdir, filename)
+            self._safe_download(url, dest)
+
+        else:
+          for dt in self._iter_hours():
+            temp_dt = dt + timedelta(hours = 2)
+            date_str = temp_dt.strftime("%Y%m%d")
+            hour_str = f"{temp_dt.hour:02d}"
+            domain_str= '' if self.domain == 'conus' \
+                    else "_puertorico" if self.domain == 'prvi' else f"_{self.domain}"
+            domain_str2= 'conus' if self.domain == 'conus' \
+                    else "puertorico" if self.domain == 'prvi' else f"{self.domain}"
+
+            if self.domain == 'hawaii':
+               date_str = dt.strftime("%Y%m%d")
+               url = f"{base}/nwm.{date_str}/analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.channel_rt.tm0200.{domain_str2}.nc"
+               filename = f"{date_str}{dt.hour:02d}00.CHRTOUT_DOMAIN1"
+               dest = os.path.join(outdir, filename)
+               self._safe_download(url, dest)
+               for t in [45, 30, 15, 00]:
+                  temp_dt = dt + timedelta(hours = 1)
+                  temp_dt = temp_dt - timedelta( minutes = t)
+                  temp_date_str = temp_dt.strftime("%Y%m%d")
+                  url = f"{base}/nwm.{temp_date_str}/analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.channel_rt.tm01{t:02d}.{domain_str2}.nc"
+                  filename = f"{date_str}{temp_dt.hour:02d}{(60-t)%60:02d}.CHRTOUT_DOMAIN1"
+                  dest = os.path.join(outdir, filename)
+                  self._safe_download(url, dest)
+            else:
+               url = f"{base}/nwm.{date_str}/analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.channel_rt.tm02.{domain_str2}.nc"
+               #filename = f"nwm_channel_rt_{date_str}_{hour_str}.nc"
+               temp_date_str = dt.strftime("%Y%m%d")
+               filename = f"{temp_date_str}{dt.hour:02d}00.CHRTOUT_DOMAIN1"
+               dest = os.path.join(outdir, filename)
+               self._safe_download(url, dest)
+
+
+    # ---------- Utilities ----------
+    def _iter_hours(self):
+        """Yield datetimes at hourly steps: [start_dt, end_dt)"""
+        current = self.start_dt
+        if self.coastal_model == "schism":
+            end_time = self.end_dt + timedelta(hours=1)
+        else:
+            end_time = self.end_dt
+        while current < end_time:
             yield current
             current += timedelta(hours=1)
 

--- a/coastal/SFINCS/Testing/coastalforcing/main.py
+++ b/coastal/SFINCS/Testing/coastalforcing/main.py
@@ -179,6 +179,41 @@ def prepare_sfincs_base_simulation_folder(cfg, domain_info):
     else:
         print(f"WARNING: sfincs.inp not found in {sim_dir}")
 
+def prepare_schism_base_simulation_folder(cfg, domain_info):
+    # Normalize & ensure dirs
+    sim_root = _normpath(cfg['sim_dir'])
+    start_iso = _parse_utc(cfg['start_time'])
+    run_folder_name = f"{cfg['coastal_model']}_{start_iso}"
+    sim_dir = _normpath(sim_root, run_folder_name)
+    Path(sim_dir).mkdir(parents=True, exist_ok=True)
+
+    dts = datetime.strptime(_parse_utc(cfg['start_time']), "%Y-%m-%dT%H-%M-%SZ")
+    dte = datetime.strptime(_parse_utc(cfg['end_time']), "%Y-%m-%dT%H-%M-%SZ")
+
+    startpdy = dts.strftime( "%Y%m%d")
+    startcyc = dts.strftime("%H")
+
+    forecastlength_in_hrs = int( (dte - dts).total_seconds()/3600 )
+
+    here = Path(__file__).resolve().parent
+    raw_download_dir=_normpath(here, cfg['raw_download_dir'])
+
+    with open( f"{sim_dir}/schism_calib.cfg", "w") as schcfg:
+      schcfg.write(f"export STARTPDY={startpdy}\n")
+      schcfg.write(f"export STARTCYC={startcyc}\n")
+      schcfg.write(f"export FCST_LENGTH_HRS={forecastlength_in_hrs}\n")
+      schcfg.write("export HOT_START_FILE=\'\'\n")
+      if cfg['coastal_water_level_source'] == 'tpxo':
+        schcfg.write('export USE_TPXO="YES"\n')
+      else:
+        schcfg.write('export USE_TPXO="NO"\n')
+      schcfg.write(f"export COASTAL_DOMAIN={cfg['domain_file']}\n")
+      schcfg.write(f"export METEO_SOURCE={cfg['meteo_source'].upper()}\n")
+      schcfg.write(f"export COASTAL_WORK_DIR={sim_dir}\n")
+      schcfg.write(f"export RAW_DOWNLOAD_DIR={raw_download_dir}\n")
+      schcfg.write("SIF_PATH=/contrib/Zhengtao.Cui/home/ngwpc/singularity/ngen_coastal_sing.sif\n")
+
+
 # ---- Main ----
 
 def main():
@@ -200,6 +235,9 @@ def main():
         cfg = yaml.safe_load(f)
 
     validate_config(cfg)
+
+    nwm_domain = cfg['domain_file'] if cfg['domain_file'] == 'hawaii' or cfg['domain_file'] == 'prvi' else \
+                 'conus' 
 
     # Load domain info and normalize base path relative to the domain YAML
     domain_file = f"domain_lists/{cfg['coastal_model']}/{cfg['domain_file']}.yaml"
@@ -226,12 +264,14 @@ def main():
 
     # Download data
     downloader = DataDownloader(
+        coastal_model=cfg['coastal_model'],
         start_time=_parse_utc(cfg['start_time']),
         end_time=_parse_utc(cfg['end_time']),
         meteo_source=cfg['meteo_source'],
         hydrology_source=cfg['hydrology_source'],
         coastal_water_level_source=cfg['coastal_water_level_source'],
         raw_download_dir=_normpath(here, cfg['raw_download_dir']),
+        nwm_domain=nwm_domain,
         domain_info=domain_info
     )
     downloader.download_all()
@@ -240,21 +280,22 @@ def main():
     if cfg["coastal_model"].lower() == "sfincs":
         prepare_sfincs_base_simulation_folder(cfg, domain_info)
     elif cfg["coastal_model"].lower() == "schism":
-        print("SCHISM simulation preparation not yet implemented.")
+        prepare_schism_base_simulation_folder(cfg, domain_info)
     else:
         print(f"WARNING: No preparation routine defined for model '{cfg['coastal_model']}'.")
 
     # Process data
     sim_dir = _normpath(here, cfg['sim_dir'], f"{cfg['coastal_model']}_{_parse_utc(cfg['start_time'])}")
 
-    tpxo_env = None
-    ld_library_path = cfg.get('ld_library_path', None)
-    if ld_library_path:
+    if  cfg["coastal_model"].lower() == "sfincs": 
+      tpxo_env = None
+      ld_library_path = cfg.get('ld_library_path', None)
+      if ld_library_path:
         tpxo_env={
             "LD_LIBRARY_PATH": ld_library_path
         }
 
-    processor = DataProcessor(
+      processor = DataProcessor(
         coastal_model=cfg['coastal_model'],
         domain_info=domain_info,
         sim_dir=sim_dir,
@@ -267,8 +308,8 @@ def main():
         tpxo_relative_path=cfg.get('tpxo_relative_path', None),
         tpxo_model_control=cfg.get('tpxo_model_control', None),
         tpxo_env=tpxo_env
-    )
-    processor.process_all()
+      )
+      processor.process_all()
 
     print("Forcing file generation COMPLETE")
 

--- a/coastal/SFINCS/Testing/coastalforcing/schism_config.yaml
+++ b/coastal/SFINCS/Testing/coastalforcing/schism_config.yaml
@@ -1,0 +1,23 @@
+# -----------------------------------------------------------------------------
+# User Configuration File for Coastal Forcing
+#
+# This file controls model type, hydrology source, meteo source, 
+# coastal water level source, domain selection, and output paths.
+# -----------------------------------------------------------------------------
+coastal_model: schism                   # Options: schism, sfincs
+meteo_source: nwm_retro                  # Options: nwm_retro, nwm_ana
+hydrology_source: nwm                   # Options: nwm, ngen
+coastal_water_level_source: stofs      # Options: stofs, tpxo, glofs (great lakes only)
+# domain_file: /contrib/MohammedKarim/ngwpc/FORCING/Testing/coastalforcing/domain_lists/sfincs/texas_example              # Options: see domain_lists/{coastal_model}/
+domain_file: pacific
+start_time: 2022-06-11T00-00-00Z        # Simulation start time in format YYYY-MM-DDTHH-MM-SSZ
+end_time: 2022-06-11T03-00-00Z          # Simulation end time in format YYYY-MM-DDTHH-MM-SSZ
+
+# These should be externally mounted
+raw_download_dir: /efs/schism_use_case/sfincs_config_test/data/raw          # Directory for storing raw downloaded data
+sim_dir: /efs/schism_use_case/sfincs_config_test  # Directory for storing all processed model files ready to run
+
+# TPXO Info 
+tpxo_relative_path: process_data/TPXO
+tpxo_model_control: Model_tpxo10_atlas  # inside relative path w.r.t tpxo_relative_path
+ld_library_path: /contrib/software/gcc/8.5.0/lib64:/contrib/software/netcdf/4.7.4/lib


### PR DESCRIPTION
Merged the download scripts for both sfinics and schism. Updated the configuration such that the schism calibration use case will be able to use the same configuration files as sfincs. See stories
https://jira.nextgenwaterprediction.com/browse/NGWPC-7695
and https://jira.nextgenwaterprediction.com/browse/NGWPC-7692


[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

