### PR TITLE
Dockerfiles for hydromt_sfincs and Delft Dashboard

### DIFF
--- a/coastal/SFINCS/Dockerfile.delft_dashboard
+++ b/coastal/SFINCS/Dockerfile.delft_dashboard
@@ -1,0 +1,54 @@
+#FROM jess/firefox
+
+FROM ubuntu:latest
+
+SHELL ["/bin/bash", "-c"] 
+
+# Set environment variable to avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update the package list and install Python 3 and pip
+RUN apt-get update && \
+        apt-get install -y python3-full python3-pip && \
+        apt-get install -y git && \
+        apt-get install -y freeglut3-dev && \
+        apt-get install -y libnss3 && \
+        apt-get install libxkbfile1 && \
+        apt-get install -y libasound2t64 && \
+        rm -rf /var/lib/apt/lists/*
+
+#RUN apt-get -y install libxcb-cursor-dev
+#RUN apt install -y libxcb*
+RUN apt update && apt install -y \
+    qt6-base-dev \
+    # Add other Qt6 modules you need, for example:
+    # qt6-declarative-dev \
+    # qt6-qml-dev \
+    # qt6-webengine-dev \
+    # ... and any other dependencies for your specific application
+    build-essential \
+    cmake \
+    libxcb* \
+    # Clean up apt caches to reduce image size
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the working directory inside the container (optional, but good practice)
+    WORKDIR /app
+#RUN set -eux && \
+#    add-apt-repository universe && \
+#    apt update && \
+#    apt-get -y install libxcb-cursor-dev
+
+#RUN set -eux && \
+#   apt install python3
+
+# Set the working directory (optional)
+WORKDIR /app
+RUN set -eux && \
+   python3 -m venv delftdashboard && \
+   source delftdashboard/bin/activate && \
+   pip3 install delftdashboard@git+https://github.com/deltares-research/delftdashboard.git
+
+# Set environment variable to use host's X11 display
+ENV DISPLAY=:0
+ENTRYPOINT [ "/bin/bash", "-c", "source ~/.bashrc" ]

--- a/coastal/SFINCS/Dockerfile.hydromt_sfincs
+++ b/coastal/SFINCS/Dockerfile.hydromt_sfincs
@@ -1,0 +1,98 @@
+# syntax=docker/dockerfile:1.4
+
+##############################
+# Stage: Base – Common Setup
+##############################
+FROM rockylinux:8 AS base
+
+# cannot remove LANG even though https://bugs.python.org/issue19846 is fixed
+# last attempted removal of LANG broke many users:
+# https://github.com/docker-library/python/pull/570
+ENV LANG="C.UTF-8"
+
+# runtime dependencies
+RUN set -eux && \
+    dnf install -y epel-release && \
+    dnf config-manager --set-enabled powertools && \
+    dnf install -y \
+        autoconf \
+        automake \
+        bc \
+        cmake \
+        curl curl-devel \
+        file \
+        findutils \
+        conda \
+        git \
+## FIXME: replace GNU compilers with Intel compiler ##
+        gcc-toolset-10 \
+## FIXME: replace GNU compilers with Intel compiler ##
+        gcc-toolset-10 \
+        gcc-toolset-10-libasan-devel \
+        libasan6 \
+        libffi libffi-devel \
+        m4 \
+        udunits2 udunits2-devel \
+        bzip2 bzip2-devel \
+        zlib zlib-devel \
+## FIXME: replace openmpi with Intel MPI libraries ##
+        openmpi openmpi-devel \
+        openssl openssl-devel \
+        rsync \
+        sqlite sqlite-devel \
+        tk tk-devel \
+        uuid uuid-devel \
+        which \
+        xz \
+        jq \
+    && dnf clean all && rm -rf /var/cache/dnf
+
+## FIXME: replace GNU compilers with Intel compiler ##
+SHELL [ "/usr/bin/scl", "enable", "gcc-toolset-10" ]
+## FIXME: replace openmpi with Intel MPI libraries ##
+ENV PATH="${PATH}:/usr/lib64/openmpi/bin/"
+
+# Fix OpenMPI support within container
+ENV PSM3_HAL=loopback \
+    PSM3_DEVICES=self
+
+ENV MINICONDA_VERSION="latest"
+ENV MINICONDA_INSTALLER_URL="https://github.com/conda-forge/miniforge/releases/${MINICONDA_VERSION}/download/Miniforge3-Linux-x86_64.sh"
+
+ENV CONDA_DIR="/opt/conda"
+
+RUN curl --location --output ./miniforge.sh ${MINICONDA_INSTALLER_URL} && \
+    bash ./miniforge.sh -b -p ${CONDA_DIR} && \
+    rm miniforge.sh && \
+    /opt/conda/bin/conda init bash 
+
+ENV PATH="/opt/conda/bin:$PATH"
+
+WORKDIR /ngen-app/
+
+RUN set -eux && \
+     git clone https://github.com/Deltares/hydromt_sfincs.git && \
+     cd hydromt_sfincs && \
+     conda env create -f envs/hydromt-sfincs-dev.yml 
+
+RUN set -eux && \
+    echo "conda activate hydromt-sfincs-dev" >> ~/.bashrc
+
+WORKDIR /ngen-app/hydromt_sfincs
+
+RUN set -eux && \
+     source activate base && \
+     conda activate hydromt-sfincs-dev && \ 
+     pip install -e .
+
+#RUN set -eux && \
+#    conda install mamba -n base -c conda-forge
+#
+#RUN set -eux && \
+#    mamba env create -f https://raw.githubusercontent.com/Deltares/hydromt_sfincs/main/environment.yml && \
+#    echo "conda activate hydromt-sfincs" >> ~/.bashrc
+
+#WORKDIR /
+
+ENTRYPOINT [ "bash", "-c", "source ~/.bashrc" ]
+CMD ["hydromt","--models"]


### PR DESCRIPTION
Added two Dockerfiles, one for Deltares HydroMT-SFINCS and another for Delft Dashboard. 
Note that when running Delft Dashboard in the docker container, the map window is blank. If running it on a Parallel Works cluster, it crashes when generating a mesh. These issues should be fixed. On the other hand, Delft Dashboard works in the AWS workspace Ubuntu system without a problem.

[Short description explaining the high-level reason for the pull request]

## Additions

- coastal/SFINCS Dockerfile.hydromt_sfincs
- coastal/SFINCS Dockerfile.delft_dashboard

## Removals

-

## Changes

-

## Testing

1. hydromt_sfincs test results are here, https://confluence.nextgenwaterprediction.com/spaces/NGWPC/pages/65765435/Deltares+HydroMT-SFINCS+Installation+on+OE.
2. The Delft Dashboard test results are there, https://confluence.nextgenwaterprediction.com/pages/viewpage.action?pageId=40731845&spaceKey=NGWPC&title=SFINCS%2BDelft%2BDashboard%2BInstallation%2Band%2BQuick%2BStart%2BGuide

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

