### PR TITLE
ngen-forcing:Feature:edit cicd workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [master, nwm-master, development, release-candidate]
+    branches: [ngwpc-candidate, ngwpc-release, master, nwm-master, development, release-candidate]
   pull_request:
-    branches: [main, nwm-master, development, release-candidate]
+    branches: [ngwpc-candidate, ngwpc-release, main, nwm-master, development, release-candidate]
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary
- Added ngwpc-candidate and ngwpc-release branches to CI/CD workflow triggers
- These branches now trigger the workflow on both push and pull_request events

## Changes
- Updated `.github/workflows/cicd.yml` line 5 (push branches)
- Updated `.github/workflows/cicd.yml` line 7 (pull_request branches)