### PR TITLE
BMI model output path override

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -156,7 +156,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
     # ------------------------------------------------------------
 
     # -------------------------------------------------------------------
-    def initialize(self, config_file: str) -> None:
+    def initialize(self, config_file: str, output_path: str | None = None) -> None:
         """
         This function is part of the BMI (Basic Model Interface) specification and is automatically
         invoked by the BMI system. When running standalone, call `initialize_with_params()` instead,
@@ -600,7 +600,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             self._values['CAT-ID'] = self._WrfHydroGeoMeta.element_ids
 
 
-        self._configure_output_path()
+        self._configure_output_path(output_path)
 
     def initialize_with_params(self, config_file: str, b_date: str = None, geogrid: str = None, output_path: str = None) -> None:
         """
@@ -627,9 +627,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         self._job_meta = config.ConfigOptions(self.cfg_bmi, b_date=b_date, geogrid_arg=geogrid)
 
         # Now that _job_meta is set, call initialize() to set up the core model
-        self.initialize(config_file)
-
-        self._configure_output_path(output_path)
+        self.initialize(config_file, output_path=output_path)
 
 
     def _configure_output_path(self, output_path: str | None = None) -> None:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -172,7 +172,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
 
 
         LOG.info('---------------------------')
-        LOG.info("BMI Forcing Engine initialized with {config_file}")
+        LOG.info(f"BMI Forcing Engine initialized with {config_file}")
 
         # -------------- Read in the BMI configuration -------------------------#
         if not isinstance(config_file, str) or len(config_file) == 0:


### PR DESCRIPTION
`output_path` was not being leveraged during call to `NWMv3_Forcing_Engine_BMI_model.initialize_with_params` (used by `NextGen_Forcings_Engine_BMI.run_bmi_model`), since the call to `initialize` was calling `_configure_output_path` without it.

## Changes

Adds arg `output_path` to `self.initialize`, which is passed to `self.initialize`'s call to `self._configure_output_path`.

Removes direct call to `self._configure_output_path` from `self.initialize_with_params`

Also fixes one log call which needed `f` added to format its message string.

## Testing

I ran `run_bmi_model` with and without the optional CLI arg `-output_path` and confirmed that the arg is being leveraged, and confirmed that default behavior is not changed (when CLI arg not provided).

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

