### PR TITLE
Reduce unnecessary model runs (NGWPC-8671)

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -663,8 +663,8 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
 
         :return: None
         """
-        self._values['current_model_time'] += self._values['time_step_size']
-        self.update_until(self._values['current_model_time'])
+        # Run the model to the next timestep
+        self.update_until(self._values['current_model_time'] + self._values["time_step_size"])
 
     # ------------------------------------------------------------
     def update_until(self, future_time: float):
@@ -679,11 +679,13 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         :param future_time: The target time to update the model to.
         :return: None
         """
-        
-        # Flag to check if future_time is different from the current model time.
-        # If future_time is not equal to the current model time, we perform an
-        # iterative update, advancing time in steps until we reach future_time.
-        if future_time != self._values['current_model_time']:
+
+        # Method for running the model on the initial time if the model has not been run,
+        # and the future time is the same as the initial time.
+        if self._values["current_model_time"] == future_time == self.cfg_bmi["initial_time"]:
+            self._model.run(self._values, future_time, self._job_meta, self._WrfHydroGeoMeta,
+                            self._inputForcingMod, self._suppPcpMod, self._mpi_meta, self._OutputObj)
+        else:
             # Start a while loop to iterate the model time step by step until the
             # current model time reaches or exceeds the future_time.
             while self._values['current_model_time'] < future_time:
@@ -692,11 +694,6 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
                 # Run the model for the new current time and update the state.
                 self._model.run(self._values, self._values['current_model_time'], self._job_meta, self._WrfHydroGeoMeta,
                                 self._inputForcingMod, self._suppPcpMod, self._mpi_meta, self._OutputObj)
-        else:
-            # If future_time is the same as current_model_time, just run the model
-            # for a single time step without entering a loop.
-            self._model.run(self._values, future_time, self._job_meta, self._WrfHydroGeoMeta,
-                            self._inputForcingMod, self._suppPcpMod, self._mpi_meta, self._OutputObj)
 
     # ------------------------------------------------------------
     def finalize(self):


### PR DESCRIPTION
Prevent the BMI from running the model when `update_until` is called with the future time equal to the current model time. I found no benefit for running the model multiple times on the same timestep, so this should reduce unnecessary processing. The `update` method was changed to accommodate this new behavior.

[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

- The NGEN BMI's `update` method will pass the sum of its current time and its time step to `update_until` instead of modifying its current time.
- The NGEN BMI's `update_until` function will no longer run the model when the BMI's current time is the same as the future time parameter.

## Testing

1. Tested using various configurations to confirm efficient calling and correct time handling.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

