### PR TITLE
Add NetCDF-C and NetCDF-Fortran to Ngen-forcing-sfincs image

### DIFF
--- a/Dockerfile.sfincs
+++ b/Dockerfile.sfincs
@@ -9,6 +9,9 @@ ENV PYTHON_VERSION=3.11
 ENV MINICONDA_VERSION="latest"
 ENV MINICONDA_INSTALLER_URL="https://github.com/conda-forge/miniforge/releases/${MINICONDA_VERSION}/download/Miniforge3-Linux-x86_64.sh"
 
+ENV NETCDF_C_VERSION="4.7.4" 
+ENV NETCDF_FORTRAN_VERSION="4.5.4" 
+
 # basic tools (works whether the base is apt or dnf)
 RUN set -eux; \
   if command -v apt-get >/dev/null 2>&1; then \
@@ -36,6 +39,44 @@ RUN set -eux; \
   "${CONDA_DIR}/bin/conda" config --system --set always_yes yes --set changeps1 no; \
   "${CONDA_DIR}/bin/conda" install "python=${PYTHON_VERSION}" pip; \
   "${CONDA_DIR}/bin/conda" clean --all --yes
+
+RUN set -eux; \
+    \
+    curl --location --output netcdf-c.tar.gz "https://github.com/Unidata/netcdf-c/archive/refs/tags/v${NETCDF_C_VERSION%%[a-z]*}.tar.gz"; \
+    mkdir --parents /usr/src/netcdf-c; \
+    tar --extract --directory /usr/src/netcdf-c --strip-components=1 --file netcdf-c.tar.gz; \
+    rm netcdf-c.tar.gz; \
+    \
+    cd /usr/src/netcdf-c; \
+    cmake -B cmake_build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DENABLE_TESTS=OFF \
+    ; \
+    nproc="$(nproc)"; \
+    cmake --build cmake_build --parallel "$nproc" \
+    ; \
+    cmake --build cmake_build --target install ; \
+    \
+    rm --recursive --force /usr/src/netcdf-c
+
+RUN set -eux; \
+    \
+    curl --location --output netcdf-fortran.tar.gz "https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v${NETCDF_FORTRAN_VERSION%%[a-z]*}.tar.gz"; \
+    mkdir --parents /usr/src/netcdf-fortran; \
+    tar --extract --directory /usr/src/netcdf-fortran --strip-components=1 --file netcdf-fortran.tar.gz; \
+    rm netcdf-fortran.tar.gz; \
+    \
+    cd /usr/src/netcdf-fortran; \
+    cmake -B cmake_build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DENABLE_TESTS=OFF \
+    -DCMAKE_Fortran_COMPILER=/opt/rh/gcc-toolset-10/root/usr/bin/gfortran \
+    ; \
+    nproc="$(nproc)"; \
+    cmake --build cmake_build --parallel "$nproc" \
+    ; \
+    cmake --build cmake_build --target install ; \
+    \
+    rm --recursive --force /usr/src/netcdf-fortran
+
+#Env for netcdf-fortran
+ENV LD_LIBRARY_PATH=/usr/local/lib64
 
 # venv
 ENV VENV_DIR=/opt/venv

--- a/Dockerfile.sfincs
+++ b/Dockerfile.sfincs
@@ -9,21 +9,17 @@ ENV PYTHON_VERSION=3.11
 ENV MINICONDA_VERSION="latest"
 ENV MINICONDA_INSTALLER_URL="https://github.com/conda-forge/miniforge/releases/${MINICONDA_VERSION}/download/Miniforge3-Linux-x86_64.sh"
 
-ENV NETCDF_C_VERSION="4.7.4" 
-ENV NETCDF_FORTRAN_VERSION="4.5.4" 
+ENV NETCDF_C_VERSION="4.7.4"
+ENV NETCDF_FORTRAN_VERSION="4.5.4"
 
-# basic tools (works whether the base is apt or dnf)
+# basic build tools for Ubuntu (apt)
 RUN set -eux; \
-  if command -v apt-get >/dev/null 2>&1; then \
-    apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      ca-certificates curl bash bzip2 unzip tar findutils; \
-    rm -rf /var/lib/apt/lists/*; \
-  elif command -v dnf >/dev/null 2>&1; then \
-    dnf -y install --setopt=install_weak_deps=False --setopt=deltarpm=false \
-      ca-certificates curl bash bzip2 unzip tar findutils; \
-    dnf clean all && rm -rf /var/cache/dnf; \
-  fi
+  apt-get update; \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates curl \
+    build-essential cmake gfortran m4 pkg-config \
+    libhdf5-dev zlib1g-dev libcurl4-openssl-dev; \
+  rm -rf /var/lib/apt/lists/*
 
 # locale & python env
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 \
@@ -54,7 +50,7 @@ RUN set -eux; \
     cmake --build cmake_build --parallel "$nproc" \
     ; \
     cmake --build cmake_build --target install ; \
-    \
+    ldconfig ; \
     rm --recursive --force /usr/src/netcdf-c
 
 RUN set -eux; \
@@ -66,17 +62,17 @@ RUN set -eux; \
     \
     cd /usr/src/netcdf-fortran; \
     cmake -B cmake_build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON -DENABLE_TESTS=OFF \
-    -DCMAKE_Fortran_COMPILER=/opt/rh/gcc-toolset-10/root/usr/bin/gfortran \
+    -DCMAKE_Fortran_COMPILER=/usr/bin/gfortran \
     ; \
     nproc="$(nproc)"; \
     cmake --build cmake_build --parallel "$nproc" \
     ; \
     cmake --build cmake_build --target install ; \
-    \
+    ldconfig ; \
     rm --recursive --force /usr/src/netcdf-fortran
 
-#Env for netcdf-fortran
-ENV LD_LIBRARY_PATH=/usr/local/lib64
+# runtime search path for locally installed libs
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
 # venv
 ENV VENV_DIR=/opt/venv

--- a/coastal/SFINCS/requirements.txt
+++ b/coastal/SFINCS/requirements.txt
@@ -1,4 +1,4 @@
-pyYaml
+PyYAML
 numpy
 xarray
 pyproj
@@ -7,3 +7,4 @@ matplotlib
 scipy
 netcdf4
 requests
+cfgrib==0.9.15.0


### PR DESCRIPTION
To run Sfincs forcing (TPXO), we need NetCDF-Fortran (which needs netCDF-C).
We need to add that to the image.

## Additions

NetCDF-Fortran 
NetCDF-C

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

