### PR TITLE
Try to address EBUSY failures in some runs

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -716,14 +716,6 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         :return: None
         """
 
-        if self._mpi_meta.rank == 0:
-            for filename in os.listdir(self._job_meta.scratch_dir):
-                file_path = os.path.join(self._job_meta.scratch_dir, filename)
-                if os.path.isfile(file_path) and filename[0:23] != "NextGen_Forcings_Engine":
-                    os.remove(file_path)
-                elif os.path.isdir(file_path):
-                    os.rmdir(file_path)
-
         # Force destruction of ESMF objects
         try:
             del self._WrfHydroGeoMeta
@@ -741,6 +733,22 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             pass
 
         self._model = None
+
+        # Try moving this after all of the ESMF and model bits have
+        # been disposed of - maybe they were keeping something open.
+        #
+        # Potential workaround if that's not enough: uncomment the
+        # return before the file cleanup block, leak the files during
+        # the job, and let the workflow clean them up after the
+        # process exits
+        #return
+        if self._mpi_meta.rank == 0:
+            for filename in os.listdir(self._job_meta.scratch_dir):
+                file_path = os.path.join(self._job_meta.scratch_dir, filename)
+                if os.path.isfile(file_path) and filename[0:23] != "NextGen_Forcings_Engine":
+                    os.remove(file_path)
+                elif os.path.isdir(file_path):
+                    os.rmdir(file_path)
 
     # -------------------------------------------------------------------
     # -------------------------------------------------------------------

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -718,21 +718,9 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         """
 
         # Force destruction of ESMF objects
-        try:
-            del self._WrfHydroGeoMeta
-        except AttributeError:
-            pass
-
-        try:
-            del self._inputForcingMod
-        except AttributeError:
-            pass
-
-        try:
-            del self._suppPcpMod
-        except AttributeError:
-            pass
-
+        self._WrfHydroGeoMeta = None
+        self._inputForcingMod = None
+        self._suppPcpMod = None
         self._model = None
 
         # Try moving this after all of the ESMF and model bits have
@@ -745,11 +733,15 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         gc.collect()  # make sure objects are deleted from memory
         if self._mpi_meta.rank == 0:
             for filename in os.listdir(self._job_meta.scratch_dir):
-                file_path = os.path.join(self._job_meta.scratch_dir, filename)
-                if os.path.isfile(file_path) and filename[0:23] != "NextGen_Forcings_Engine":
-                    os.remove(file_path)
-                elif os.path.isdir(file_path):
-                    os.rmdir(file_path)
+                # NFS mounts may create temporary files to facilitate read-after-delete functionality on linux systems
+                # these will be cleaned when the mount is removed but will throw an error if python tries to remove it
+                # the file name is typically ".nfs" followed by numbers, so we'll just ignore files that start with it
+                if not filename.startswith(".nfs"):
+                    file_path = os.path.join(self._job_meta.scratch_dir, filename)
+                    if os.path.isfile(file_path) and filename[0:23] != "NextGen_Forcings_Engine":
+                        os.remove(file_path)
+                    elif os.path.isdir(file_path):
+                        os.rmdir(file_path)
 
     # -------------------------------------------------------------------
     # -------------------------------------------------------------------

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -1,6 +1,7 @@
 # Need these for BMI
 # This is needed for get_var_bytes
 import os
+import gc
 from pathlib import Path
 
 import netCDF4 as nc
@@ -741,7 +742,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         # return before the file cleanup block, leak the files during
         # the job, and let the workflow clean them up after the
         # process exits
-        #return
+        gc.collect()  # make sure objects are deleted from memory
         if self._mpi_meta.rank == 0:
             for filename in os.listdir(self._job_meta.scratch_dir):
                 file_path = os.path.join(self._job_meta.scratch_dir, filename)


### PR DESCRIPTION
Move file cleanups after model object disposal, so that hopefully everything should be closed.

There's a potential workaround of just leaving the files, and letting the broader workflow delete them later.

A softer-touch workaround that maybe occupies less space would be to catch and swallow exceptions from each of the `os.remove` and `os.rmdir` calls, so that whatever's not still open would still get deleted.

## Additions

-

## Removals

-

## Changes

- Scratch file deletion happens after objects that may have used them are removed from memory.
- Garbage collector explicitly called after deleting processing objects to ensure they've been removed from memory.
- The search for files to delete from the scratch directory will ignore files that start with ".nfs". These are typically made by the NFS mount process and should be automatically deleted when unmounted, so they should be safe to ignore.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

