### PR TITLE
Add Error and Warning Trapping System Logger (NGWPC-7198)

### DIFF
--- a/Forcing_Extraction_Scripts/forecast_download_base.py
+++ b/Forcing_Extraction_Scripts/forecast_download_base.py
@@ -11,6 +11,13 @@ from urllib import request, error
 import requests
 from bs4 import BeautifulSoup
 
+import logging
+from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
+if not LOG.handlers:
+    # No handlers attached — fallback to default root logger
+    logging.basicConfig()
+    LOG = logging.getLogger()
 
 class ForecastDownloader(ABC):
     """
@@ -214,7 +221,7 @@ class ForecastDownloader(ABC):
         if os.path.isfile(self.lockfile):
             with open(self.lockfile, 'r') as f:
                 pid = f.readline().strip()
-            print(f"ERROR: Lock file {self.lockfile} exists. PID: {pid}")
+            LOG.critical(f"Lock file {self.lockfile} exists. PID: {pid}")
             sys.exit(1)
 
         with open(self.lockfile, 'w') as f:
@@ -231,7 +238,7 @@ class ForecastDownloader(ABC):
             try:
                 os.remove(self.lockfile)
             except Exception as e:
-                print(f"Warning: Failed to remove lockfile: {e}")
+                LOG.warning(f"Failed to remove lockfile: {e}")
 
     def _cleanup_old_data(self):
         """
@@ -252,7 +259,7 @@ class ForecastDownloader(ABC):
                 # Default behavior: remove build_output_dir if it exists
                 dir_path = self.build_output_dir(d_start, self.ens_number)
                 if os.path.isdir(dir_path):
-                    print(f"Removing old data: {dir_path}")
+                    LOG.debug(f"Removing old data: {dir_path}")
                     shutil.rmtree(dir_path)
 
     @staticmethod
@@ -264,14 +271,14 @@ class ForecastDownloader(ABC):
         :param levels: Max number of parent levels to prune if empty.
         """
         if os.path.isdir(path):
-            print(f"Removing directory: {path}")
+            LOG.debug(f"Removing directory: {path}")
             shutil.rmtree(path)
 
             # Prune up to `levels` empty parent directories
             for _ in range(levels):
                 path = os.path.dirname(path)
                 if os.path.isdir(path) and not os.listdir(path):
-                    print(f"Removing empty parent directory: {path}")
+                    LOG.debug(f"Removing empty parent directory: {path}")
                     os.rmdir(path)
                 else:
                     break
@@ -281,13 +288,14 @@ class ForecastDownloader(ABC):
         Download forecast files by iterating over the desired time range and download targets.
         Each timestamp may have one or more targets to process.
         """
+        LOG.info(f"ForecastDownloader: Download data. lookback: {self.lookback_hours} lagback: {self.effective_lagback()}")
         for hour in range(self.lookback_hours, self.effective_lagback(), -1):
             d_start = self.start_time - timedelta(hours=hour)
 
             if self.should_process_hour(d_start):
-                print(f"Processing hour offset: {hour}, timestamp: {d_start}")
+                LOG.debug(f"Processing hour offset: {hour}, timestamp: {d_start}")
             else:
-                print(f"Skipping hour offset: {hour}, timestamp: {d_start}")
+                LOG.debug(f"Skipping hour offset: {hour}, timestamp: {d_start}")
                 continue
 
             output_dir = self.build_output_dir(d_start, self.ens_number)
@@ -301,7 +309,7 @@ class ForecastDownloader(ABC):
                 out_path = os.path.join(output_dir, filename)
 
                 if os.path.isfile(out_path):
-                    print(f"Skipping existing: {out_path}")
+                    LOG.debug(f"Skipping existing: {out_path}")
                     continue
 
                 self._download_file(url, out_path)
@@ -320,24 +328,24 @@ class ForecastDownloader(ABC):
 
         while attempt < max_attempts:
             try:
-                print(f"Attempt {attempt + 1}: Downloading {url}")
+                LOG.debug(f"Attempt {attempt + 1}: Downloading {url}")
                 request.urlretrieve(url, out_path)
-                print(f"Download complete: {out_path}")
+                LOG.debug(f"Download complete: {out_path}")
                 return
             except error.HTTPError as e:
                 if e.code == 404:
-                    print(f"File not found (404): {url} - Stopping retries")
+                    LOG.error(f"File not found (404): {url} - Stopping retries")
                     return False
-                print(f"HTTPError {e.code} while downloading {url}: {e.reason}")
+                LOG.error(f"HTTPError {e.code} while downloading {url}: {e.reason}")
             except error.URLError as e:
-                print(f"URLError while downloading {url}: {e.reason}")
+                LOG.error(f"URLError while downloading {url}: {e.reason}")
             except Exception as e:
-                print(f"Unexpected error while downloading {url}: {e}")
+                LOG.error(f"Unexpected error while downloading {url}: {e}")
 
             attempt += 1
             time.sleep(interval)
 
-        print(f"Failed to download after {max_attempts} attempts: {url}")
+        LOG.error(f"Failed to download after {max_attempts} attempts: {url}")
 
 
 class FixedFileDownloader(ForecastDownloader, ABC):
@@ -366,13 +374,14 @@ class FixedFileDownloader(ForecastDownloader, ABC):
         pass
 
     def _download_data(self):
+        LOG.info(f"FixedFileDownloader: Download data. lookback: {self.lookback_hours} lagback: {self.effective_lagback()}")
         for hour in range(self.lookback_hours, self.effective_lagback(), -1):
             d_start = self.start_time - timedelta(hours=hour)
 
             if self.should_process_hour(d_start):
-                print(f"Processing hour offset: {hour}, timestamp: {d_start}")
+                LOG.debug(f"Processing hour offset: {hour}, timestamp: {d_start}")
             else:
-                print(f"Skipping hour offset: {hour}, timestamp: {d_start}")
+                LOG.debug(f"Skipping hour offset: {hour}, timestamp: {d_start}")
                 continue
 
             for subdir, filename in self.get_file_specs(d_start):
@@ -382,7 +391,7 @@ class FixedFileDownloader(ForecastDownloader, ABC):
                 out_path = os.path.join(full_dir, filename)
 
                 if os.path.isfile(out_path):
-                    print(f"Skipping existing: {out_path}")
+                    LOG.debug(f"Skipping existing: {out_path}")
                     continue
 
                 self._download_file(url, out_path)
@@ -416,17 +425,18 @@ class ScrapedFileDownloader(ForecastDownloader, ABC):
         raise NotImplementedError("ScrapedFileDownloader uses scraping logic instead of build_file_url_and_name().")
 
     def _download_data(self):
+        LOG.info(f"ScrapedFileDownloader: Download data. lookback: {self.lookback_hours} lagback: {self.effective_lagback()}")
         for hour in range(self.lookback_hours, self.effective_lagback(), -1):
             d_start = self.start_time - timedelta(hours=hour)
 
             if self.should_process_hour(d_start):
-                print(f"Processing hour offset: {hour}, timestamp: {d_start}")
+                LOG.debug(f"Processing hour offset: {hour}, timestamp: {d_start}")
             else:
-                print(f"Skipping hour offset: {hour}, timestamp: {d_start}")
+                LOG.debug(f"Skipping hour offset: {hour}, timestamp: {d_start}")
                 continue
 
             url = self.get_scrape_url(d_start)
-            print(f"Scraping: {url}")
+            LOG.info(f"Scraping: {url}")
             output_dir = self.build_output_dir(d_start)
             os.makedirs(output_dir, exist_ok=True)
 
@@ -439,7 +449,7 @@ class ScrapedFileDownloader(ForecastDownloader, ABC):
                     out_path = os.path.join(output_dir, os.path.basename(full_url))
 
                     if os.path.isfile(out_path):
-                        print(f"Skipping existing: {out_path}")
+                        LOG.debug(f"Skipping existing: {out_path}")
                         continue
 
                     self._download_file(full_url, out_path)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_grid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_grid.py
@@ -10,8 +10,12 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+import logging
+LOG = logging.getLogger("")
 
 _error_on_grid_type: bool = False
 
@@ -117,6 +121,7 @@ class Grid:
             NDArray[np.int16]: array of GridUnit enum VALUES denoting the grid unit for each rank.
         """
         if _error_on_grid_type and self.type == GridType.scalar:
+            LOG.error("Scalar has no grid units")
             raise GridTypeAccessError("Scalar has no grid units")
         return self._units
 
@@ -183,6 +188,7 @@ class Grid:
             It is possible for grid values to be associated with the nodes or with the cells.
         """
         if _error_on_grid_type and self.type == GridType.scalar:
+            LOG.error("Scalar has no shape")
             raise GridTypeAccessError("Scalar has no shape")
         return self._shape
 
@@ -207,6 +213,7 @@ class Grid:
             NDArray[np.float64]: Tuple of size rank with the spacing in each of rank dimensions
         """
         if _error_on_grid_type and self.type == GridType.scalar:
+            LOG.error("Scalar has no grid spacing")
             raise GridTypeAccessError("Scalar has no grid spacing")
         return self._spacing
 
@@ -230,6 +237,7 @@ class Grid:
             NDArray[np.float64]: Tuple of size rank with the coordinates of the the grid origin
         """
         if _error_on_grid_type and self.type == GridType.scalar:
+            LOG.error("Scalar has no grid origin")
             raise GridTypeAccessError("Scalar has no grid origin")
         return self._origin
 
@@ -254,6 +262,7 @@ class Grid:
         """
         return self._grid_x
         # if _error_on_grid_type and self.type == GridType.scalar:
+        #    LOG.error("Scalar has no grid x value")
         #    raise GridTypeAccessError("Scalar has no grid x value")
         ##TODO refactor this -- not generic to grid, this works for structured/quads, not for unstructured
         # if (self.type == GridType.rectilinear or self.type == GridType.uniform_rectilinear) and len(self.shape) > 0:
@@ -264,6 +273,7 @@ class Grid:
         #    return np.array( [ self.origin[idx] + self.spacing[idx]*x for x in range(self.shape[idx]) ], dtype=np.float64 )
         # else:
         #    #TODO should this raise an error or return an empty array?
+        #    #LOG.critical(f"Cannot get x coordinates of grid with shape {self.shape}")
         #    #raise RuntimeError(f"Cannot get x coordinates of grid with shape {self.shape}")
         #    return np.array((), dtype=np.float64)
 
@@ -276,6 +286,7 @@ class Grid:
         """
         return self._grid_y
         # if _error_on_grid_type and self.type == GridType.scalar:
+        #    LOG.error("Scalar has no grid y value")
         #    raise GridTypeAccessError("Scalar has no grid y value")
 
         # if (self.type == GridType.rectilinear or self.type == GridType.uniform_rectilinear) and len(self.shape) > 1:
@@ -283,6 +294,7 @@ class Grid:
         #    return np.array( [ self.origin[idx] + self.spacing[idx]*y for y in range(self.shape[idx]) ], dtype=np.float64 )
         # else:
         #    #TODO should this raise an error or return an empty array?
+        #    #LOG.critical(f"Cannot get y coordinates of grid with shape {self.shape}")
         #    #raise RuntimeError(f"Cannot get y coordinates of grid with shape {self.shape}")
         #    return np.array((), dtype=np.float64)
 
@@ -295,6 +307,7 @@ class Grid:
         """
         return self._grid_z
         # if _error_on_grid_type and self.type == GridType.scalar:
+        #    LOG.error("Scalar has no grid z value")
         #    raise GridTypeAccessError("Scalar has no grid z value")
         #
         # if (self.type == GridType.rectilinear or self.type == GridType.uniform_rectilinear) and len(self.shape) > 2:
@@ -302,5 +315,6 @@ class Grid:
         #    return np.array( [ self.origin[idx] + self.spacing[idx]*z for z in range(self.shape[idx]) ], dtype=np.float64 )
         # else:
         #    #TODO should this raise an error or return an empty array?
+        #    #LOG.critical(f"Cannot get z coordinates of grid with shape {self.shape}")
         #    #raise RuntimeError(f"Cannot get z coordinates of grid with shape {self.shape}")
         #    return np.array((), dtype=np.float64)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_grid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_grid.py
@@ -14,8 +14,10 @@ import numpy as np
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
+from .log_level_set import MODULE_NAME
+
 import logging
-LOG = logging.getLogger("")
+LOG = logging.getLogger(MODULE_NAME)
 
 _error_on_grid_type: bool = False
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -167,7 +167,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
 
 
         LOG.info('---------------------------')
-        LOG.info("BMI Forcing Engine initialized with %s", config_file)
+        LOG.info("BMI Forcing Engine initialized with {config_file}")
 
         # -------------- Read in the BMI configuration -------------------------#
         if not isinstance(config_file, str) or len(config_file) == 0:
@@ -927,7 +927,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             LOG.error("Output variable names:")
             for var in self._output_var_names:
                 LOG.error(f" - {var}")
-            LOG.error("Grid type:", self._grid_type)
+            LOG.error("Grid type: {self._grid_type}")
             raise UnknownBMIVariable(f"No known variable in BMI model: '{var_name}'")
 
         arr = self._values[var_name]

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -42,8 +42,11 @@ from numpy.typing import NDArray
 if ESMF.version_compare('8.7.0', ESMF.__version__) < 0:
     manager = ESMF.api.esmpymanager.Manager(endFlag=ESMF.constants.EndAction.KEEP_MPI)
 
-from log_level_set import log_level_set
-LOG = log_level_set()
+from .log_level_set import log_level_set, MODULE_NAME
+log_level_set()
+
+import logging
+LOG = logging.getLogger(MODULE_NAME)
 
 class UnknownBMIVariable(RuntimeError):
     """

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -42,6 +42,8 @@ from numpy.typing import NDArray
 if ESMF.version_compare('8.7.0', ESMF.__version__) < 0:
     manager = ESMF.api.esmpymanager.Manager(endFlag=ESMF.constants.EndAction.KEEP_MPI)
 
+from log_level_set import log_level_set
+LOG = log_level_set()
 
 class UnknownBMIVariable(RuntimeError):
     """
@@ -161,18 +163,20 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         """
 
 
-        print('---------------------------')
-        print("BMI Forcing Engine initialized with", config_file)
+        LOG.info('---------------------------')
+        LOG.info("BMI Forcing Engine initialized with %s", config_file)
 
         # -------------- Read in the BMI configuration -------------------------#
         if not isinstance(config_file, str) or len(config_file) == 0:
+            LOG.critical("No BMI initialize configuration provided, nothing to do...")
             raise RuntimeError("No BMI initialize configuration provided, nothing to do...")
 
         bmi_cfg_file = Path(config_file).resolve()
         if not bmi_cfg_file.is_file():
+            LOG.critical(f"Config file {bmi_cfg_file} not found, nothing to do...")
             raise RuntimeError(f"Config file {bmi_cfg_file} not found, nothing to do...")
 
-        print(f"Reading config file: {bmi_cfg_file}")
+        LOG.info(f"Reading config file: {bmi_cfg_file}")
         with bmi_cfg_file.open('r') as fp:
             cfg = yaml.safe_load(fp)
 
@@ -211,7 +215,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         except Exception as e:
             err_handler.err_out_screen(self._job_meta.errMsg, e)
 
-        #print(f"self._job_meta type: {type(self._job_meta)}")
+        #LOG.debug(f"self._job_meta type: {type(self._job_meta)}")
         #Call ESMF mesh creation process
         esmf_creation.create_mesh(self._job_meta)
         #Call forcing_extraction process
@@ -754,7 +758,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         try:
             return self._att_map[att_name.lower()]
         except Exception as e:
