### PR TITLE
fixing logic for supplemental radar forcing_extraction time handling

### DIFF
--- a/NextGen_Forcings_Engine_BMI/forcing_extraction.py
+++ b/NextGen_Forcings_Engine_BMI/forcing_extraction.py
@@ -60,6 +60,8 @@ def retrieve_forcing(cfg: 'ConfigOptions'):
     # Extract forcing data from appropriate sources
     for i in range(len(input_forcings)):
 
+        #print(f"i: {i}, input_forcings[i]: {input_forcings[i]}, input_horizons[i]: {input_horizons[i]}, ")
+
         # Format extraction path
         extract_outPath = input_forcing_dirs[i]
 
@@ -69,9 +71,14 @@ def retrieve_forcing(cfg: 'ConfigOptions'):
             forcing_script = forcing_src.get(input_forcings[i])
             forcing_start_time = refcstbdate + timedelta(hours=1)
         elif ana_flag == 1:
-            look_back_hours = int(look_back / 60) + 1
-            forcing_start_time = refcstbdate + timedelta(hours=(look_back_hours-1))
-            forcing_script = forcing_ana_src.get(input_forcings[i])
+            if input_forcings[i] in ("supp1", "supp2", "supp6", "supp10", "supp11", "supp12"):
+                look_back_hours = int(look_back / 60) + 1
+                forcing_start_time = refcstbdate + timedelta(hours=(look_back_hours))
+                forcing_script = forcing_ana_src.get(input_forcings[i])
+            else:
+                look_back_hours = int(look_back / 60) + 1
+                forcing_start_time = refcstbdate + timedelta(hours=(look_back_hours-1))
+                forcing_script = forcing_ana_src.get(input_forcings[i])
 
         # Set path to extraction script
         extract_scriptPath = Path(extraction_scriptPath) / forcing_script


### PR DESCRIPTION
There are minor changes to time handling for downloading radar data (ie: mrms). Valid times work differently from atmospheric model data.

## Changes

- Updated time handling in forcing_extraction to account for radar differences.

## Testing

1. Tested locally on my build (Kyle)
2. Peter testing on ngenCERF build. (Peter).

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

