### PR TITLE
ngwpc 7354 - Fixing unstructured mesh variables node/element locations

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -143,6 +143,18 @@ class OutputObj:
                         ConfigOptions.errMsg = f"Unable to create element id dimension in: {self.outPath} - {e}"
                         err_handler.log_critical(ConfigOptions, MpiConfig)
                         break
+                    try:
+                        self.idOut.createDimension("nodeCount", geoMetaWrfHydro.ny_global)  # Node ID dimension for unstructured grid
+                    except Exception as e:
+                        ConfigOptions.errMsg = f"Unable to create nodeCount dimension in: {self.outPath} - {e}"
+                        err_handler.log_critical(ConfigOptions, MpiConfig)
+                        break
+                    try:
+                        self.idOut.createDimension("coordDim", 2)  # Node ID dimension for unstructured grid
+                    except Exception as e:
+                        ConfigOptions.errMsg = f"Unable to create coordDim dimension in: {self.outPath} - {e}"
+                        err_handler.log_critical(ConfigOptions, MpiConfig)
+                        break
 
                 # Set global attributes for the output file (model initialization time, version, etc.)
                 try:
@@ -236,6 +248,8 @@ class OutputObj:
                 elif ConfigOptions.grid_type == "unstructured":
                     dim_x = "element-id"
                     dim_y = "element-id"
+                    dim_node = "nodeCount"
+                    dim_coord = "coordDim"
                 else:
                     raise ValueError(f'Invalid grid_type: {ConfigOptions.grid_type}')
 
@@ -386,6 +400,36 @@ class OutputObj:
                             err_handler.log_critical(ConfigOptions, MpiConfig)
                             break
 
+                    # added node dimension and coordinates for 'unstructured', necessary for schism
+                    # the SCHISM BMI uses elements for RAINTATE but nodes for all other variables
+                    if ConfigOptions.grid_type == "unstructured":
+                      try:
+                        if ConfigOptions.useCompression == 1:
+                            self.idOut.createVariable('nodeCoords', 'f8', (dim_node,dim_coord), zlib=True, complevel=2)
+                        else:
+                            self.idOut.createVariable('nodeCoords', 'f8', ( dim_node, dim_coord) )
+                      except Exception as e:
+                        ConfigOptions.errMsg = f"Unable to create node variable in: {self.outPath} - {e}"
+                        err_handler.log_critical(ConfigOptions, MpiConfig)
+                        break
+
+                      try:
+                        self.idOut.variables['nodeCoords'].setncattr("standard_name", "Longitude/Latitude")
+                        self.idOut.variables['nodeCoords'].setncattr("long_name", "Longitude and latitude coordinate of projection")
+                        self.idOut.variables['nodeCoords'].setncattr("units", units)
+                      except Exception as e:
+                        ConfigOptions.errMsg = f"Unable to establish node coordinate attributes in: {self.outPath} - {e}"
+                        err_handler.log_critical(ConfigOptions, MpiConfig)
+                        break
+
+                      try:
+                        self.idOut.variables['nodeCoords'][:,:] = idTmp.variables[ConfigOptions.nodecoords_var][:,:]
+                      except Exception as e:
+                        ConfigOptions.errMsg = f"Unable to place node coordinate values into output variable for output file: {self.outPath} - {e}"
+                        err_handler.log_critical(ConfigOptions, MpiConfig)
+                        break
+
+
                     if ConfigOptions.grid_type == "hydrofabric":
                         try:
                             self.idOut.createVariable('ids', 'str', dim_y)
@@ -456,6 +500,25 @@ class OutputObj:
                                 complevel=complevel,
                                 least_significant_digit=least_significant_digit
                             )
+                        elif ConfigOptions.grid_type == "unstructured":
+                            if  varTmp == 'RAINRATE': 
+                              # use elements for RAINATE only
+                              self.idOut.createVariable(
+                                varTmp, dtype, ('time', dim_y),
+                                fill_value=fill_value,
+                                zlib=zlib,
+                                complevel=complevel,
+                                least_significant_digit=least_significant_digit
+                              )
+                            else:
+                              # use nodes for other variables
+                              self.idOut.createVariable(
+                                varTmp, dtype, ('time', dim_node),
+                                fill_value=fill_value,
+                                zlib=zlib,
+                                complevel=complevel,
+                                least_significant_digit=least_significant_digit
+                              )
                         else:
                             self.idOut.createVariable(
                                 varTmp, dtype, ('time', dim_y),
@@ -612,7 +675,10 @@ class OutputObj:
                 elif ConfigOptions.grid_type == "hydrofabric":
                     dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local[output_variable_attribute_dict[varTmp][0], :], ConfigOptions)
                 elif ConfigOptions.grid_type == "unstructured":
-                    dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local_elem[output_variable_attribute_dict[varTmp][0], :], ConfigOptions)
+                    if varTmp == "RAINRATE":
+                      dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local_elem[output_variable_attribute_dict[varTmp][0], :], ConfigOptions)
+                    else:
+                      dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local[output_variable_attribute_dict[varTmp][0], :], ConfigOptions)
                 else:
                     raise ValueError(f'Invalid grid_type: {ConfigOptions.grid_type}')
             except Exception as e:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -6232,6 +6232,8 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
         # Remove all four scratch files on every rank
         for f in (mrms_tmp_grib2, mrms_tmp_nc, mrms_tmp_rqi_grib2, mrms_tmp_rqi_nc):
+          #only do this on the first rank to avoid "Unable remove scratch file" error
+          if mpi_config.rank == 0:
             if os.path.isfile(f):
                 try:
                     os.remove(f)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -6232,11 +6232,12 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
         # Remove all four scratch files on every rank
         for f in (mrms_tmp_grib2, mrms_tmp_nc, mrms_tmp_rqi_grib2, mrms_tmp_rqi_nc):
-          #only do this on the first rank to avoid "Unable remove scratch file" error
-          if mpi_config.rank == 0:
             if os.path.isfile(f):
                 try:
                     os.remove(f)
+                #need this to avoid "Unable remove scratch file" error
+                except FileNotFoundError:
+                    pass
                 except OSError:
                     config_options.errMsg = f"Unable to remove scratch file: {f}"
                     err_handler.log_critical(config_options, mpi_config)


### PR DESCRIPTION
The SCHISM BMI requires the `RAINRATE` variable to be located on the elements and the other variables to be located on the nodes. Changed the code to output variables on the nodes except `RAINRATE`. 

## Additions

- Added node output for variables `V2D, U2D, LWDOWN, T2D, Q2D, PSFC, SWDOWN` in unstructured mesh
- Added `nodeCount` and node coordinates to the output NetCDF file.

## Removals

- Removed element output for variables `V2D, U2D, LWDOWN, T2D, Q2D, PSFC, SWDOWN` in unstructured mesh

## Changes

- Updated the unstructured output NetCDF data model to use elements for `RAINRATE` and nodes for other variables.

## Testing

1. Tested with the Hawaii domain mesh for the extended AnA configuration

## Screenshots


## Notes

- Currently on the extended AnA configuration works. The other configurations have data input problems that need to be fixed.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