-            print(f' ERROR: Could not find attribute: {att_name} - {e}')
+            LOG.error(f'Could not find attribute: {att_name} - {e}')
 
     # --------------------------------------------------------
     # Note: These are currently variables needed from other
@@ -826,17 +830,17 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         :return: The destination array containing the variable values.
         """
 
-        #print(f"[BMI get_value] Called with var_name: '{var_name}'")
-        #print(f"[BMI get_value] Destination array shape: {dest.shape}, dtype: {dest.dtype}")
+        #LOG.debug(f"[BMI get_value] Called with var_name: '{var_name}'")
+        #LOG.debug(f"[BMI get_value] Destination array shape: {dest.shape}, dtype: {dest.dtype}")
 
         if var_name == "grid:count":
-            print(f"[BMI get_value] Special case: 'grid:count', grid_type: {self._job_meta.grid_type}")
+            LOG.debug(f"[BMI get_value] Special case: 'grid:count', grid_type: {self._job_meta.grid_type}")
             if self._job_meta.grid_type != 'unstructured':
                 dest[...] = 1
             else:
                 dest[...] = 2
         elif var_name == "grid:ids":
-            print(f"[BMI get_value] Special case: 'grid:ids', grid_type: {self._job_meta.grid_type}")
+            LOG.debug(f"[BMI get_value] Special case: 'grid:ids', grid_type: {self._job_meta.grid_type}")
             if self._job_meta.grid_type == 'gridded':
                 dest[:] = [self.grid_1.id]
             elif self._job_meta.grid_type == 'unstructured':
@@ -844,7 +848,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             elif self._job_meta.grid_type == 'hydrofabric':
                 dest[:] = [self.grid_4.id]
         elif var_name == "grid:ranks":
-            print(f"[BMI get_value] Special case: 'grid:ranks', grid_type: {self._job_meta.grid_type}")
+            LOG.debug(f"[BMI get_value] Special case: 'grid:ranks', grid_type: {self._job_meta.grid_type}")
             if self._job_meta.grid_type == 'gridded':
                 dest[:] = [self.grid_1.rank]
             elif self._job_meta.grid_type == 'unstructured':
@@ -853,14 +857,14 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
                 dest[:] = [self.grid_4.rank]
         else:
             src = self.get_value_ptr(var_name)
-            print(f"[BMI get_value] Source array shape: {src.shape}, dtype: {src.dtype}")
+            LOG.debug(f"[BMI get_value] Source array shape: {src.shape}, dtype: {src.dtype}")
             if dest.shape != src.shape:
-                print(f"[BMI WARNING] Shape mismatch! dest.shape = {dest.shape}, src.shape = {src.shape}")
+                LOG.warning(f"BMI Shape mismatch! dest.shape = {dest.shape}, src.shape = {src.shape}")
             if dest.dtype != src.dtype:
-                print(f"[BMI WARNING] Dtype mismatch! dest.dtype = {dest.dtype}, src.dtype = {src.dtype}")
+                LOG.warning(f"BMI Dtype mismatch! dest.dtype = {dest.dtype}, src.dtype = {src.dtype}")
             dest[:] = src
 
-        print(f"[BMI get_value] Completed assignment for var_name: '{var_name}'")
+        LOG.debug(f"[BMI get_value] Completed assignment for var_name: '{var_name}'")
 
         return dest
 
@@ -913,28 +917,27 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         # if var_name not in self._values.keys():
         #     raise (UnknownBMIVariable(f"No known variable in BMI model: {var_name}"))
         if var_name not in self._values:
-            print("\n[ BMI Diagnostic ]")
-            print(f"Requested variable: '{var_name}'")
-            print("Available variables:")
+            LOG.error(f"No known variable in BMI model: '{var_name}'")
+            LOG.error("Available variables:")
             for key in self._values:
-                print(f" - {key}")
-            print("Output variable names:")
+                LOG.error(f" - {key}")
+            LOG.error("Output variable names:")
             for var in self._output_var_names:
-                print(f" - {var}")
-            print("Grid type:", self._grid_type)
+                LOG.error(f" - {var}")
+            LOG.error("Grid type:", self._grid_type)
             raise UnknownBMIVariable(f"No known variable in BMI model: '{var_name}'")
 
         arr = self._values[var_name]
-        # print(f"[BMI get_value_ptr] Found variable '{var_name}' with shape {arr.shape} and dtype {arr.dtype}")
+        # LOG.debug(f"[BMI get_value_ptr] Found variable '{var_name}' with shape {arr.shape} and dtype {arr.dtype}")
 
         # Ensure array is C-contiguous
         if not arr.flags['C_CONTIGUOUS']:
-            print(f"[BMI WARNING] Array for '{var_name}' is not C-contiguous; making a copy.")
+            LOG.warning(f"[BMI] Array for '{var_name}' is not C-contiguous; making a copy.")
             arr = np.ascontiguousarray(arr)
 
         # Ensure dtype is float64 (C double)
         if arr.dtype != np.float64:
-            print(f"[BMI WARNING] Array for '{var_name}' has dtype {arr.dtype}, expected float64; converting.")
+            LOG.warning(f"[BMI] Array for '{var_name}' has dtype {arr.dtype}, expected float64; converting.")
             arr = arr.astype(np.float64)
 
         # Confirm raveling is safe
@@ -945,9 +948,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             # reset original shape
             arr.shape = shape
         except ValueError as e:
+            LOG.critical("Cannot flatten array without copying -- " + str(e).split(": ")[-1])
             raise RuntimeError("Cannot flatten array without copying -- " + str(e).split(": ")[-1])
 
-        #print(f"[BMI get_value_ptr] Returning ravelled array for variable '{var_name}'")
+        #LOG.debug(f"[BMI get_value_ptr] Returning ravelled array for variable '{var_name}'")
         return arr.ravel()
 
     # -------------------------------------------------------------------
@@ -1673,16 +1677,16 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         :param cfg: A dictionary containing the configuration settings. The dictionary may include paths, dates, and lists of values.
         :return: The updated configuration dictionary with appropriately parsed values.
         """
-        #print(f"[DEBUG] Entering _parse_config with cfg type: {type(cfg)}")
+        #LOG.debug(f"Entering _parse_config with cfg type: {type(cfg)}")
         if isinstance(cfg, str):
-            print(f"[ERROR] Received string data instead of dictionary: {cfg[:200]}...")
+            LOG.error(f"Received string data (raw CSV) instead of dictionary: {cfg[:200]}...")
             raise TypeError("Expected dictionary in _parse_config, but got a raw CSV string.")
 
         # if not isinstance(cfg, dict):
         #     raise TypeError(f"[ERROR] Expected dictionary in _parse_config, got {type(cfg)} with contents: {cfg}")
 
         for key, val in cfg.items():
-            # print(f"[DEBUG] Processing key: {key}, value type: {type(val)}, value: {val}")
+            # LOG.debug(f"Processing key: {key}, value type: {type(val)}, value: {val}")
             # Convert all path strings to PosixPath objects
             if any([key.endswith(x) for x in ['_dir', '_path', '_file', '_files']]):
                 if (val is not None) and (val != "None"):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -8,6 +8,10 @@ import numpy as np
 from . import err_handler
 from . import time_handling
 
+import logging
+from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
+
 FORCE_COUNT = 27
 
 
@@ -172,7 +176,7 @@ class ConfigOptions:
             if not os.path.isdir(geogrid_dir):
                 try:
                     os.makedirs(geogrid_dir, exist_ok=True)
-                    print(f"Created esmf mesh directory: {geogrid_dir}")
+                    LOG.info(f"Created esmf mesh directory: {geogrid_dir}")
                 except OSError as e:
                     err_handler.err_out_screen(f'Unable to create esmf_mesh directory: {geogrid_dir}. Error: {e}')
 
@@ -285,7 +289,7 @@ class ConfigOptions:
                     else:
                         try:
                             os.makedirs(dir_path, exist_ok=True)
-                            print(f'Created missing forcing directory: {dir_path}')
+                            LOG.info(f"Created missing forcing directory: {dir_path}")
                         except OSError as e: 
                             err_handler.err_out_screen(f'Unable to create forcing directory: {dir_path}. Error: {e}')
 
@@ -371,7 +375,7 @@ class ConfigOptions:
         except configparser.NoOptionError as e:
             err_handler.err_out_screen('Unable to locate ScratchDir in the configuration file.', e)
         os.makedirs(self.scratch_dir, exist_ok=True)
-        print(f'Scratch dir: {self.scratch_dir}')
+        LOG.debug(f"Scratch dir: {self.scratch_dir}")
 
         # Read in compression option
         try:
@@ -474,7 +478,7 @@ class ConfigOptions:
         else:
             self.b_date_proc = -9999
 
-        print('Begin date:', beg_date_tmp)
+        LOG.info(f"Begin date: {beg_date_tmp}")
 
         # If the Retro flag is off, and lookback is off, then we assume we are
         # running a reforecast.
@@ -715,7 +719,7 @@ class ConfigOptions:
         # Process geospatial information
 
         if self.geogrid:
-            print(f"Geogrid: {self.geogrid}")
+            LOG.info(f"Geogrid: {self.geogrid}")
         else:
             try:
                 self.geogrid = cfg_bmi['GeogridIn']
@@ -1235,7 +1239,7 @@ class ConfigOptions:
                 if not os.path.isdir(self.supp_precip_dirs[dirTmp]):
                     try:
                         os.makedirs(self.supp_precip_dirs[dirTmp], exist_ok=True)
-                        print(f"Created supp pcp directory: {self.supp_precip_dirs[dirTmp]}")
+                        LOG.info(f"Created supp pcp directory: {self.supp_precip_dirs[dirTmp]}")
                     except OSError as e:
                         err_handler.err_out_screen(f'Unable to create supp pcp directory: {self.supp_precip_dirs[dirTmp]}. Error: {e}')
 
@@ -1352,7 +1356,7 @@ class ConfigOptions:
             if not os.path.isdir(self.supp_precip_param_dir):
                 try:
                     os.makedirs(self.supp_precip_param_dir, exist_ok=True)
-                    print(f'Created missing SuppPcpParamDir: {self.supp_precip_param_dir}' )
+                    LOG.info(f"Created missing SuppPcpParamDir: {self.supp_precip_param_dir}")
                 except OSError as e:
                     err_handler.err_out_screen(f'Unable to locate SuppPcpParamDir: {self.supp_precip_param_dir}. Error: {e}' )
 
@@ -1364,8 +1368,8 @@ class ConfigOptions:
                 if optTmp == 7:
                     try:
                         self.cfsv2EnsMember = cfg_bmi['cfsEnsNumber']
-                        print(f"ens mem: {self.cfsv2EnsMember}")
-                        print(f"cfg ens mem: {cfg_bmi['cfsEnsNumber']}")
+                        LOG.info(f"ens mem: {self.cfsv2EnsMember}")
+                        LOG.info(f"cfg ens mem: {cfg_bmi['cfsEnsNumber']}")
                     except KeyError as e:
                         err_handler.err_out_screen('Unable to locate cfsEnsNumber under the Ensembles section of the configuration file', e)
                     except configparser.NoOptionError as e:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -176,7 +176,7 @@ class ConfigOptions:
             if not os.path.isdir(geogrid_dir):
                 try:
                     os.makedirs(geogrid_dir, exist_ok=True)
-                    LOG.info(f"Created esmf mesh directory: {geogrid_dir}")
+                    LOG.debug(f"Created esmf mesh directory: {geogrid_dir}")
                 except OSError as e:
                     err_handler.err_out_screen(f'Unable to create esmf_mesh directory: {geogrid_dir}. Error: {e}')
 
@@ -289,7 +289,7 @@ class ConfigOptions:
                     else:
                         try:
                             os.makedirs(dir_path, exist_ok=True)
-                            LOG.info(f"Created missing forcing directory: {dir_path}")
+                            LOG.debug(f"Created missing forcing directory: {dir_path}")
                         except OSError as e: 
                             err_handler.err_out_screen(f'Unable to create forcing directory: {dir_path}. Error: {e}')
 
@@ -719,7 +719,7 @@ class ConfigOptions:
         # Process geospatial information
 
         if self.geogrid:
-            LOG.info(f"Geogrid: {self.geogrid}")
+            LOG.debug(f"Geogrid: {self.geogrid}")
         else:
             try:
                 self.geogrid = cfg_bmi['GeogridIn']
@@ -1239,7 +1239,7 @@ class ConfigOptions:
                 if not os.path.isdir(self.supp_precip_dirs[dirTmp]):
                     try:
                         os.makedirs(self.supp_precip_dirs[dirTmp], exist_ok=True)
-                        LOG.info(f"Created supp pcp directory: {self.supp_precip_dirs[dirTmp]}")
+                        LOG.debug(f"Created supp pcp directory: {self.supp_precip_dirs[dirTmp]}")
                     except OSError as e:
                         err_handler.err_out_screen(f'Unable to create supp pcp directory: {self.supp_precip_dirs[dirTmp]}. Error: {e}')
 
@@ -1356,7 +1356,7 @@ class ConfigOptions:
             if not os.path.isdir(self.supp_precip_param_dir):
                 try:
                     os.makedirs(self.supp_precip_param_dir, exist_ok=True)
-                    LOG.info(f"Created missing SuppPcpParamDir: {self.supp_precip_param_dir}")
+                    LOG.debug(f"Created missing SuppPcpParamDir: {self.supp_precip_param_dir}")
                 except OSError as e:
                     err_handler.err_out_screen(f'Unable to locate SuppPcpParamDir: {self.supp_precip_param_dir}. Error: {e}' )
 
@@ -1368,8 +1368,8 @@ class ConfigOptions:
                 if optTmp == 7:
                     try:
                         self.cfsv2EnsMember = cfg_bmi['cfsEnsNumber']
-                        LOG.info(f"ens mem: {self.cfsv2EnsMember}")
-                        LOG.info(f"cfg ens mem: {cfg_bmi['cfsEnsNumber']}")
+                        LOG.debug(f"ens mem: {self.cfsv2EnsMember}")
+                        LOG.debug(f"cfg ens mem: {cfg_bmi['cfsEnsNumber']}")
                     except KeyError as e:
                         err_handler.err_out_screen('Unable to locate cfsEnsNumber under the Ensembles section of the configuration file', e)
                     except configparser.NoOptionError as e:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/downscale.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/downscale.py
