### PR TITLE
PRVI NWM retrospective forcing file and CONUS TPXO error fixes

### DIFF
--- a/coastal/SFINCS/coastalforcing/main.py
+++ b/coastal/SFINCS/coastalforcing/main.py
@@ -296,15 +296,14 @@ def main():
     # Process data
     sim_dir = _normpath(here, cfg['sim_dir'], f"{cfg['coastal_model']}_{_parse_utc(cfg['start_time'])}")
 
-    if  cfg["coastal_model"].lower() == "sfincs": 
-      tpxo_env = None
-      ld_library_path = cfg.get('ld_library_path', None)
-      if ld_library_path:
+    tpxo_env = None
+    ld_library_path = cfg.get('ld_library_path', None)
+    if ld_library_path:
         tpxo_env={
             "LD_LIBRARY_PATH": ld_library_path
         }
 
-      processor = DataProcessor(
+    processor = DataProcessor(
         coastal_model=cfg['coastal_model'],
         domain_info=domain_info,
         sim_dir=sim_dir,
@@ -317,8 +316,14 @@ def main():
         tpxo_relative_path=cfg.get('tpxo_relative_path', None),
         tpxo_model_control=cfg.get('tpxo_model_control', None),
         tpxo_env=tpxo_env
-      )
+    )
+
+    if  cfg["coastal_model"].lower() == "sfincs": 
       processor.process_all()
+    elif  cfg["coastal_model"].lower() == "schism": 
+      processor.process_schism()
+    else:
+        raise ValueError("Unknown value for config key: coastal_model! ")
 
     print("Forcing file generation COMPLETE")
 

--- a/coastal/SFINCS/coastalforcing/process_data/data_processor.py
+++ b/coastal/SFINCS/coastalforcing/process_data/data_processor.py
@@ -9,6 +9,8 @@ import geopandas as gpd  # kept if you plan to use later
 from shapely.affinity import rotate
 from shapely.geometry import box
 import pandas as pd
+import netCDF4 as nc
+from netCDF4 import  num2date, date2num
 from .glofs_sfincs import build_bzs_from_glofs_legacy
 from .mateo_sfincs import write_sfincs_meteo_from_nwm
 
@@ -1143,3 +1145,18 @@ class DataProcessor:
             print(f"[tpxo] wrote bzs  → {bzs_path} (nt={tgt.size}, npts={npts}, dt={out_dt_seconds}s)")
         '''
 
+    def process_schism(self):
+        if self.model != "schism":
+            print(f"[process] Model '{self.model}' not implemented yet.")
+            return
+        else:
+            if self.domain_info['domain'][0]['name'] == 'prvi' and self.meteo == "nwm_retro":
+              path = os.path.join(self.raw_root, "meteo", "nwm_retro")
+              retro_files = os.listdir(path)
+              for f in retro_files:
+                  if f.endswith('.LDASIN_DOMAIN1'):
+                      ncfile = path + '/' + f
+                      with nc.Dataset(ncfile, mode="r+") as dataset:
+                          validtimevar = dataset.variables['valid_time']
+                          correct_validtime = datetime.strptime( f, "%Y%m%d%H.LDASIN_DOMAIN1") 
+                          validtimevar[:] = date2num([ correct_validtime ], validtimevar.units)

--- a/coastal/calib/make_tpxo_ocean.bash
+++ b/coastal/calib/make_tpxo_ocean.bash
@@ -45,7 +45,7 @@ make_tpxo_ocean() {
    local _correction_file=$DATAexec/elevation_correction.csv
    if [[ -f  ${_correction_file} ]]; then
        echo "Applying elevation datum correction to elev2D.th.nc file"
-       ${MPICOMMAND3} python $USHnwm/wrf_hydro_workflow_dev/coastal/correct_elevation.py \
+       python $USHnwm/wrf_hydro_workflow_dev/coastal/correct_elevation.py \
        ./elev2D.th.nc ${_correction_file} 
    fi
    cd -

--- a/coastal/calib/sing_run.bash
+++ b/coastal/calib/sing_run.bash
@@ -14,7 +14,7 @@ set -x
 #load the configuration file
 . ./schism_calib.cfg
 
-export NGWPC_COASTAL_PARM_DIR=/ngwpc-coastal
+export NGWPC_COASTAL_PARM_DIR=/ngen-test/coastal/ngwpc-coastal
 
 export NGEN_APP_DIR=/ngen-app
 #


### PR DESCRIPTION
1) Fixed the wrong valid_time variable values in the NWM Retrospective forcing files in the PRVI domain.
2) Fixed the TPXO error when using TPXO boundary conditions in the CONUS domain for the SCHISM use case.
These two issues were found during the testing of the SCHISM calibration use case on the integration cluster.

## Additions
-
None
## Removals
None
-

## Changes
1. Updated the SFINCS/SCHISM download and setup tool.
2. Updated the shell script to run the TPXO model in the CONUS domain.
-

## Testing

1. Test with PRVI and CONUS domain passed

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