@@ -588,12 +588,12 @@ def nwm_monthly_PRISM_downscale(input_forcings,ConfigOptions,GeoMetaWrfHydro,Mpi
     if input_forcings.nwmPRISM_denGrid is None and input_forcings.nwmPRISM_numGrid is None:
         # We are on situation 1 - This is the first output step.
         initialize_flag = True
-        # print('WE NEED TO READ IN PRISM GRIDS')
+        # LOG.debug('WE NEED TO READ IN PRISM GRIDS')
     if ConfigOptions.current_output_date.month != ConfigOptions.prev_output_date.month:
         # We are on situation #2 - The month has changed so we need to reinitialize the
         # PRISM grids.
         initialize_flag = True
-        # print('MONTH CHANGE.... NEED TO READ IN NEW PRISM GRIDS.')
+        # LOG.debug('MONTH CHANGE.... NEED TO READ IN NEW PRISM GRIDS.')
     if initialize_flag is True:
         while (True):
             # First reset the local PRISM grids to be safe.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -8,6 +8,9 @@ from mpi4py import MPI
 from scipy import spatial
 from logging import FileHandler
 
+import logging
+from ..log_level_set import MODULE_NAME
+log_name = MODULE_NAME
 
 def err_out_screen(err_msg: str, exc: BaseException | None = None):
     """
@@ -96,6 +99,22 @@ def init_log(ConfigOptions, MpiConfig):
     if MpiConfig.rank != 0:
         return
 
+    global log_name
+
+    # Check for ngen Error and Warning Trapping System named logger
+    logger = logging.getLogger(MODULE_NAME) 
+
+    # checking whether the logger object has an attribute named _initialized, 
+    # and if it does, whether its value is True. If the attribute doesn't exist,
+    # it defaults to False.
+    if getattr(logger, "_initialized", False):
+        for handler in logger.handlers:
+            if isinstance(handler, logging.FileHandler):
+                ConfigOptions.logFile = handler.baseFilename
+                break
+        log_name = MODULE_NAME
+        return  # logger already initialized, nothing else to do
+
     log_name = 'logForcing'
     filename = ConfigOptions.logFile
 
@@ -130,17 +149,18 @@ def err_out(ConfigOptions):
     :return:
     """
     try:
-        logObj = logging.getLogger('logForcing')
+        logObj = logging.getLogger(log_name)
     except Exception:
         ConfigOptions.errMsg = "Unable to obtain a logger object for: " + \
                                ConfigOptions.logFile
         raise Exception()
-    try:
-        logObj.setLevel(logging.ERROR)
-    except Exception:
-        ConfigOptions.errMsg = "Unable to set ERROR logger level for: " + \
-                               ConfigOptions.logFile
-        raise Exception()
+    if log_name != MODULE_NAME:
+        try:
+            logObj.setLevel(logging.ERROR)
+        except Exception:
+            ConfigOptions.errMsg = "Unable to set ERROR logger level for: " + \
+                                ConfigOptions.logFile
+            raise Exception()
     try:
         logObj.error(ConfigOptions.errMsg)
     except Exception:
@@ -159,15 +179,16 @@ def log_error(ConfigOptions, MpiConfig):
     :return:
     """
     try:
-        logObj = logging.getLogger('logForcing')
+        logObj = logging.getLogger(log_name)
     except Exception:
         err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.setLevel(logging.ERROR)
-    except Exception:
-        err_out_screen_para(('Unable to set ERROR logger level on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
+    if log_name != MODULE_NAME:
+        try:
+            logObj.setLevel(logging.ERROR)
+        except Exception:
+            err_out_screen_para(('Unable to set ERROR logger level on RANK: ' + str(MpiConfig.rank) +
+                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
     try:
         logObj.error("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
     except Exception:
@@ -184,15 +205,16 @@ def log_critical(ConfigOptions, MpiConfig):
     :return:
     """
     try:
-        logObj = logging.getLogger('logForcing')
+        logObj = logging.getLogger(log_name)
     except Exception:
         err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.setLevel(logging.CRITICAL)
-    except Exception:
-        err_out_screen_para(('Unable to set CRITICAL logger level on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
+    if log_name != MODULE_NAME:
+        try:
+            logObj.setLevel(logging.CRITICAL)
+        except Exception:
+            err_out_screen_para(('Unable to set CRITICAL logger level on RANK: ' + str(MpiConfig.rank) +
+                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
     try:
         logObj.critical("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
     except Exception:
@@ -212,15 +234,16 @@ def log_warning(ConfigOptions, MpiConfig):
     :return:
     """
     try:
-        logObj = logging.getLogger('logForcing')
+        logObj = logging.getLogger(log_name)
     except Exception:
         err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.setLevel(logging.WARNING)
-    except Exception:
-        err_out_screen_para(('Unable to set WARNING logger level on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
+    if log_name != MODULE_NAME:
+        try:
+            logObj.setLevel(logging.WARNING)
+        except Exception:
+            err_out_screen_para(('Unable to set WARNING logger level on RANK: ' + str(MpiConfig.rank) +
+                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
     try:
         logObj.warning("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
     except Exception:
@@ -235,15 +258,16 @@ def log_msg(ConfigOptions, MpiConfig):
     :return:
     """
     try:
-        logObj = logging.getLogger('logForcing')
+        logObj = logging.getLogger(log_name)
     except Exception:
         err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.setLevel(logging.INFO)
-    except Exception:
-        err_out_screen_para(('Unable to set INFO logger level on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
+    if log_name != MODULE_NAME:
+        try:
+            logObj.setLevel(logging.INFO)
+        except Exception:
+            err_out_screen_para(('Unable to set INFO logger level on RANK: ' + str(MpiConfig.rank) +
+                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
     try:
         logObj.info("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
     except Exception:
@@ -261,8 +285,11 @@ def close_log(ConfigOptions, MpiConfig):
     if getattr(ConfigOptions, "logHandle", None) is None:
         return
 
+    if log_name == MODULE_NAME:
+        return
+    
     try:
-        logObj = logging.getLogger('logForcing')
+        logObj = logging.getLogger(log_name)
     except Exception:
         err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -10,6 +10,7 @@ from logging import FileHandler
 
 import logging
 from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
 log_name = MODULE_NAME
 
 def err_out_screen(err_msg: str, exc: BaseException | None = None):
@@ -81,7 +82,8 @@ def check_program_status(ConfigOptions, MpiConfig):
         if ConfigOptions.errFlag:
             # print("any_error: ", any_error, type(any_error), flush=True)
             stack = traceback.format_stack()[:-1]
-            [print(frame, flush=True, end='') for frame in stack]
+            for frame in stack:
+                LOG.error(frame)
             MpiConfig.comm.Abort()
             sys.exit(1)
 
@@ -100,6 +102,7 @@ def init_log(ConfigOptions, MpiConfig):
         return
 
     global log_name
+    global LOG
 
     # Check for ngen Error and Warning Trapping System named logger
     logger = logging.getLogger(MODULE_NAME) 
@@ -113,6 +116,7 @@ def init_log(ConfigOptions, MpiConfig):
                 ConfigOptions.logFile = handler.baseFilename
                 break
         log_name = MODULE_NAME
+        LOG = logger
         return  # logger already initialized, nothing else to do
 
     log_name = 'logForcing'
@@ -124,6 +128,7 @@ def init_log(ConfigOptions, MpiConfig):
         # If a FileHandler for this filename is already attached, skip (prevents one log per catchment)
         for handler in logger.handlers:
             if isinstance(handler, FileHandler) and getattr(handler, 'baseFilename', None) == filename:
+                LOG = logger
                 return
 
         # Otherwise, create and attach a new FileHandler
@@ -135,6 +140,7 @@ def init_log(ConfigOptions, MpiConfig):
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
         logger.setLevel(logging.INFO)
+        LOG = logger
 
     except Exception as e:
         ConfigOptions.errMsg = f"Unable to initialize log file '{filename}': {e}"
@@ -148,21 +154,13 @@ def err_out(ConfigOptions):
     :param ConfigOptions:
     :return:
     """
-    try:
-        logObj = logging.getLogger(log_name)
-    except Exception:
+    if not LOG.hasHandlers():
         ConfigOptions.errMsg = "Unable to obtain a logger object for: " + \
                                ConfigOptions.logFile
         raise Exception()
-    if log_name != MODULE_NAME:
-        try:
-            logObj.setLevel(logging.ERROR)
-        except Exception:
-            ConfigOptions.errMsg = "Unable to set ERROR logger level for: " + \
-                                ConfigOptions.logFile
-            raise Exception()
+
     try:
-        logObj.error(ConfigOptions.errMsg)
+        LOG.error(ConfigOptions.errMsg)
     except Exception:
         ConfigOptions.errMsg = "Unable to write error message to: " + \
                                ConfigOptions.logFile
@@ -178,19 +176,13 @@ def log_error(ConfigOptions, MpiConfig):
     :param MpiConfig:
     :return:
     """
+    if not LOG.hasHandlers():
+        ConfigOptions.errMsg = "Unable to obtain a logger object for: " + \
+                               ConfigOptions.logFile
+        raise Exception()
+
     try:
-        logObj = logging.getLogger(log_name)
-    except Exception:
-        err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    if log_name != MODULE_NAME:
-        try:
-            logObj.setLevel(logging.ERROR)
-        except Exception:
-            err_out_screen_para(('Unable to set ERROR logger level on RANK: ' + str(MpiConfig.rank) +
-                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.error("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
+        LOG.error("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
     except Exception:
         err_out_screen_para(('Unable to write ERROR message on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
@@ -204,25 +196,19 @@ def log_critical(ConfigOptions, MpiConfig):
     :param ConfigOptions:
     :return:
     """
+    if not LOG.hasHandlers():
+        ConfigOptions.errMsg = "Unable to obtain a logger object for: " + \
+                               ConfigOptions.logFile
+        raise Exception()
+
     try:
-        logObj = logging.getLogger(log_name)
-    except Exception:
-        err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    if log_name != MODULE_NAME:
-        try:
-            logObj.setLevel(logging.CRITICAL)
-        except Exception:
-            err_out_screen_para(('Unable to set CRITICAL logger level on RANK: ' + str(MpiConfig.rank) +
-                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.critical("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
+        LOG.critical("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
     except Exception:
         err_out_screen_para(('Unable to write CRITICAL message on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
 
     # Add this for debugging:
-    print(f"[DEBUG] log_critical called on RANK {MpiConfig.rank}: {ConfigOptions.errMsg}", flush=True)
+    LOG.debug(f"log_critical called on RANK {MpiConfig.rank}: {ConfigOptions.errMsg}")
 
     ConfigOptions.errFlag = 1
 
@@ -233,19 +219,13 @@ def log_warning(ConfigOptions, MpiConfig):
     :param ConfigOptions:
     :return:
     """
+    if not LOG.hasHandlers():
+        ConfigOptions.errMsg = "Unable to obtain a logger object for: " + \
+                               ConfigOptions.logFile
+        raise Exception()
+
     try:
-        logObj = logging.getLogger(log_name)
-    except Exception:
-        err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    if log_name != MODULE_NAME:
-        try:
-            logObj.setLevel(logging.WARNING)
-        except Exception:
-            err_out_screen_para(('Unable to set WARNING logger level on RANK: ' + str(MpiConfig.rank) +
-                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.warning("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
+        LOG.warning("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
     except Exception:
         err_out_screen_para(('Unable to write WARNING message on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
@@ -257,19 +237,13 @@ def log_msg(ConfigOptions, MpiConfig):
     :param ConfigOptions:
     :return:
     """
+    if not LOG.hasHandlers():
+        ConfigOptions.errMsg = "log_msg: Unable to obtain a logger object for: " + \
+                               ConfigOptions.logFile
+        raise Exception()
+
     try:
-        logObj = logging.getLogger(log_name)
-    except Exception:
-        err_out_screen_para(('Unable to obtain logger object on RANK: ' + str(MpiConfig.rank) +
-                             ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    if log_name != MODULE_NAME:
-        try:
-            logObj.setLevel(logging.INFO)
-        except Exception:
-            err_out_screen_para(('Unable to set INFO logger level on RANK: ' + str(MpiConfig.rank) +
-                                ' for log file: ' + ConfigOptions.logFile), MpiConfig)
-    try:
-        logObj.info("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
+        LOG.info("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
     except Exception:
         err_out_screen_para(('Unable to write INFO message on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -231,7 +231,7 @@ def log_warning(ConfigOptions, MpiConfig):
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
 
 
-def log_msg(ConfigOptions, MpiConfig):
+def log_msg(ConfigOptions, MpiConfig, debug: bool = False):
     """
     Function to log INFO messages to a specified log file.
     :param ConfigOptions:
@@ -243,9 +243,12 @@ def log_msg(ConfigOptions, MpiConfig):
         raise Exception()
 
     try:
-        LOG.info("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
+        if debug:
+            LOG.debug("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
+        else:
+            LOG.info("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.statusMsg)
     except Exception:
-        err_out_screen_para(('Unable to write INFO message on RANK: ' + str(MpiConfig.rank) +
+        err_out_screen_para(('Unable to write log_msg message on RANK: ' + str(MpiConfig.rank) +
                              ' for log file: ' + ConfigOptions.logFile), MpiConfig)
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
@@ -10,6 +10,9 @@ from . import regrid
 from . import timeInterpMod
 from . import time_handling
 
+import logging
+from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
 
 class input_forcings:
     """
@@ -573,7 +576,7 @@ class input_forcings:
             27: time_handling.find_nwm_neighbors
         }
 
-        print(f'keyValue: {self.keyValue}, {find_neighbor_files[self.keyValue].__name__}')
+        LOG.debug(f'keyValue: {self.keyValue}, {find_neighbor_files[self.keyValue].__name__}')
         find_neighbor_files[self.keyValue](self, ConfigOptions, dCurrent, MpiConfig)
 
     def regrid_inputs(self, ConfigOptions, wrfHyroGeoMeta, MpiConfig):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/geoMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/geoMod.py
@@ -9,6 +9,9 @@ try:
 except ImportError:
     import ESMF
 
+import logging
+from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
 
 class GeoMetaWrfHydro:
     """
@@ -81,19 +84,19 @@ class GeoMetaWrfHydro:
             self.ny_local = len(self.esmf_grid.coords[0][1])
             self.nx_local_elem = len(self.esmf_grid.coords[1][1])
             self.ny_local_elem = len(self.esmf_grid.coords[1][1])
-            # print("ESMF Mesh nx local node is " + str(self.nx_local))
-            # print("ESMF Mesh nx local elem is " + str(self.nx_local_elem))
+            # LOG.debug("ESMF Mesh nx local node is " + str(self.nx_local))
+            # LOG.debug("ESMF Mesh nx local elem is " + str(self.nx_local_elem))
         elif ConfigOptions.grid_type == 'hydrofabric':
             self.nx_local = len(self.esmf_grid.coords[1][1])
             self.ny_local = len(self.esmf_grid.coords[1][1])
             # self.nx_local_poly = len(self.esmf_poly_coords)
             # self.ny_local_poly = len(self.esmf_poly_coords)
-            # print("ESMF Mesh nx local elem is " + str(self.nx_local))
-            # print("ESMF Mesh nx local poly is " + str(self.nx_local_poly))
-        # print("WRF-HYDRO LOCAL X BOUND 1 = " + str(self.x_lower_bound))
-        # print("WRF-HYDRO LOCAL X BOUND 2 = " + str(self.x_upper_bound))
-        # print("WRF-HYDRO LOCAL Y BOUND 1 = " + str(self.y_lower_bound))
-        # print("WRF-HYDRO LOCAL Y BOUND 2 = " + str(self.y_upper_bound))
+            # LOG.debug("ESMF Mesh nx local elem is " + str(self.nx_local))
+            # LOG.debug("ESMF Mesh nx local poly is " + str(self.nx_local_poly))
+        # LOG.debug("WRF-HYDRO LOCAL X BOUND 1 = " + str(self.x_lower_bound))
+        # LOG.debug("WRF-HYDRO LOCAL X BOUND 2 = " + str(self.x_upper_bound))
+        # LOG.debug("WRF-HYDRO LOCAL Y BOUND 1 = " + str(self.y_lower_bound))
+        # LOG.debug("WRF-HYDRO LOCAL Y BOUND 2 = " + str(self.y_upper_bound))
 
     def initialize_destination_geo_gridded(self, ConfigOptions, MpiConfig):
         """

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -761,14 +761,14 @@ def open_grib2(GribFileIn, NetCdfFileOut, Wgrib2Cmd, ConfigOptions, MpiConfig,
         # Check to see if output file already exists. If so, delete it and
         # override.
         ConfigOptions.statusMsg = "Reading in GRIB2 file: " + GribFileIn
-        err_handler.log_msg(ConfigOptions, MpiConfig)
+        err_handler.log_msg(ConfigOptions, MpiConfig, True)  # log at debug level
         if os.path.isfile(NetCdfFileOut):
             ConfigOptions.statusMsg = "Overwriting temporary NetCDF file: " + NetCdfFileOut
-            err_handler.log_msg(ConfigOptions, MpiConfig)
+            err_handler.log_msg(ConfigOptions, MpiConfig, True)  # log at debug level
         try:
             # WCOSS fix for WGRIB2 crashing when called on the same file twice in python
             if not os.environ.get('MFE_SILENT') and not special_case:
-                LOG.info(f"Wgrib2 command: {Wgrib2Cmd}")
+                LOG.debug(f"Wgrib2 command: {Wgrib2Cmd}", True)  # log at debug level
 
             # set up GRIB2TABLE if needed:
             if not os.environ.get('GRIB2TABLE'):
@@ -783,12 +783,13 @@ def open_grib2(GribFileIn, NetCdfFileOut, Wgrib2Cmd, ConfigOptions, MpiConfig,
                 os.environ['GRIB2TABLE'] = g2path
             if WGRIB2_env:
                 result = subprocess.run(Wgrib2Cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-                exitcode = result.returncode
-                LOG.info(f"wgrib2 output:\n{result.stdout}")
-
-                if exitcode != 0:
+                if (exitcode := result.returncode) != 0:    
                     ConfigOptions.errMsg = f"wgrib2 failed with exit code {exitcode}. Output:\n{result.stdout}"
                     err_handler.log_critical(ConfigOptions, MpiConfig)
+                else:
+                    LOG.debug("wgrib2 output:")
+                    for line in result.stdout.splitlines(): # Log each line separately
+                        LOG.debug(line)
 
             else:
                 sys.stdout.flush()  # Native code uses unbuffered output, so flush our buffer first
@@ -929,7 +930,7 @@ def unzip_file(GzFileIn: str, FileOut: str, ConfigOptions, MpiConfig):
         # Unzip the file in place.
         try:
             ConfigOptions.statusMsg = f"Unzipping file: {GzFileIn}"
-            err_handler.log_msg(ConfigOptions, MpiConfig)
+            err_handler.log_msg(ConfigOptions, MpiConfig, True)  # log at debug level
             with gzip.open(GzFileIn, 'rb') as fTmpGz:  # fTmpGz is of type BinaryIO
                 with open(FileOut, 'wb') as fTmp:  # fTmp is also of type BinaryIO
                     # noinspection PyUnresolvedReferences
@@ -982,7 +983,7 @@ def read_rqi_monthly_climo(ConfigOptions, MpiConfig, supplemental_precip, GeoMet
         # Only read the file if the rank is 0 (master processor)
         if MpiConfig.rank == 0:
             ConfigOptions.statusMsg = f"Reading in RQI Parameter File: {rqiPath}"
-            err_handler.log_msg(ConfigOptions, MpiConfig)
+            err_handler.log_msg(ConfigOptions, MpiConfig, True)  # log at debug level
 
             # Ensure the RQI file exists before proceeding
             if not os.path.isfile(rqiPath):
@@ -1041,7 +1042,7 @@ def read_rqi_monthly_climo(ConfigOptions, MpiConfig, supplemental_precip, GeoMet
         # We need to read in a new RQI monthly grid.
         if MpiConfig.rank == 0:
             ConfigOptions.statusMsg = f"Reading in RQI Parameter File: {rqiPath}"
-            err_handler.log_msg(ConfigOptions, MpiConfig)
+            err_handler.log_msg(ConfigOptions, MpiConfig, True)  # log at debug level
 
             # Ensure the RQI file exists
             if not os.path.isfile(rqiPath):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -18,6 +18,10 @@ from netCDF4 import Dataset
 
 from . import err_handler
 
+import logging
+from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
+
 if "WGRIB2" not in os.environ:
     WGRIB2_env = False
     import pywgrib2_s
@@ -764,8 +768,7 @@ def open_grib2(GribFileIn, NetCdfFileOut, Wgrib2Cmd, ConfigOptions, MpiConfig,
         try:
             # WCOSS fix for WGRIB2 crashing when called on the same file twice in python
             if not os.environ.get('MFE_SILENT') and not special_case:
-                print(f"Wgrib2 command: {Wgrib2Cmd}")
-                print()
+                LOG.info(f"Wgrib2 command: {Wgrib2Cmd}")
 
             # set up GRIB2TABLE if needed:
             if not os.environ.get('GRIB2TABLE'):
@@ -781,7 +784,7 @@ def open_grib2(GribFileIn, NetCdfFileOut, Wgrib2Cmd, ConfigOptions, MpiConfig,
             if WGRIB2_env:
                 result = subprocess.run(Wgrib2Cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
                 exitcode = result.returncode
-                print(f"wgrib2 output:\n{result.stdout}")
+                LOG.info(f"wgrib2 output:\n{result.stdout}")
 
                 if exitcode != 0:
                     ConfigOptions.errMsg = f"wgrib2 failed with exit code {exitcode}. Output:\n{result.stdout}"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -30,6 +30,10 @@ import dask
 import dask.delayed
 import time
 
+import logging
+from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
+
 if "WGRIB2" not in os.environ:
     WGRIB2_env = False
 else:
@@ -208,7 +212,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}"
                 err_handler.log_msg(config_options, mpi_config)
-                print(config_options.statusMsg, flush=True)
+                LOG.info(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
                     try:
                         var_tmp = ds.variables[nc_var][0, :, :]
@@ -2001,7 +2005,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out.data, config_options.globalNdv)
-                    # print(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp", flush=True)
+                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2[input_forcings.input_map_output[force_count], :, :] = (1 - frz_fract).filled(1.0)
@@ -2073,7 +2077,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out.data, config_options.globalNdv)
-                    # print(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp", flush=True)
+                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2[input_forcings.input_map_output[force_count], :] = (1 - frz_fract).filled(1.0)
@@ -2144,7 +2148,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2_elem[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out_elem.data, config_options.globalNdv)
-                    # print(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp", flush=True)
+                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2_elem[input_forcings.input_map_output[force_count], :] = (1 - frz_fract).filled(1.0)
@@ -2216,7 +2220,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out.data, config_options.globalNdv)
-                    # print(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp", flush=True)
+                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2[input_forcings.input_map_output[force_count], :] = (1 - frz_fract).filled(1.0)
@@ -2607,7 +2611,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                                                 input_forcings.netcdf_var_names[force_count] + \
                                                 " into local numpy array. (" + str(err) + ")"
                     # except TypeError:
-                    #    print("DEBUG: ", input_forcings.coarse_input_forcings2, input_forcings.input_map_output, force_count)
+                    #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
                     if config_options.current_output_step == 1:
                         input_forcings.coarse_input_forcings1[input_forcings.input_map_output[force_count], :, :] = \
@@ -2714,7 +2718,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                                                 input_forcings.netcdf_var_names[force_count] + \
                                                 " into local numpy array. (" + str(err) + ")"
                     # except TypeError:
-                    #    print("DEBUG: ", input_forcings.coarse_input_forcings2, input_forcings.input_map_output, force_count)
+                    #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
                     if config_options.current_output_step == 1:
                         input_forcings.coarse_input_forcings1[input_forcings.input_map_output[force_count], :, :] = \
@@ -2820,7 +2824,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                                                 input_forcings.netcdf_var_names[force_count] + \
                                                 " into local numpy array. (" + str(err) + ")"
                     # except TypeError:
-                    #    print("DEBUG: ", input_forcings.coarse_input_forcings2, input_forcings.input_map_output, force_count)
+                    #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count})
 
                     if config_options.current_output_step == 1:
                         input_forcings.coarse_input_forcings1_elem[input_forcings.input_map_output[force_count], :, :] = \
@@ -2927,7 +2931,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                                                 input_forcings.netcdf_var_names[force_count] + \
                                                 " into local numpy array. (" + str(err) + ")"
                     # except TypeError:
-                    #    print("DEBUG: ", input_forcings.coarse_input_forcings2, input_forcings.input_map_output, force_count)
+                    #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
                     if config_options.current_output_step == 1:
                         input_forcings.coarse_input_forcings1[input_forcings.input_map_output[force_count], :, :] = \
@@ -4093,7 +4097,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             # Read in the ERA5-Interim height field, which is used for downscaling purposes.
             if 'Geopotential' in id_tmp.variables.keys():
-                print('Found geopotential height in ERA5-Interim data')
+                LOG.info('Found geopotential height in ERA5-Interim data')
             # To Do, see if NCAR downscaling methods are applicable
             # for reanalysis datasets with coarser resolution
             else:
@@ -4805,7 +4809,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if grib_var == 'CPOFP':
                 if mpi_config.rank == 0:
-                    # print(f"DEBUG: CPOFP stats, min={var_tmp[var_tmp > 0].min()} mean={var_tmp[var_tmp > 0].mean()} max={var_tmp[var_tmp > 0].max()}", flush=True)
+                    # LOG.debug(f"CPOFP stats, min={var_tmp[var_tmp > 0].min()} mean={var_tmp[var_tmp > 0].mean()} max={var_tmp[var_tmp > 0].max()}")
                     var_tmp[var_tmp >= 0] = (100 - var_tmp[var_tmp >= 0]) / 100  # convert frozen fraction to liquid fraction
                     var_tmp[var_tmp < 0] = 1.0  # assume all liquid if not specifically given
                     if config_options.grid_type == "unstructured":
@@ -8227,7 +8231,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     hour = input_forcings.fcst_hour2
     current_cycle = config_options.current_fcst_cycle
     forecast_time = config_options.current_time
-    # DEBUG if mpi_config.rank == 0: print(f"NEXT FILE: {hour=}, {current_cycle=}, {forecast_time=}", flush=True)
+    # DEBUG if mpi_config.rank == 0: LOG.debug(f"NEXT FILE: {hour=}, {current_cycle=}, {forecast_time=}")
 
     ndfd_files = ('tmp', 'wdir', 'wspd', 'qpf')
     fill_values = {'tmp': 288.0, 'wdir': 45.0, 'wspd': 0.71, 'qpf': 0}
@@ -8355,7 +8359,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 elif config_options.grid_type == "unstructured":
                     input_forcings.esmf_field_in.data[:] = var_sub_tmp
                     input_forcings.esmf_field_in_elem.data[:] = var_sub_tmp_elem
-                # DEBUG if mpi_config.rank == 1: print(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
+                # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = "Unable to place local array into local ESMF field: " + str(err)
                 err_handler.log_critical(config_options, mpi_config)
@@ -9167,7 +9171,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
             mask[:, :] = mpi_config.scatter_array(input_forcings, gmask, config_options)
             err_handler.check_program_status(config_options, mpi_config)
         except Exception as e:
-            print(e, flush=True)
+            LOG.error(f"{e}")
 
     lat_tmp = None
     lon_tmp = None

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -64,7 +64,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
     if mpi_config.rank == 0:
         try:
             config_options.statusMsg = name + " file being used: " + input_file
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             os.symlink(input_file, tmpFile)
         except:
@@ -95,8 +95,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         if not os.path.isfile(input_forcings.file_in2):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "No AK AnA in_2 file found for this timestep."
-                err_handler.log_msg(config_options, mpi_config)
-            err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             return
 
         # Check to see if the regrid complete flag for this
@@ -105,8 +104,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
                 config_options.statusMsg = "No AK AnA regridding required for this timestep."
-                err_handler.log_msg(config_options, mpi_config)
-            err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             return
 
         # Only rank‐0 opens the file
@@ -211,8 +209,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}"
-                err_handler.log_msg(config_options, mpi_config)
-                LOG.info(f"{config_options.statusMsg}")
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
                     try:
                         var_tmp = ds.variables[nc_var][0, :, :]
@@ -315,7 +313,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No StageIV regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -349,7 +347,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
 
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"WGRIB2 command: {cmd}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             id_tmp = ioMod.open_grib2(supplemental_precip.file_in2, stage4_tmp_nc, cmd,
                                       config_options, mpi_config, inputVar=None, special_case=False)
             err_handler.check_program_status(config_options, mpi_config)
@@ -365,7 +363,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
         if calc_regrid_flag:
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Calculating STAGE IV regridding weights."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             calculate_supp_pcp_weights(supplemental_precip, id_tmp, stage4_tmp_nc, config_options, mpi_config, lat_var, lon_var)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -375,7 +373,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :]
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -393,7 +391,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :]
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -411,7 +409,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :]
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -430,7 +428,7 @@ def _regrid_ak_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hydro
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :]
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -681,7 +679,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No StageIV regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -715,7 +713,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
 
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"WGRIB2 command: {cmd}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             id_tmp = ioMod.open_grib2(supplemental_precip.file_in2, stage4_tmp_nc, cmd,
                                       config_options, mpi_config, inputVar=None, special_case=False)
             err_handler.check_program_status(config_options, mpi_config)
@@ -731,7 +729,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
         if calc_regrid_flag:
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Calculating STAGE IV regridding weights."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             calculate_supp_pcp_weights(supplemental_precip, id_tmp, stage4_tmp_nc, config_options, mpi_config, lat_var, lon_var)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -741,7 +739,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :]
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -759,7 +757,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :].data
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -777,7 +775,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :].data
                     var_tmp_elem = np.where(var_tmp_elem == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp_elem)
@@ -796,7 +794,7 @@ def _regrid_conus_ext_ana_pcp_stage4(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[-1]][0, :, :]
                     var_tmp = np.where(var_tmp == id_tmp[supplemental_precip.netcdf_var_names[0]]._FillValue, 0.0, var_tmp)
@@ -1043,8 +1041,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     if not os.path.isfile(input_forcings.file_in2):
         if mpi_config.rank == 0:
             config_options.statusMsg = "No HRRR in_2 file found for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
-        err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Check to see if the regrid complete flag for this
@@ -1053,8 +1050,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No HRRR regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
-        err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -1062,6 +1058,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regrid CONUS HRRR"
+        err_handler.log_msg(config_options, mpi_config)
+
         if input_forcings.fileType != NETCDF:
 
             # This file shouldn't exist.... but if it does (previously failed
@@ -1081,7 +1080,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Converting HRRR Variable: {grib_var}"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 if 0 < input_forcings.cycleFreq < 60:
                     time_str = f"{input_forcings.fcst_min1}-{input_forcings.fcst_min2} min acc fcst" if grib_var == 'APCP' else f"{input_forcings.fcst_min2} min fcst"
                     sub_rem = int(input_forcings.fcst_min1) % 60
@@ -1108,7 +1107,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing HRRR Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -1117,14 +1116,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculating HRRR regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # # Read in the HRRR height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in HRRR elevation data."
-                #     err_handler.log_msg(config_options, mpi_config)
+                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -1159,7 +1158,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -1211,7 +1210,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -1259,7 +1258,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                            input_forcings.esmf_field_out_elem)
@@ -1311,7 +1310,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -1357,7 +1356,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Processing input HRRR variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         if 0 < input_forcings.cycleFreq < 60:
                             var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][sub_id, :, :]
@@ -1386,7 +1385,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input HRRR Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                              input_forcings.esmf_field_out)
@@ -1425,7 +1424,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Processing input HRRR variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         if 0 < input_forcings.cycleFreq < 60:
                             var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][sub_id, :, :]
@@ -1454,7 +1453,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input HRRR Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                              input_forcings.esmf_field_out)
@@ -1492,7 +1491,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Processing input HRRR variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         if 0 < input_forcings.cycleFreq < 60:
                             var_tmp_elem = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][sub_id, :, :]
@@ -1522,7 +1521,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input HRRR Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                        input_forcings.esmf_field_out_elem)
@@ -1561,7 +1560,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Processing input HRRR variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         if 0 < input_forcings.cycleFreq < 60:
                             var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][sub_id, :, :]
@@ -1590,7 +1589,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input HRRR Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                              input_forcings.esmf_field_out)
@@ -1659,7 +1658,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No RAP regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -1668,6 +1667,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regrid CONUS RAP"
+        err_handler.log_msg(config_options, mpi_config)
         if input_forcings.fileType != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
@@ -1687,7 +1688,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Converting CONUS RAP Variable: " + grib_var
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 time_str = "{}-{} hour acc fcst".format(input_forcings.fcst_hour1, input_forcings.fcst_hour2) \
                     if grib_var in ("APCP", "FROZR") else str(input_forcings.fcst_hour2) + " hour fcst"
                 fields.append(':' + grib_var + ':' +
@@ -1712,7 +1713,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing Conus RAP Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -1721,14 +1722,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculating RAP regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in RAP elevation data."
-                #     err_handler.log_msg(config_options, mpi_config)
+                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -1759,7 +1760,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -1808,7 +1809,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -1856,7 +1857,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                            input_forcings.esmf_field_out_elem)
@@ -1905,7 +1906,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -1972,7 +1973,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input RAP Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                              input_forcings.esmf_field_out)
@@ -2005,7 +2006,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out.data, config_options.globalNdv)
-                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
+                    # LOG.debug(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2[input_forcings.input_map_output[force_count], :, :] = (1 - frz_fract).filled(1.0)
@@ -2044,7 +2045,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input RAP Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                              input_forcings.esmf_field_out)
@@ -2077,7 +2078,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out.data, config_options.globalNdv)
-                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
+                    # LOG.debug(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2[input_forcings.input_map_output[force_count], :] = (1 - frz_fract).filled(1.0)
@@ -2115,7 +2116,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input RAP Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                        input_forcings.esmf_field_out_elem)
@@ -2148,7 +2149,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2_elem[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out_elem.data, config_options.globalNdv)
-                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
+                    # LOG.debug(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2_elem[input_forcings.input_map_output[force_count], :] = (1 - frz_fract).filled(1.0)
@@ -2187,7 +2188,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input RAP Field: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                              input_forcings.esmf_field_out)
@@ -2220,7 +2221,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     RAINRATE = 3  # TODO: determine this programmatically
                     total_pcp = np.ma.masked_values(input_forcings.regridded_forcings2[RAINRATE], config_options.globalNdv)
                     frozn_pcp = np.ma.masked_values(input_forcings.esmf_field_out.data, config_options.globalNdv)
-                    # LOG.info(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
+                    # LOG.debug(f"rank {mpi_config.rank} has {(frozn_pcp > total_pcp).sum()} instances of frozn_pcp > total_pcp")
                     frz_fract = frozn_pcp / total_pcp
                     frz_fract[frz_fract > 1] = 1
                     input_forcings.regridded_forcings2[input_forcings.input_map_output[force_count], :] = (1 - frz_fract).filled(1.0)
@@ -2271,7 +2272,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         # need to regrid bias-corrected data every hour.
         if mpi_config.rank == 0:
             config_options.statusMsg = "No need to read in new CFSv2 data at this time."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -2280,6 +2281,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regrid CFSv2"
+        err_handler.log_msg(config_options, mpi_config)
         if input_forcings.fileType != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
@@ -2299,7 +2302,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Converting CFSv2 Variable: " + grib_var
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 fields.append(':' + grib_var + ':' +
                               input_forcings.grib_levels[force_count] + ':'
                               + str(input_forcings.fcst_hour2) + " hour fcst:")
@@ -2322,7 +2325,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing CFSv2 Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -2331,7 +2334,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculate CFSv2 regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                 calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2339,7 +2342,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in CFSv2 elevation data."
-                #     err_handler.log_msg(config_options, mpi_config)
+                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 #
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
@@ -2372,7 +2375,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
@@ -2422,7 +2425,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
@@ -2471,7 +2474,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     try:
                         input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
@@ -2521,7 +2524,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
@@ -2571,7 +2574,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     if not config_options.runCfsNldasBiasCorrect:
                         config_options.statusMsg = "Regridding CFSv2 variable: " + \
                                                    input_forcings.netcdf_var_names[force_count]
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -2678,7 +2681,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     if not config_options.runCfsNldasBiasCorrect:
                         config_options.statusMsg = "Regridding CFSv2 variable: " + \
                                                    input_forcings.netcdf_var_names[force_count]
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -2784,7 +2787,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     if not config_options.runCfsNldasBiasCorrect:
                         config_options.statusMsg = "Regridding CFSv2 variable: " + \
                                                    input_forcings.netcdf_var_names[force_count]
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -2891,7 +2894,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     if not config_options.runCfsNldasBiasCorrect:
                         config_options.statusMsg = "Regridding CFSv2 variable: " + \
                                                    input_forcings.netcdf_var_names[force_count]
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -3033,16 +3036,19 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No NWM NetCDF regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
     id_tmp = ioMod.open_netcdf_forcing(input_forcings.file_in2, config_options, mpi_config, open_on_all_procs=True)
 
+    config_options.statusMsg = "Regrid NWM Custom NetCDF Forcing Variables"
+    err_handler.log_msg(config_options, mpi_config)
+
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing Custom NetCDF Forcing Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                config_options, wrf_hydro_geo_meta, mpi_config)
 
@@ -3053,14 +3059,14 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         if mpi_config.rank == 0:
             config_options.statusMsg = f"Unable to locate HGT_surface in: {input_forcings.file_in2}. " \
                                        f"Downscaling will not be available."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -3107,7 +3113,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -3153,7 +3159,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -3200,7 +3206,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -3265,7 +3271,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No NWM NetCDF regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -3288,10 +3294,13 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             
             id_tmp = id_tmp.assign_coords(longitude=(['y', 'x'], lon_coords), latitude=(['y', 'x'], lat_coords))
 
+    config_options.statusMsg = "Regrid NWM Custom zarr Forcing Variables"
+    err_handler.log_msg(config_options, mpi_config)
+
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing Custom zarr Forcing Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                config_options, wrf_hydro_geo_meta, mpi_config)
         if calc_regrid_flag:
@@ -3308,7 +3317,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom zarr input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -3355,7 +3364,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom zarr input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -3401,7 +3410,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom zarr input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -3448,7 +3457,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom zarr input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -3528,7 +3537,7 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No Custom Hourly NetCDF regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -3537,10 +3546,13 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
     fill_values = {'TMP': 288.0, 'SPFH': 0.005, 'PRES': 101300.0, 'APCP': 0,
                    'UGRD': 1.0, 'VGRD': 1.0, 'DSWRF': 80.0, 'DLWRF': 310.0}
 
+    config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
+    err_handler.log_msg(config_options, mpi_config)
+
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing Custom NetCDF Forcing Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                config_options, wrf_hydro_geo_meta, mpi_config)
 
@@ -3576,7 +3588,7 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -3624,7 +3636,7 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -3671,7 +3683,7 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                            input_forcings.esmf_field_out_elem)
@@ -3719,7 +3731,7 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -3763,10 +3775,10 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -3835,10 +3847,10 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -3905,10 +3917,10 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -3976,10 +3988,10 @@ def regrid_custom_hourly_netcdf(input_forcings, config_options, wrf_hydro_geo_me
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -4073,7 +4085,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No ERA5-Interim regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4086,10 +4098,13 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     seconds_index = np.abs((pd.to_datetime(time) - pd.to_datetime(config_options.current_time)).total_seconds())
     ind = np.where(seconds_index == np.min(seconds_index))[0][0]
 
+    config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
+    err_handler.log_msg(config_options, mpi_config)
+
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing ERA-5 Interim Forcing Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                config_options, wrf_hydro_geo_meta, mpi_config)
         if calc_regrid_flag:
@@ -4117,10 +4132,10 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding ERA5-Interim input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using -9999. to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -4196,10 +4211,10 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding ERA5-Interim input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using -9999. to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -4274,10 +4289,10 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding ERA5-Interim input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using -9999. to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_confi, True)  # log at debug level
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -4354,10 +4369,10 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding ERA5-Interim input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using -9999. to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -4459,7 +4474,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No 13km GFS regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -4493,10 +4508,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regridding 13km GFS Variables."
+        err_handler.log_msg(config_options, mpi_config)
+
         if reuse_prev_file:
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Reusing previous input file: " + input_forcings.file_in2
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             id_tmp = ioMod.open_netcdf_forcing(input_forcings.tmpFile, config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
         else:
@@ -4505,7 +4523,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 for force_count, grib_var in enumerate(input_forcings.grib_vars):
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Converting 13km GFS Variable: " + grib_var
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     # Create a temporary NetCDF file from the GRIB2 file.
                     if grib_var == "PRATE":
                         # By far the most complicated of output variables. We need to calculate
@@ -4545,7 +4563,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing 13km GFS Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -4554,14 +4572,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculating 13km GFS regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Read in the GFS height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #    config_options.statusMsg = "Reading in 13km GFS elevation data."
-                #    err_handler.log_msg(config_options, mpi_config)
+                #    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #    "\":(HGT):(surface):\" " + \
                 #    " -netcdf " + input_forcings.tmpFileHeight
@@ -4631,7 +4649,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding 13km GFS surface elevation data to the WRF-Hydro domain."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in, input_forcings.esmf_field_out)
@@ -4864,7 +4882,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input 13km GFS Field: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     begin = time.monotonic()
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
@@ -4872,7 +4890,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = time.monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding took {} seconds".format(end - begin)
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 except ValueError as ve:
                     config_options.errMsg = "Unable to regrid GFS variable: " + input_forcings.netcdf_var_names[force_count] + " (" + str(ve) + ")"
                     err_handler.log_critical(config_options, mpi_config)
@@ -4903,7 +4921,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             elif config_options.grid_type == "unstructured":
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input 13km GFS Field for Mesh nodes: " + input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     begin = time.monotonic()
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
@@ -4911,7 +4929,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = time.monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Node Regridding took {} seconds".format(end - begin)
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 except ValueError as ve:
                     config_options.errMsg = "Unable to regrid GFS variable for Mesh Nodes: " + input_forcings.netcdf_var_names[force_count] \
                                             + " (" + str(ve) + ")"
@@ -4943,7 +4961,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input 13km GFS Field for Mesh elements: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     begin = time.monotonic()
                     input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
@@ -4951,7 +4969,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = time.monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Element Regridding took {} seconds".format(end - begin)
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 except ValueError as ve:
                     config_options.errMsg = "Unable to regrid GFS variable for Mesh Elements: " + input_forcings.netcdf_var_names[force_count] \
                                             + " (" + str(ve) + ")"
@@ -4985,7 +5003,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding Input 13km GFS Field for Mesh Elements: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     begin = time.monotonic()
                     input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
@@ -4993,7 +5011,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = time.monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Element Regridding took {} seconds".format(end - begin)
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 except ValueError as ve:
                     config_options.errMsg = "Unable to regrid GFS variable for Mesh Element: " + input_forcings.netcdf_var_names[force_count] \
                                             + " (" + str(ve) + ")"
@@ -5062,7 +5080,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         config_options.statusMsg = "No regridding of NAM nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -5071,6 +5089,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regridding NAM nest data"
+        err_handler.log_msg(config_options, mpi_config)
         if input_forcings.fileType != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
@@ -5089,7 +5109,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Converting NAM-Nest Variable: " + grib_var
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 fields.append(':' + grib_var + ':' +
                               input_forcings.grib_levels[force_count] + ':'
                               + str(input_forcings.fcst_hour2) + " hour fcst:")
@@ -5115,7 +5135,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing NAM Nest Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -5124,14 +5144,14 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculating NAM nest regridding weights...."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in NAM nest elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config)
+                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -5159,7 +5179,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -5207,7 +5227,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -5254,7 +5274,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                            input_forcings.esmf_field_out_elem)
@@ -5302,7 +5322,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -5352,7 +5372,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding NAM nest input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -5409,7 +5429,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding NAM nest input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -5465,7 +5485,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding NAM nest input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -5522,7 +5542,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding NAM nest input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -5622,7 +5642,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No MRMS regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -5668,6 +5688,9 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
     id_mrms = None
     id_mrms_rqi = None
     try:
+        config_options.statusMsg = "Rrgrid MRMS"
+        err_handler.log_msg(config_options, mpi_config)
+
         if supplemental_precip.fileType != NETCDF:
             # Unzip MRMS files to temporary locations.
             ioMod.unzip_file(supplemental_precip.file_in2, mrms_tmp_grib2, config_options, mpi_config)
@@ -5716,7 +5739,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Calculating MRMS regridding weights."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             calculate_supp_pcp_weights(supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5745,7 +5768,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding MRMS RQI Field."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out = supplemental_precip.regridObj(supplemental_precip.esmf_field_in,
                                                                                        supplemental_precip.esmf_field_out)
@@ -5760,7 +5783,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if n_masked > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"{n_masked} masked cells in RQI field, will remove"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     supplemental_precip.esmf_field_out.data[np.where(supplemental_precip.regridded_mask == 0)] = \
                         config_options.globalNdv
@@ -5792,7 +5815,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding MRMS RQI Field."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out = supplemental_precip.regridObj(supplemental_precip.esmf_field_in,
                                                                                        supplemental_precip.esmf_field_out)
@@ -5807,7 +5830,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if n_masked > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"{n_masked} masked cells in RQI field, will remove"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     supplemental_precip.esmf_field_out.data[np.where(supplemental_precip.regridded_mask == 0)] = \
                         config_options.globalNdv
@@ -5838,7 +5861,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding MRMS RQI Field."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out_elem = supplemental_precip.regridObj_elem(supplemental_precip.esmf_field_in_elem,
                                                                                                  supplemental_precip.esmf_field_out_elem)
@@ -5853,7 +5876,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if n_masked > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"{n_masked} masked cells in RQI field, will remove"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
                     supplemental_precip.esmf_field_out_elem.data[np.where(supplemental_precip.regridded_mask_elem == 0)] = \
                         config_options.globalNdv
@@ -5874,7 +5897,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
 
             if mpi_config.rank == 0:
                 config_options.statusMsg = "MRMS Will not be filtered using RQI values."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
         elif supplemental_precip.rqiMethod == 2:
             # Read in the RQI field from monthly climatological files.
@@ -5896,7 +5919,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -5945,7 +5968,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = config_options.globalNdv
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
@@ -5978,7 +6001,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -6027,7 +6050,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = config_options.globalNdv
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
@@ -6059,7 +6082,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_mrms.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -6109,7 +6132,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if len(ind_filter_elem) > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = config_options.globalNdv
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
@@ -6141,7 +6164,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -6190,7 +6213,7 @@ def regrid_mrms_hourly(supplemental_precip, config_options, wrf_hydro_geo_meta, 
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
                             config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = config_options.globalNdv
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
@@ -6445,7 +6468,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         config_options.statusMsg = "No regridding of WRF-ARW nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -6454,6 +6477,9 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regrid WRF-ARW nest data"
+        err_handler.log_msg(config_options, mpi_config)
+
         if input_forcings.fileType != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
@@ -6472,7 +6498,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Converting WRF-ARW Variable: " + grib_var
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 time_str = "{}-{} hour acc fcst".format(input_forcings.fcst_hour1, input_forcings.fcst_hour2) \
                     if grib_var == 'APCP' else str(input_forcings.fcst_hour2) + " hour fcst"
                 fields.append(':' + grib_var + ':' +
@@ -6500,7 +6526,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing WRF-ARW Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -6509,14 +6535,14 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculating WRF-ARW regridding weights...."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in WRF-ARW elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config)
+                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -6544,7 +6570,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -6591,7 +6617,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -6638,7 +6664,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
                                                                                            input_forcings.esmf_field_out_elem)
@@ -6686,7 +6712,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
 
                     if mpi_config.rank == 0:
                         config_options.statusMsg = "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
                                                                                  input_forcings.esmf_field_out)
@@ -6736,7 +6762,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF-ARW input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -6804,7 +6830,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF-ARW input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -6871,7 +6897,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF-ARW input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -6939,7 +6965,7 @@ def regrid_hourly_wrf_arw(input_forcings, config_options, wrf_hydro_geo_meta, mp
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF-ARW input variable: " + \
                                                input_forcings.netcdf_var_names[force_count]
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[input_forcings.netcdf_var_names[force_count]][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
@@ -7038,7 +7064,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No ARW regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -7047,6 +7073,9 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
 
     id_tmp = None
     try:
+        config_options.statusMsg = "Regrid ARW"
+        err_handler.log_msg(config_options, mpi_config)
+
         if supplemental_precip.fileType != NETCDF:
             # These files shouldn't exist. If they do, remove them.
             if mpi_config.rank == 0:
@@ -7094,7 +7123,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
         if calc_regrid_flag:
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Calculating WRF ARW regridding weights."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             calculate_supp_pcp_weights(supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7104,7 +7133,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables['APCP_surface'][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -7166,7 +7195,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables['APCP_surface'][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -7227,7 +7256,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables['APCP_surface'][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -7289,7 +7318,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(supplemental_precip, config_options, wrf_hy
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables['APCP_surface'][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -7391,7 +7420,7 @@ def regrid_sbcv2_liquid_water_fraction(supplemental_forcings, config_options, wr
     if calc_regrid_flag:
         if mpi_config.rank == 0:
             config_options.statusMsg = "Calculating SBCv2 Liquid Water Fraction regridding weights."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calculate_supp_pcp_weights(supplemental_forcings, id_tmp, supplemental_forcings.file_in1,
                                    config_options, mpi_config, lat_var="Lat", lon_var="Lon")
         err_handler.check_program_status(config_options, mpi_config)
@@ -7453,8 +7482,8 @@ def regrid_sbcv2_liquid_water_fraction(supplemental_forcings, config_options, wr
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction - unstructured"
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -7504,8 +7533,8 @@ def regrid_sbcv2_liquid_water_fraction(supplemental_forcings, config_options, wr
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction input variable."
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             try:
                 var_tmp_elem = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -7556,7 +7585,7 @@ def regrid_sbcv2_liquid_water_fraction(supplemental_forcings, config_options, wr
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction."
+                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction - hydrofabric"
                 err_handler.log_msg(config_options, mpi_config)
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
@@ -7658,7 +7687,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
         for force_count, grib_var in enumerate(forcings_or_precip.grib_vars):
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Converting NBM Variable: " + grib_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             time_str = "{}-{} hour acc fcst".format(forcings_or_precip.fcst_hour1, forcings_or_precip.fcst_hour2) \
                 if grib_var == 'APCP' else str(forcings_or_precip.fcst_hour2) + " hour fcst"
             fields.append(':' + grib_var + ':' +
@@ -7683,10 +7712,13 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
 
     err_handler.check_program_status(config_options, mpi_config)
 
+    config_options.statusMsg = "Processing NBM Variables"
+    err_handler.log_msg(config_options, mpi_config)
+
     for force_count, nc_var in enumerate(forcings_or_precip.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing NBM Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -7704,13 +7736,13 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
             if is_supp:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Calculating NBM {tag} regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_supp_pcp_weights(forcings_or_precip, id_tmp, forcings_or_precip.file_in1, config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Calculating NBM {tag} regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, force_count, forcings_or_precip, config_options, mpi_config, fill=True)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7749,7 +7781,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
 
                         if mpi_config.rank == 0:
                             config_options.statusMsg = "Regridding NBM elevation data to the WRF-Hydro domain."
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = forcings_or_precip.regridObj(forcings_or_precip.esmf_field_in,
                                                                                              forcings_or_precip.esmf_field_out)
@@ -7798,7 +7830,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
 
                         if mpi_config.rank == 0:
                             config_options.statusMsg = "Regridding NBM elevation data to the WRF-Hydro domain."
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = forcings_or_precip.regridObj(forcings_or_precip.esmf_field_in,
                                                                                              forcings_or_precip.esmf_field_out)
@@ -7847,7 +7879,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
 
                         if mpi_config.rank == 0:
                             config_options.statusMsg = "Regridding NBM elevation data to the WRF-Hydro domain."
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = forcings_or_precip.regridObj(forcings_or_precip.esmf_field_in,
                                                                                              forcings_or_precip.esmf_field_out)
@@ -7893,7 +7925,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
 
                         if mpi_config.rank == 0:
                             config_options.statusMsg = "Regridding NBM elevation data to the unstructured domain."
-                            err_handler.log_msg(config_options, mpi_config)
+                            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out_elem = forcings_or_precip.regridObj_elem(forcings_or_precip.esmf_field_in_elem,
                                                                                                        forcings_or_precip.esmf_field_out_elem)
@@ -7928,7 +7960,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"Regridding NBM {nc_var}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -7998,7 +8030,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"Regridding NBM {nc_var}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -8067,7 +8099,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"Regridding NBM {nc_var}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -8136,7 +8168,7 @@ def regrid_hourly_nbm(forcings_or_precip, config_options, wrf_hydro_geo_meta, mp
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = f"Regridding NBM {nc_var}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -8225,8 +8257,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
             config_options.statusMsg = "No NDFD regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
+
+    config_options.statusMsg = "Regrid NDFD"
+    err_handler.log_msg(config_options, mpi_config)
 
     hour = input_forcings.fcst_hour2
     current_cycle = config_options.current_fcst_cycle
@@ -8249,7 +8284,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         if not reuse_prev_file and mpi_config.rank == 0:
             if os.path.isfile(tmp_file):
                 config_options.statusMsg = f"Deleting old temporary file: {tmp_file}"
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     os.remove(tmp_file)
                 except OSError:
@@ -8262,12 +8297,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             if reuse_prev_file:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"Cycle unchanged, reusing temporary file: {tmp_file}"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
                 else:
@@ -8282,26 +8317,26 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 if ndfd_var != "qpf":
                     if forecast_time > times[-1] + timedelta(hours=3):
                         config_options.statusMsg = f"Forecast time beyond NDFD range, skipping"
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
                         config_options.statusMsg = f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}"
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     else:
                         time_index = min(range(len(times)), key=lambda i: abs(times[i] - forecast_time))
                         config_options.statusMsg = f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}"
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
                         config_options.statusMsg = f"Forecast time beyond NDFD precip range, skipping"
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
                         config_options.statusMsg = f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}"
-                        err_handler.log_msg(config_options, mpi_config)
+                        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             skip_file = mpi_config.broadcast_parameter(skip_file, config_options, param_type=np.ubyte)
             err_handler.check_program_status(config_options, mpi_config)
@@ -8318,7 +8353,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Processing NDFD variable: " + ndfd_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             calc_regrid_flag = check_regrid_status(id_tmp, i, input_forcings,
                                                    config_options, wrf_hydro_geo_meta, mpi_config)
@@ -8327,7 +8362,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Calculating NDFD regridding weights."
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 calculate_weights(id_tmp, i, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8501,10 +8536,13 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     #    id_tmp = None
     # mpi_config.comm.barrier()
 
+    config_options.statusMsg = "Processing Custom NetCDF Forcing Variables"
+    err_handler.log_msg(config_options, mpi_config)
+
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = "Processing Custom NetCDF Forcing Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(id_tmp, force_count, input_forcings,
                                                config_options, wrf_hydro_geo_meta, mpi_config)
 
@@ -8523,10 +8561,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -8595,10 +8633,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -8665,10 +8703,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -8736,10 +8774,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fill = fill_values.get(input_forcings.grib_vars[force_count], config_options.globalNdv)
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Regridding Custom netCDF input variable: " + nc_var
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 try:
                     config_options.statusMsg = f"Using {fill} to replace missing values in input"
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                     var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                 except Exception as err:
                     config_options.errMsg = "Unable to extract " + nc_var + \
@@ -9079,6 +9117,9 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     :return:
     """
 
+    config_options.statusMsg = "Calculate Weights"
+    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+
     if mpi_config.rank == 0:
         if config_options.aws:
             try:
@@ -9160,7 +9201,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
                 config_options.statusMsg = "Trimming input forcing `{}` by {} grid cells".format(
                     input_forcings.productName,
                     border)
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
             gmask[:+border, :] = 0.  # top edge
@@ -9380,7 +9421,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Loading cached ESMF weight object for " + input_forcings.productName + \
                                                " from " + weight_file
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 err_handler.check_program_status(config_options, mpi_config)
 
                 begin = time.monotonic()
@@ -9392,7 +9433,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Finished loading weight object with ESMF, took {} seconds".format(
                         end - begin)
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
                 config_options.errMsg = "Unable to load cached ESMF weight file: " + str(esmf_error)
@@ -9405,7 +9446,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Loading cached ESMF mesh element weight object for " + input_forcings.productName + \
                                                " from " + weight_file
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 err_handler.check_program_status(config_options, mpi_config)
 
                 begin = time.monotonic()
@@ -9417,7 +9458,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
                 if mpi_config.rank == 0:
                     config_options.statusMsg = "Finished loading mesh element weight object with ESMF, took {} seconds".format(
                         end - begin)
-                    err_handler.log_msg(config_options, mpi_config)
+                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
                 config_options.errMsg = "Unable to load cached ESMF mesh element weight file: " + str(esmf_error)
@@ -9426,7 +9467,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     if input_forcings.regridObj is None:
         if mpi_config.rank == 0:
             config_options.statusMsg = "Creating weight object from ESMF"
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         err_handler.check_program_status(config_options, mpi_config)
         extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
         regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
@@ -9444,7 +9485,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Finished generating weight object with ESMF, took {} seconds".format(
                     end - begin)
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
             config_options.errMsg = "Unable to regrid input data from ESMF: " + str(esmf_error)
             err_handler.log_critical(config_options, mpi_config)
@@ -9475,7 +9516,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     if config_options.grid_type == "unstructured" and input_forcings.regridObj_elem is None:
         if mpi_config.rank == 0:
             config_options.statusMsg = "Creating ESMF mesh element weight object from ESMF"
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         err_handler.check_program_status(config_options, mpi_config)
         extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
         regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
@@ -9493,7 +9534,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
             if mpi_config.rank == 0:
                 config_options.statusMsg = "Finished generating ESMF mesh element weight object with ESMF, took {} seconds".format(
                     end - begin)
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
             config_options.errMsg = "Unable to regrid input data into ESMF mesh element weight object from ESMF: " + str(esmf_error)
             err_handler.log_critical(config_options, mpi_config)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
@@ -11,6 +11,10 @@ import pandas as pd
 from . import err_handler
 from .forcingInputMod import input_forcings
 
+import logging
+from ..log_level_set import MODULE_NAME
+LOG = logging.getLogger(MODULE_NAME)
+
 NETCDF = input_forcings.NETCDF
 
 
@@ -721,7 +725,7 @@ def find_conus_hrrr_neighbors(input_forcings, config_options, d_current, mpi_con
     tmp_file2 = input_forcings.inDir + '/hrrr.' + current_hrrr_cycle.strftime(
         '%Y%m%d') + "/hrrr.t" + current_hrrr_cycle.strftime('%H') + 'z.wrfsfcf' \
                 + str(next_hrrr_forecast_hour).zfill(2) + input_forcings.file_ext
-    print(f"temp_file_names", tmp_file1, tmp_file2)
+    LOG.info(f"temp_file_names {tmp_file1}, {tmp_file2}")
     # Check to see if we need to change pathway extension for HRRR data
     # to HPSS tape storage naming conventions
     if (os.path.isfile(tmp_file1) == False and os.path.isfile(tmp_file2) == False):
@@ -1446,8 +1450,8 @@ def find_gfs_neighbors(input_forcings, config_options, d_current, mpi_config):
     err_handler.check_program_status(config_options, mpi_config)
 
     # debug - ksl
-    print(f"file_in1: {input_forcings.file_in1}")
-    print(f"file_in2: {input_forcings.file_in2}")
+    LOG.info(f"file_in1: {input_forcings.file_in1}")
+    LOG.info(f"file_in2: {input_forcings.file_in2}")
 
     # Ensure we have the necessary new file
     if mpi_config.rank == 0:
@@ -3129,8 +3133,8 @@ def find_hourly_nbm_neighbors(supplemental_precip, config_options, d_current, mp
 
         supplemental_precip.file_in1 = tmp_file1
         supplemental_precip.file_in2 = tmp_file2
-        print(f"tmp_file1: {tmp_file1}")
-        print(f"tmp_file2: {tmp_file2}")
+        LOG.info(f"tmp_file1: {tmp_file1}")
+        LOG.info(f"tmp_file2: {tmp_file2}")
         supplemental_precip.regridComplete = False
 
     # Ensure we have the necessary new file
@@ -3281,7 +3285,7 @@ def find_hourly_mrms_precip_flag(supplemental_precip, config_options, d_current,
     """
 
     # debug - ksl
-    print(f"Starting find_hourly_mrms_precip_flag method.")
+    LOG.info(f"Starting find_hourly_mrms_precip_flag method.")
 
     # First we need to find the nearest previous and next hour, which is
     # the previous/next MRMS files we will be using.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
@@ -507,7 +507,7 @@ def find_ak_ext_ana_neighbors(input_forcings, config_options, d_current, mpi_con
     if mpi_config.rank == 0:
         config_options.statusMsg = "Processing Alaska ExtAnA Data. Calculating neighboring " \
                                    "files for this output timestep"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
     # First find the current ExtAnA forecast cycle that we are using.
     ana_offset = 1 if config_options.ana_flag else 0
@@ -655,7 +655,7 @@ def find_conus_hrrr_neighbors(input_forcings, config_options, d_current, mpi_con
     if mpi_config.rank == 0:
         config_options.statusMsg = "Processing Conus HRRR Data. Calculating neighboring " \
                                    "files for this output timestep"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
     # Fortunately, HRRR data is straightforward compared to GFS in terms of precip values, etc.
     if d_current >= datetime.datetime(2018, 10, 1):
@@ -725,7 +725,7 @@ def find_conus_hrrr_neighbors(input_forcings, config_options, d_current, mpi_con
     tmp_file2 = input_forcings.inDir + '/hrrr.' + current_hrrr_cycle.strftime(
         '%Y%m%d') + "/hrrr.t" + current_hrrr_cycle.strftime('%H') + 'z.wrfsfcf' \
                 + str(next_hrrr_forecast_hour).zfill(2) + input_forcings.file_ext
-    LOG.info(f"temp_file_names {tmp_file1}, {tmp_file2}")
+    LOG.debug(f"temp_file_names {tmp_file1}, {tmp_file2}")
     # Check to see if we need to change pathway extension for HRRR data
     # to HPSS tape storage naming conventions
     if (os.path.isfile(tmp_file1) == False and os.path.isfile(tmp_file2) == False):
@@ -838,7 +838,7 @@ def find_ak_hrrr_neighbors(input_forcings, config_options, d_current, mpi_config
     if mpi_config.rank == 0:
         config_options.statusMsg = "Processing Conus HRRR AK Data. Calculating neighboring " \
                                    "files for this output timestep"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
     default_horizon = 18  # 18-hour forecasts.
     six_hr_horizon = 48  # 48-hour forecasts every six hours.
@@ -1450,8 +1450,8 @@ def find_gfs_neighbors(input_forcings, config_options, d_current, mpi_config):
     err_handler.check_program_status(config_options, mpi_config)
 
     # debug - ksl
-    LOG.info(f"file_in1: {input_forcings.file_in1}")
-    LOG.info(f"file_in2: {input_forcings.file_in2}")
+    LOG.debug(f"file_in1: {input_forcings.file_in1}")
+    LOG.debug(f"file_in2: {input_forcings.file_in2}")
 
     # Ensure we have the necessary new file
     if mpi_config.rank == 0:
@@ -2072,14 +2072,14 @@ def find_hourly_mrms_radar_neighbors(supplemental_precip, config_options, d_curr
 
     if mpi_config.rank == 0:
         config_options.statusMsg = "Previous MRMS supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next MRMS supplemental file: " + tmp_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         if os.path.isfile(tmp_rqi_file1) and os.path.isfile(tmp_rqi_file2):
             config_options.statusMsg = "Previous MRMS RQI supplemental file: " + tmp_rqi_file1
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
             config_options.statusMsg = "Next MRMS RQI supplemental file: " + tmp_rqi_file2
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to see if files are already set. If not, then reset, grids and
@@ -2528,9 +2528,9 @@ def _find_ak_ext_ana_precip_stage4(supplemental_precip, config_options, d_curren
 
     if mpi_config.rank == 0:
         config_options.statusMsg = "Previous Stage IV supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next Stage IV supplemental file: " + tmp_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to see if files are already set. If not, then reset, grids and
@@ -2647,9 +2647,9 @@ def _find_conus_ext_ana_precip_stage4(supplemental_precip, config_options, d_cur
 
     if mpi_config.rank == 0:
         config_options.statusMsg = "Previous Stage IV supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next Stage IV supplemental file: " + tmp_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to see if files are already set. If not, then reset, grids and
@@ -2773,9 +2773,9 @@ def _find_ak_ext_ana_precip_mrms(supplemental_precip, config_options, d_current,
 
     if mpi_config.rank == 0:
         config_options.statusMsg = "Previous MRMS supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next MRMS supplemental file: " + tmp_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to see if files are already set. If not, then reset, grids and
@@ -2893,9 +2893,9 @@ def _find_conus_ext_ana_precip_mrms(supplemental_precip, config_options, d_curre
 
     if mpi_config.rank == 0:
         config_options.statusMsg = "Previous MRMS supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next MRMS supplemental file: " + tmp_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to see if files are already set. If not, then reset, grids and
@@ -3117,9 +3117,9 @@ def find_hourly_nbm_neighbors(supplemental_precip, config_options, d_current, mp
 
     if mpi_config.rank == 0:
         # config_options.statusMsg = "Prev NBM supplemental file: " + tmp_file2
-        # err_handler.log_msg(config_options, mpi_config)
+        # err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next NBM supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to see if files are already set. If not, then reset, grids and
@@ -3133,8 +3133,8 @@ def find_hourly_nbm_neighbors(supplemental_precip, config_options, d_current, mp
 
         supplemental_precip.file_in1 = tmp_file1
         supplemental_precip.file_in2 = tmp_file2
-        LOG.info(f"tmp_file1: {tmp_file1}")
-        LOG.info(f"tmp_file2: {tmp_file2}")
+        LOG.debug(f"tmp_file1: {tmp_file1}")
+        LOG.debug(f"tmp_file2: {tmp_file2}")
         supplemental_precip.regridComplete = False
 
     # Ensure we have the necessary new file
@@ -3386,7 +3386,7 @@ def find_input_neighbors(input_forcings, config_options, d_current, mpi_config):
     if mpi_config.rank == 0:
         config_options.statusMsg = "Processing %s Input Data. Calculating neighboring " \
                                    "files for this output timestep" % input_forcings.productName
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
     # First find the current input forecast cycle that we are using.
 
@@ -3465,7 +3465,7 @@ def find_input_neighbors(input_forcings, config_options, d_current, mpi_config):
         tmp_file1 = files1[0]
         if mpi_config.rank == 0:
             config_options.statusMsg = "Previous input file being used: " + tmp_file1
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
         pattern1 = f"{input_forcings.inDir}/*.{current_input_cycle.strftime('%Y%m%d')}/*{current_input_cycle.strftime('%H')}z*{str(next_input_forecast_hour).zfill(2)}.grib2"
         pattern2 = f"{input_forcings.inDir}/*.{current_input_cycle.strftime('%Y%m%d')}/conus/*{current_input_cycle.strftime('%H')}z*{str(next_input_forecast_hour).zfill(2)}.grib2"
@@ -3488,7 +3488,7 @@ def find_input_neighbors(input_forcings, config_options, d_current, mpi_config):
         tmp_file1 = files1[0]
         if mpi_config.rank == 0:
             config_options.statusMsg = "Previous input file being used: " + tmp_file1
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3638,13 +3638,13 @@ def find_custom_freq_neighbors(supplemental_precip, config_options, d_current, m
 
     if mpi_config.rank == 0:
         config_options.statusMsg = "Previous Custom supplemental file: " + tmp_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next Custom supplemental file: " + tmp_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Previous RQI supplemental file: " + tmp_rqi_file1
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         config_options.statusMsg = "Next RQI supplemental file: " + tmp_rqi_file2
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
 
     supplemental_precip.file_in1 = tmp_file1

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
@@ -27,6 +27,21 @@ class CustomFormatter(logging.Formatter):
         logging.CRITICAL: "FATAL"
     }
  
+    # Apply custom formatter (UTC timestamps applied only to this formatter)
+    def converter(self, timestamp):
+        """Override time converter to return UTC time tuple"""
+        return time.gmtime(timestamp)
+
+    def formatTime(self, record, datefmt=None):
+        """Use our UTC converter"""
+        ct = self.converter(record.created)
+        if datefmt:
+            s = time.strftime(datefmt, ct)
+        else:
+            t = time.strftime("%Y-%m-%d %H:%M:%S", ct)
+            s = f"{t},{int(record.msecs):03d}"
+        return s
+
     def format(self, record):
         original_levelname = record.levelname
         record.levelname = self.LEVEL_NAME_MAP.get(record.levelno, original_levelname)
@@ -73,12 +88,12 @@ def get_log_file_path():
                 # Set full log path
                 username = getpass.getuser()
                 if username:
-                    logFieDir = logFieDir + DS + username
+                    logFileDir = logFileDir + DS + username
                 else:
                     logFileDir = logFileDir + DS + create_timestamp(True)
                 # Create directory
-                with os.makedirs(logFileDir, exist_ok=True):
-                    logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
+                os.makedirs(logFileDir, exist_ok=True)
+                logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
             except Exception as e:
                 logFilePath = ""
  
@@ -176,24 +191,24 @@ def log_level_set():
         )
         handler.setFormatter(formatter)
  
+        # Get or create your named logger
+        logger = logging.getLogger(MODULE_NAME)
+
         # Setup root logger
-        logging.getLogger().handlers.clear()  # Clear any default handlers
-        logging.getLogger().setLevel(translate_ngwpc_log_level(log_level))
-        logging.getLogger().addHandler(handler)
- 
-        # Ensure UTC timestamps
-        logging.Formatter.converter = time.gmtime
+        logger.handlers.clear()  # Clear any default handlers
+        logger.setLevel(translate_ngwpc_log_level(log_level))
+        logger.addHandler(handler)
  
         # Save the current log level
-        current_level = logging.getLogger().getEffectiveLevel()
+        current_level = logger.getEffectiveLevel()
  
         try:
             # Temporarily set log level to INFO
-            logging.getLogger().setLevel(logging.INFO)
+            logger.setLevel(logging.INFO)
              
             # Log the message at INFO level
-            logging.info(f"Log level set to {log_level}")
+            logger.info(f"Log level set to {log_level}")
             print(f"Module {MODULE_NAME} Log Level set to {log_level}")
         finally:
             # Restore the original log level
-            logging.getLogger().setLevel(current_level)
+            logger.setLevel(current_level)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
@@ -158,7 +158,9 @@ def log_level_set():
     See also https://docs.python.org/3/library/logging.html
      
     '''
-
+    # Use a named logger because Forcing is handled differently
+    # than other BMI modules in ngen. This ensures the entries
+    # are identified as FORCING and not NGEN in the log.
     logger = logging.getLogger(MODULE_NAME)
     if getattr(logger, "_initialized", False):
         return  # logger already initialized, nothing else to do
@@ -198,7 +200,7 @@ def log_level_set():
         )
         handler.setFormatter(formatter)
  
-        # Setup root logger
+        # Setup logger
         logger.handlers.clear()  # Clear any default handlers
         logger.setLevel(translate_ngwpc_log_level(log_level))
         logger.addHandler(handler)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
@@ -193,7 +193,6 @@ def log_level_set():
         formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
  
         # Apply custom formatter
-        formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
         formatter = CustomFormatter(
             fmt=f"%(asctime)s.%(msecs)03d {formatted_module} %(levelname_padded)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
@@ -1,0 +1,199 @@
+import logging
+import sys  
+from datetime import datetime, timezone
+import os
+import time
+import getpass
+ 
+ 
+MODULE_NAME           = "Forcing";
+LOG_DIR_NGENCERF      = "/ngencerf/data";       # ngenCERF log directory string if environement var empty.
+LOG_DIR_DEFAULT       = "run-logs";             # Default parent log directory string if env var empty  & ngencerf dosn't exist
+LOG_FILE_EXT          = "log";                  # Log file name extension
+DS                    = "/";                    # Directory separator
+LOG_MODULE_NAME_LEN   = 8;                      # Width of module name for log entries
+ 
+EV_EWTS_LOGGING       = "NGEN_EWTS_LOGGING";    # Enable/disable of Error Warning and Trapping System 
+EV_NGEN_LOGFILEPATH   = "NGEN_LOG_FILE_PATH";   # ngen log file
+EV_MODULE_LOGLEVEL    = "FORCING_LOGLEVEL";     # This modules log level
+EV_MODULE_LOGFILEPATH = "FORCING_LOGFILEPATH";  # This modules log full log filename
+ 
+class CustomFormatter(logging.Formatter):
+    LEVEL_NAME_MAP = {
+        logging.DEBUG: "DEBUG",
+        logging.INFO: "INFO",
+        logging.WARNING: "WARNING",
+        logging.ERROR: "SEVERE",
+        logging.CRITICAL: "FATAL"
+    }
+ 
+    def format(self, record):
+        original_levelname = record.levelname
+        record.levelname = self.LEVEL_NAME_MAP.get(record.levelno, original_levelname)
+        record.levelname_padded = record.levelname.ljust(7)[:7]  # Exactly 7 chars
+        formatted = super().format(record)
+        record.levelname = original_levelname  # Restore original in case it's reused
+        return formatted
+     
+def create_timestamp(date_only: bool = False, iso: bool = False, append_ms: bool = False) -> str:
+    now = datetime.now(timezone.utc)
+ 
+    if date_only:
+        ts_base = now.strftime("%Y%m%d")
+    elif iso:
+        ts_base = now.strftime("%Y-%m-%dT%H:%M:%S")
+    else:
+        ts_base = now.strftime("%Y%m%dT%H%M%S")
+ 
+    if append_ms:
+        ms_str = f".{now.microsecond // 1000:03d}"
+        return ts_base + ms_str
+    else:
+        return ts_base
+ 
+def get_log_file_path():
+    appendEntries = True
+    moduleLogEnvExists = False
+    moduleEnvVar = os.getenv(EV_MODULE_LOGFILEPATH, "")
+    if moduleEnvVar:
+        logFilePath = moduleEnvVar
+        moduleLogEnvExists = True
+    else:
+        ngenEnvVar = os.getenv(EV_NGEN_LOGFILEPATH, "")
+        if ngenEnvVar:
+            logFilePath = ngenEnvVar
+        else:
+            appendEntries = False
+            if os.path.isdir(LOG_DIR_NGENCERF):
+                logFileDir = LOG_DIR_NGENCERF + DS + LOG_DIR_DEFAULT
+            else:
+                logFileDir = os.path.expanduser("~") + DS + LOG_DIR_DEFAULT
+            try:
+                os.makedirs(logFileDir, exist_ok=True)
+                # Set full log path
+                username = getpass.getuser()
+                if username:
+                    logFieDir = logFieDir + DS + username
+                else:
+                    logFileDir = logFileDir + DS + create_timestamp(True)
+                # Create directory
+                with os.makedirs(logFileDir, exist_ok=True):
+                    logFilePath = logFileDir + DS + MODULE_NAME + "_" + create_timestamp() + "." + LOG_FILE_EXT
+            except Exception as e:
+                logFilePath = ""
+ 
+    # Ensure log file can be opened and set module env var
+    try:
+        if (logFilePath):
+            if (appendEntries):
+                logFile = open(logFilePath, "a")
+            else:
+                logFile = open(logFilePath, "w")
+            if (moduleLogEnvExists == False):
+                os.environ[EV_MODULE_LOGFILEPATH] = logFilePath
+                print(f"Module {MODULE_NAME} Log File: {logFilePath}")
+        else:
+            raise IOError
+    except:
+        print(f"Unable to open log file for {MODULE_NAME}: {logFilePath}")
+        print(f"Log entries will be writen to stdout")
+ 
+    return logFilePath, appendEntries
+     
+def get_log_level() -> str:
+    levelEnvVar = os.getenv(EV_MODULE_LOGLEVEL, "")
+    if levelEnvVar:
+        return levelEnvVar.strip().upper()
+    else:
+        return "INFO"
+ 
+def translate_ngwpc_log_level(ngwpc_log_level: str) -> str:
+    ll = ngwpc_log_level.strip().upper()
+    if (ll == "SEVERE"):
+        return "ERROR"
+    elif (ll == "FATAL"):
+        return "CRITICAL"
+    return ll
+ 
+def log_level_set():
+    '''
+    Set logging level and specify logger configuration based on environment variables set by ngen
+     
+    Arguments
+    ---------
+    None
+         
+    Returns
+    -------
+    None
+     
+    Notes
+    -----
+    In the absense of logging environment variables the log level defaults to INFO and
+    the pathname is set as follows:
+        - Use the module log file if available (unset when first run by ngen), otherwise
+        - Use ngen log file if available, otherwise
+        - Use /ngencerf/data/run-logs/<username>/<module>_<YYMMDDTHHMMSS> if available, otherwise
+        - Use ~/run-logs/<YYYYMMDD>/<module>_<YYMMDDTHHMMSS>
+        - Onced opened, save the full log path to the modules log environment variable so
+          it is only opened once for each ngen run (vs for each catchment)
+ 
+    See also https://docs.python.org/3/library/logging.html
+     
+    '''
+    loggingEnabled = True
+    moduleEnvVar = os.getenv(EV_EWTS_LOGGING, "")
+    if moduleEnvVar:
+        if (moduleEnvVar == "DISABLED"):
+            loggingEnabled = False
+ 
+    if (loggingEnabled == False):
+        print(f"Module {MODULE_NAME} Logging DISABLED")
+        logging.disable(logging.CRITICAL)  # Disables all logs at CRITICAL and below (i.e., everything)
+    else:
+        print(f"Module {MODULE_NAME} Logging ENABLED")
+ 
+        # Get the log file name from env var or a default
+        logFilePath, appendEntries = get_log_file_path()
+        if (logFilePath):
+            # Set the open mode
+            openMode = 'a' if appendEntries else 'w'
+            handler = logging.FileHandler(logFilePath, mode=openMode)
+        else:
+            handler = logging.StreamHandler(sys.stdout)
+ 
+        # Get the log level from env var or a default
+        log_level = get_log_level()
+ 
+        # Format the module name: uppercase, fixed length, left-justify or trimmed
+        formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
+ 
+        # Apply custom formatter
+        formatted_module = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]
+        formatter = CustomFormatter(
+            fmt=f"%(asctime)s.%(msecs)03d {formatted_module} %(levelname_padded)s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S"
+        )
+        handler.setFormatter(formatter)
+ 
+        # Setup root logger
+        logging.getLogger().handlers.clear()  # Clear any default handlers
+        logging.getLogger().setLevel(translate_ngwpc_log_level(log_level))
+        logging.getLogger().addHandler(handler)
+ 
+        # Ensure UTC timestamps
+        logging.Formatter.converter = time.gmtime
+ 
+        # Save the current log level
+        current_level = logging.getLogger().getEffectiveLevel()
+ 
+        try:
+            # Temporarily set log level to INFO
+            logging.getLogger().setLevel(logging.INFO)
+             
+            # Log the message at INFO level
+            logging.info(f"Log level set to {log_level}")
+            print(f"Module {MODULE_NAME} Log Level set to {log_level}")
+        finally:
+            # Restore the original log level
+            logging.getLogger().setLevel(current_level)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
@@ -6,18 +6,20 @@ import time
 import getpass
  
  
-MODULE_NAME           = "Forcing";
-LOG_DIR_NGENCERF      = "/ngencerf/data";       # ngenCERF log directory string if environement var empty.
-LOG_DIR_DEFAULT       = "run-logs";             # Default parent log directory string if env var empty  & ngencerf dosn't exist
-LOG_FILE_EXT          = "log";                  # Log file name extension
-DS                    = "/";                    # Directory separator
-LOG_MODULE_NAME_LEN   = 8;                      # Width of module name for log entries
+MODULE_NAME           = "Forcing"
+LOG_DIR_NGENCERF      = "/ngencerf/data"       # ngenCERF log directory string if environement var empty.
+LOG_DIR_DEFAULT       = "run-logs"             # Default parent log directory string if env var empty  & ngencerf dosn't exist
+LOG_FILE_EXT          = "log"                  # Log file name extension
+DS                    = "/"                    # Directory separator
+LOG_MODULE_NAME_LEN   = 8                      # Width of module name for log entries
  
-EV_EWTS_LOGGING       = "NGEN_EWTS_LOGGING";    # Enable/disable of Error Warning and Trapping System 
-EV_NGEN_LOGFILEPATH   = "NGEN_LOG_FILE_PATH";   # ngen log file
-EV_MODULE_LOGLEVEL    = "FORCING_LOGLEVEL";     # This modules log level
-EV_MODULE_LOGFILEPATH = "FORCING_LOGFILEPATH";  # This modules log full log filename
- 
+EV_EWTS_LOGGING       = "NGEN_EWTS_LOGGING"    # Enable/disable of Error Warning and Trapping System 
+EV_NGEN_LOGFILEPATH   = "NGEN_LOG_FILE_PATH"   # ngen log file
+EV_MODULE_LOGLEVEL    = "FORCING_LOGLEVEL"     # This modules log level
+EV_MODULE_LOGFILEPATH = "FORCING_LOGFILEPATH"  # This modules log full log filename
+
+ewts_logFileDir = ""
+
 class CustomFormatter(logging.Formatter):
     LEVEL_NAME_MAP = {
         logging.DEBUG: "DEBUG",
@@ -156,6 +158,11 @@ def log_level_set():
     See also https://docs.python.org/3/library/logging.html
      
     '''
+
+    logger = logging.getLogger(MODULE_NAME)
+    if getattr(logger, "_initialized", False):
+        return  # logger already initialized, nothing else to do
+
     loggingEnabled = True
     moduleEnvVar = os.getenv(EV_EWTS_LOGGING, "")
     if moduleEnvVar:
@@ -191,9 +198,6 @@ def log_level_set():
         )
         handler.setFormatter(formatter)
  
-        # Get or create your named logger
-        logger = logging.getLogger(MODULE_NAME)
-
         # Setup root logger
         logger.handlers.clear()  # Clear any default handlers
         logger.setLevel(translate_ngwpc_log_level(log_level))
@@ -212,3 +216,5 @@ def log_level_set():
         finally:
             # Restore the original log level
             logger.setLevel(current_level)
+
+        logger._initialized = True

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -212,7 +212,7 @@ class NWMv3_Forcing_Engine_model:
             LOG.debug(f"Model.py forcing loop: {len(ConfigOptions.input_forcings)} forcings configured: {ConfigOptions.input_forcings}")
 
             for forceKey in ConfigOptions.input_forcings:
-                LOG.debug('forceKey', forceKey)
+                LOG.debug(f"forceKey: {forceKey}")
                 LOG.debug(f"ConfigOptions.aws: {ConfigOptions.aws}")
                 # Pass these methods for AORC data is ERA5-Interim blend is requested
                 # so we can finish filling in the missing gaps
@@ -307,7 +307,7 @@ class NWMv3_Forcing_Engine_model:
                 if forceKey == 10:
                     ConfigOptions.currentCustomForceNum += 1
 
-                LOG.debug(f'End of loop for forceKey {forceKey}')
+                LOG.debug(f"End of loop for forceKey {forceKey}")
 
             # Process supplemental precipitation if we specified in the configuration file.
             if ConfigOptions.number_supp_pcp > 0:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -20,6 +20,9 @@ from .core import err_handler
 from .core import layeringMod
 from . import nwm_proc
 
+import logging
+LOG = logging.getLogger("")
+
 class NWMv3_Forcing_Engine_model:
     # TODO: refactor the bmi_model.py file and this to have this type maintain its own state.
     # def __init__(self):
@@ -97,9 +100,9 @@ class NWMv3_Forcing_Engine_model:
             ConfigOptions.current_fcst_cycle = ConfigOptions.b_date_proc
             ConfigOptions.current_time = pd.Timestamp(ConfigOptions.b_date_proc) + pd.to_timedelta(future_time, unit='s')
 
-        print("NextGen Forcings Engine processing meteorological forcings for BMI timestamp")
-        print(f"Model.py current time: {ConfigOptions.current_time}")
-        print(f"Model.py current fcst cycle: {ConfigOptions.current_fcst_cycle}")
+        LOG.debug("NextGen Forcings Engine processing meteorological forcings for BMI timestamp")
+        LOG.debug(f"Model.py current time: {ConfigOptions.current_time}")
+        LOG.debug(f"Model.py current fcst cycle: {ConfigOptions.current_fcst_cycle}")
 
         if ConfigOptions.first_fcst_cycle is None:
             ConfigOptions.first_fcst_cycle = ConfigOptions.current_fcst_cycle
@@ -202,13 +205,13 @@ class NWMv3_Forcing_Engine_model:
 
             ConfigOptions.currentForceNum = 0
             ConfigOptions.currentCustomForceNum = 0
-            print(f"ConfigOptions.input_forcings: {ConfigOptions.input_forcings}")
+            LOG.debug(f"ConfigOptions.input_forcings: {ConfigOptions.input_forcings}")
             # Loop over each of the input forcings specified.
-            print(f"\n[INFO] Model.py forcing loop: {len(ConfigOptions.input_forcings)} forcings configured: {ConfigOptions.input_forcings}")
+            LOG.debug(f"Model.py forcing loop: {len(ConfigOptions.input_forcings)} forcings configured: {ConfigOptions.input_forcings}")
 
             for forceKey in ConfigOptions.input_forcings:
-                print('forceKey', forceKey)
-                print(f"ConfigOptions.aws: {ConfigOptions.aws}")
+                LOG.debug('forceKey', forceKey)
+                LOG.debug(f"ConfigOptions.aws: {ConfigOptions.aws}")
                 # Pass these methods for AORC data is ERA5-Interim blend is requested
                 # so we can finish filling in the missing gaps
                 if forceKey == 23 and 12 in ConfigOptions.input_forcings and 21 in ConfigOptions.input_forcings:
@@ -249,7 +252,7 @@ class NWMv3_Forcing_Engine_model:
 
                 # If skipping this forcing, continue early
                 if input_forcings.skip is True:
-                    print(f"Breaking loop for forceKey {forceKey}")
+                    LOG.debug(f"Breaking loop for forceKey {forceKey}")
                     break
                 # Regrid forcings.
                 input_forcings.regrid_inputs(ConfigOptions, wrfHydroGeoMeta, MpiConfig)
@@ -302,7 +305,7 @@ class NWMv3_Forcing_Engine_model:
                 if forceKey == 10:
                     ConfigOptions.currentCustomForceNum += 1
 
-                print(f'End of loop for forceKey {forceKey}\n')
+                LOG.debug(f'End of loop for forceKey {forceKey}')
 
             # Process supplemental precipitation if we specified in the configuration file.
             if ConfigOptions.number_supp_pcp > 0:
@@ -397,7 +400,7 @@ class NWMv3_Forcing_Engine_model:
         # the I/O module to update opened netcdf file with forcing fields
         if ConfigOptions.forcing_output == 1:
             OutputObj.update_forcing_file_output(ConfigOptions, wrfHydroGeoMeta, MpiConfig)
-            print(f"[INFO] Writing output forcing file for timestamp: {OutputObj.outDate.strftime('%Y-%m-%d %H:%M')}")
+            LOG.info(f"Writing output forcing file for timestamp: {OutputObj.outDate.strftime('%Y-%m-%d %H:%M')}")
 
         if ConfigOptions.grid_type == "gridded":
             for count, variable in enumerate(variables):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -20,8 +20,10 @@ from .core import err_handler
 from .core import layeringMod
 from . import nwm_proc
 
+from .log_level_set import MODULE_NAME
+
 import logging
-LOG = logging.getLogger("")
+LOG = logging.getLogger(MODULE_NAME)
 
 class NWMv3_Forcing_Engine_model:
     # TODO: refactor the bmi_model.py file and this to have this type maintain its own state.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/nwm_proc.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/nwm_proc.py
@@ -9,8 +9,10 @@ from mpi4py.futures import MPICommExecutor
 import dask.config
 import dask.array as da
 
+from .log_level_set import MODULE_NAME
+
 import logging
-LOG = logging.getLogger("")
+LOG = logging.getLogger(MODULE_NAME)
 
 #TODO expand for other domains
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/nwm_proc.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/nwm_proc.py
@@ -9,6 +9,9 @@ from mpi4py.futures import MPICommExecutor
 import dask.config
 import dask.array as da
 
+import logging
+LOG = logging.getLogger("")
+
 #TODO expand for other domains
 
 def get_domain_bounds_quick(ConfigOptions):
@@ -26,7 +29,7 @@ def get_domain_bounds_quick(ConfigOptions):
         
         return lat_min, lat_max, lon_min, lon_max
     except Exception as e:
-        print(f"Could not extract bounds: {e}")
+        LOG.critical(f"Could not extract bounds: {e}")
         return None
 
 def check_time(ConfigOptions):
@@ -70,7 +73,7 @@ def get_time_index(zarr_sample, target_time):
     # Verify bounds
     time_length = zarr_sample['time'].shape[0]
     if target_index < 0 or target_index >= time_length:
-        print(f"Warning: Calculated index {target_index} is out of bounds [0, {time_length-1}]")
+        LOG.warning(f"Calculated index {target_index} is out of bounds [0, {time_length-1}]")
         target_index = max(0, min(target_index, time_length-1))
 
     actual_time = reference_time + pd.Timedelta(hours=target_index)
@@ -113,12 +116,12 @@ def get_spatial_bounds(zarr_sample, domain_bounds):
             y_mask = (y_coords >= y_min_proj) & (y_coords <= y_max_proj)
             
         except ImportError:
-            print("pyproj not available, trying simple coordinate matching...")
+            LOG.error("pyproj not available, trying simple coordinate matching...")
             # Fallback without transformation - later steps will likely fail
             x_mask = (x_coords >= lon_min) & (x_coords <= lon_max)
             y_mask = (y_coords >= lat_min) & (y_coords <= lat_max)
         except Exception as e:
-            print(f"Coordinate transformation failed: {e}")
+            LOG.error(f"Coordinate transformation failed: {e}")
             # Fallback without transformation - later steps will likely fail
             x_mask = (x_coords >= lon_min) & (x_coords <= lon_max)
             y_mask = (y_coords >= lat_min) & (y_coords <= lat_max)
@@ -139,7 +142,7 @@ def get_spatial_bounds(zarr_sample, domain_bounds):
             else:
                 raise Exception("One or more indices not > 0")
         except Exception as e:
-            print(f"Error: {e}")
+            LOG.error(f"{e}")
             spatial_bounds = None
         
 
@@ -162,11 +165,11 @@ def read_zarr_data(files, spatial_bounds, target_index, actual_time, x_coords, y
         'u2d': 'U2D',
         'v2d': 'V2D'
     }
-    print("Reading zarr variables individually due to zarr structure.")
+    LOG.debug("Reading zarr variables individually due to zarr structure.")
     # TODO: Investigate performance optimizations.
     # NWM Retrospective zarr data structure: a separate zarr file for each variable
     for i, file_map in enumerate(files):
-        print(f"Reading variable {i+1}/{len(files)}...")
+        LOG.debug(f"Reading variable {i+1}/{len(files)}...")
         
         zarr_group = zarr.open_group(file_map, mode='r')
         
@@ -225,7 +228,7 @@ def read_zarr_data(files, spatial_bounds, target_index, actual_time, x_coords, y
             data_vars[zarr_var_name] = (['time', 'y', 'x'], var_dask, clean_attrs)
             
         else:
-            print(f"  Warning: Variable {zarr_var_name} not found in zarr group")
+            LOG.warning(f"Variable {zarr_var_name} not found in zarr group")
     return data_vars, coords, attrs            
 
 def proc_nwm(ConfigOptions, MpiConfig):    
@@ -250,7 +253,7 @@ def proc_nwm(ConfigOptions, MpiConfig):
                     ds_subset = xr.Dataset(data_vars=data_vars, coords=coords, attrs=attrs)
                     
                 except Exception as e:
-                    print(f"Error with direct zarr access: {e}")
+                    LOG.critical(f"Error with direct zarr access: {e}")
                     import traceback
                     traceback.print_exc()
                     ds_subset = None 


### PR DESCRIPTION
Added the Error and Warning Trapping System Logger to the BMI Forcing package. Since the BMI Forcing Engine appears to be called as part of ngen and not in the same manner as the other modules identified in the realization file, used a named logger for the EWTS entries instead of the global logger so the appropriate module name would be in the log entry.

## Additions

- Python log_level_set.py script
- Added the logger to each of the NextGen_Forcing_Engine_BMI package scripts
- Added log calls before throwing an exception 

## Changes

- Updated print statements to their appropriate log levels.
- Updated core/err_handler.py to first attempt to use the named EWTS Forcing logger. If it doesn't exist, default to the logger from the original code.

## Testing

- Built the latest containers for ngen-forcing, ngen, and nwm-fcst-mgr, then ran a forecast in ngenCERF. Observed the log entries in the ngen.log file.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

