### PR TITLE
Share hydrofabric results among all processors

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -950,8 +950,13 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             LOG.warning(f"[BMI] Array for '{var_name}' is not C-contiguous; making a copy.")
             arr = np.ascontiguousarray(arr)
 
-        # Ensure dtype is float64 (C double)
-        if arr.dtype != np.float64:
+        # Ensure dtype is float64 (C double), except for CAT-ID
+        if var_name == "CAT-ID":
+            if arr.dtype != np.int32:
+                msg = f"[BMI] Array for '{var_name}' has dtype {arr.dtype}, expected int32"
+                LOG.critical(msg)
+                raise RuntimeError(msg)
+        elif arr.dtype != np.float64:
             LOG.warning(f"[BMI] Array for '{var_name}' has dtype {arr.dtype}, expected float64; converting.")
             arr = arr.astype(np.float64)
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -227,6 +227,8 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         #Call ESMF mesh creation process
         if self._mpi_meta.rank == 0:
             esmf_creation.create_mesh(self._job_meta)
+        self._mpi_meta.comm.Barrier()
+
         #Call forcing_extraction process
         if self._job_meta.nwmConfig not in ['AORC', 'NWM']:
             forcing_extraction.retrieve_forcing(self._job_meta)
@@ -597,7 +599,7 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
 
         # Set catchment ids if using hydrofabric
         if self._grid_type == "hydrofabric":
-            self._values['CAT-ID'] = self._WrfHydroGeoMeta.element_ids
+            self._values['CAT-ID'] = self._WrfHydroGeoMeta.element_ids_global
 
 
         self._configure_output_path(output_path)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -37,11 +37,13 @@ class OutputObj:
 
     def __init__(self, ConfigOptions, GeoMetaWrfHydro):
         self.output_local = None
+        self.output_global = None
         self.outPath = None
         self.outDate = None
         self.idOut = None
         self.out_ndv = -9999
 
+        # TODO should the length of these depend on `if ConfigOptions.include_lqfrac`?
         # Create local "slabs" to hold final output grids. These
         # will be collected during the output routine below.
         if ConfigOptions.grid_type == 'unstructured':
@@ -51,6 +53,7 @@ class OutputObj:
             self.output_local = np.empty([9, GeoMetaWrfHydro.ny_local, GeoMetaWrfHydro.nx_local])
         elif ConfigOptions.grid_type == 'hydrofabric':
             self.output_local = np.empty([9, GeoMetaWrfHydro.ny_local])
+            self.output_global = np.empty([9, GeoMetaWrfHydro.ny_global])
         # self.output_local[:,:,:] = self.out_ndv
 
     def init_forcing_file(self, ConfigOptions, geoMetaWrfHydro, MpiConfig):
@@ -617,13 +620,22 @@ class OutputObj:
 
         err_handler.check_program_status(ConfigOptions, MpiConfig)
 
-    def update_forcing_file_output(self, ConfigOptions, geoMetaWrfHydro, MpiConfig):
+    def gather_global_outputs(self, ConfigOptions, geoMetaWrfHydro, MpiConfig):
         """
         Updates the output NetCDF file with the regridded or processed forcing data from each processor.
 
         This function will collect data from the different processors, assemble it into a final grid based on the grid type (gridded, hydrofabric, unstructured), and write the result into the output NetCDF file.
 
         It also handles setting various global and variable attributes in the output file, including the creation of dimensions, variables, and geospatial metadata.
+
+        Originally this method had one purpose: to write global results (gathered from all processors) to an output NetCDF file.
+        This method was later updated to support another purpose, the case of ngen's intentional hydrofabric catchment partitioning differing from
+        ESMF's arbitrary mesh/grid partitioning. For that case, MPI Allgatherv is used instead of Gatherv, and the results are stored in
+        an attribute that stores global outputs, s.t. all processors have access to results from all other processors. This way, the ngen rank
+        can acquire hydrofabric forcing results from any of the ngen-forcing ranks.
+
+        The update described above introduced checks for ConfigOptions.forcing_output. Previously, this method would always write to the NetCDF file,
+        but with the update, this method only writes conditionally on that configuration option.
 
         :param ConfigOptions: Configuration options object containing various settings and parameters.
                               It includes globalNdv (NoDataValue), bmi_time_index, regrid_opt, grid_type, etc.
@@ -652,7 +664,8 @@ class OutputObj:
                                                         'Fraction of precipitation that is liquid vs. frozen',
                                                         'time: point', 0.01, 0.0, 3]
 
-        if MpiConfig.rank == 0:
+        if ConfigOptions.forcing_output == 1 and MpiConfig.rank == 0:
+            LOG.debug(f"Writing output forcing file for timestamp {self.outDate.strftime('%Y-%m-%d %H:%M')}: {self.outPath}")
             # Only output on the master processor.
             try:
                 # Try opening the output file and populating the time variable
@@ -670,14 +683,16 @@ class OutputObj:
 
         # Now loop through each variable, collect the data (call on each processor), assemble into the final
         # output grid, and place into the output file (if on processor 0).
-        for varTmp in output_variable_attribute_dict:
+        for i_var, varTmp in enumerate(output_variable_attribute_dict):
 
             # Collect data from the various processors, and place into the output file.
             try:
                 if ConfigOptions.grid_type == "gridded":
                     dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local[output_variable_attribute_dict[varTmp][0], :, :], ConfigOptions)
                 elif ConfigOptions.grid_type == "hydrofabric":
-                    dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local[output_variable_attribute_dict[varTmp][0], :], ConfigOptions)
+                    dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local[output_variable_attribute_dict[varTmp][0], :], ConfigOptions, allgather=True)
+                    # NOTE this assumes that the var order here matches var order elsewhere.
+                    self.output_global[i_var, :] = dataOutTmp.flatten()
                 elif ConfigOptions.grid_type == "unstructured":
                     if varTmp == "RAINRATE":
                       dataOutTmp = MpiConfig.merge_slabs_gatherv(self.output_local_elem[output_variable_attribute_dict[varTmp][0], :], ConfigOptions)
@@ -690,7 +705,7 @@ class OutputObj:
                 err_handler.log_critical(ConfigOptions, MpiConfig)
                 continue
 
-            if MpiConfig.rank == 0:
+            if ConfigOptions.forcing_output == 1 and MpiConfig.rank == 0:
                 # Only process on the master processor
                 if idOut is not None:
                     try:
@@ -701,12 +716,12 @@ class OutputObj:
                     except (ValueError, IOError) as e:
                         ConfigOptions.errMsg = f"Unable to place final output grid for: {varTmp} - {e}"
                         err_handler.log_critical(ConfigOptions, MpiConfig)
-                # Reset temporary data objects to keep memory usage down.
-                del dataOutTmp
+            # Reset temporary data objects to keep memory usage down.
+            dataOutTmp = None
 
             err_handler.check_program_status(ConfigOptions, MpiConfig)
 
-        if MpiConfig.rank == 0 and idOut is not None:
+        if ConfigOptions.forcing_output == 1 and MpiConfig.rank == 0 and idOut is not None:
             # Close the NetCDF file
             try:
                 idOut.close()

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -53,6 +53,17 @@ class MpiConfig:
             config_options.errMsg = "Unable to retrieve the MPI processor rank."
             raise mpi_exception
 
+        if False:
+            self.wait_for_debugpy_client()
+
+    def wait_for_debugpy_client(self):
+        """This blocks until the debugpy clients have attached to cppdbg/gdb.
+        This is for debugging concurrent ngen-forcing MPI ranks (processes).
+        See `launch.json`, `devcontainer.json`, and `tasks.json` in the nwm-rte repository for details."""
+        import debugpy
+        debugpy.listen(('localhost', 5678 + self.rank))
+        debugpy.wait_for_client()
+
     def broadcast_parameter(self, value_broadcast, config_options, param_type):
         """
         Generic function for sending a parameter value out to the processors.
@@ -138,6 +149,8 @@ class MpiConfig:
             :param ConfigOptions:
             :return:
         """
+        ConfigOptions.errMsg = f"RANK {self.rank}: parallel.py: scatter_array_scatterv_no_cache(): "
+        err_handler.log_msg(ConfigOptions, self)
 
         # Determine which type of input array we have based on the
         # type of numpy array.
@@ -219,6 +232,8 @@ class MpiConfig:
             recvbuf = np.empty([counts[self.rank]], np.float64)
 
         # scatter the data
+        ConfigOptions.errMsg = f"RANK {self.rank}: parallel.py: calling Scatterv using {[sendbuf, counts, offsets, data_type], recvbuf}"
+        err_handler.log_msg(ConfigOptions, self)
         try:
             self.comm.Scatterv([sendbuf, counts, offsets, data_type], recvbuf, root=0)
         except:
@@ -227,12 +242,18 @@ class MpiConfig:
             return None
 
         subarray = np.reshape(recvbuf, [y_upper[self.rank] - y_lower[self.rank], x_upper[self.rank] - x_lower[self.rank]]).copy()
+        ConfigOptions.errMsg = f"RANK {self.rank}: parallel.py: subarray = {subarray}"
+        err_handler.log_msg(ConfigOptions, self)
         return subarray
 
     # use scatterv based scatter_array
     scatter_array = scatter_array_scatterv_no_cache
 
-    def merge_slabs_gatherv(self, local_slab, options):
+    def merge_slabs_gatherv(self, local_slab, options, allgather: bool = False):
+        """If allgather is True, then Allgatherv will be used instead of Gatherv,
+        which causes all ranks to be distributed to all other ranks. This is necessary
+        for the hydrofabric case, to handle how ngen's hydrologic catchment partitionining
+        differs from ESMF's arbitrary partitioning."""
 
         # Filter based on dimensionality of array
         if (len(local_slab.shape) == 2):
@@ -281,7 +302,7 @@ class MpiConfig:
             # err_handler.log_msg(options,self)
 
             # create the receive buffer
-            if self.rank == 0:
+            if allgather or self.rank == 0:
                 recvbuf = np.empty([total_rows, width], local_slab.dtype)
             else:
                 recvbuf = None
@@ -298,7 +319,7 @@ class MpiConfig:
             # err_handler.log_msg(options,self)
 
             # create the receive buffer
-            if self.rank == 0:
+            if allgather or self.rank == 0:
                 recvbuf = np.empty([sum(global_shapes)], local_slab.dtype)
             else:
                 recvbuf = None
@@ -314,7 +335,10 @@ class MpiConfig:
 
         # get the data with Gatherv
         try:
-            self.comm.Gatherv(sendbuf=local_slab, recvbuf=[recvbuf, counts, offsets, data_type], root=0)
+            if allgather:
+                self.comm.Allgatherv(sendbuf=local_slab, recvbuf=[recvbuf, counts, offsets, data_type])
+            else:
+                self.comm.Gatherv(sendbuf=local_slab, recvbuf=[recvbuf, counts, offsets, data_type], root=0)
         except:
             options.errMsg = "Failed to Gatherv to rank 0 from rank " + str(self.rank)
             err_handler.log_critical(options, self)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -169,6 +169,7 @@ class NWMv3_Forcing_Engine_model:
             elif ConfigOptions.grid_type == "hydrofabric":
                 # Reset out final grids to missing values.
                 OutputObj.output_local[:, :] = ConfigOptions.globalNdv
+                OutputObj.output_global[:, :] = ConfigOptions.globalNdv
 
             # Increment or initialize output step count
             if ConfigOptions.current_output_step is None:
@@ -391,10 +392,8 @@ class NWMv3_Forcing_Engine_model:
 
         # If user requests output for given domain, then call
         # the I/O module to update opened netcdf file with forcing fields
-        if ConfigOptions.forcing_output == 1:
-            OutputObj.update_forcing_file_output(ConfigOptions, wrfHydroGeoMeta, MpiConfig)
-            if MpiConfig.rank == 0:
-                LOG.debug(f"Writing output forcing file for timestamp: {OutputObj.outDate.strftime('%Y-%m-%d %H:%M')}")
+        if ConfigOptions.forcing_output == 1 or ConfigOptions.grid_type == "hydrofabric":
+            OutputObj.gather_global_outputs(ConfigOptions, wrfHydroGeoMeta, MpiConfig)
 
         if ConfigOptions.grid_type == "gridded":
             for count, variable in enumerate(variables):
@@ -405,7 +404,8 @@ class NWMv3_Forcing_Engine_model:
                 model[variable + '_NODE'] = OutputObj.output_local[count, :].flatten()
         elif ConfigOptions.grid_type == "hydrofabric":
             for count, variable in enumerate(variables):
-                model[variable + '_ELEMENT'] = OutputObj.output_local[count, :].flatten()
+                model[variable + '_ELEMENT'] = OutputObj.output_global[count, :].flatten()
+                model['CAT-ID'] = wrfHydroGeoMeta.element_ids_global
 
         ## Update BMI model time index to next iteration
         ConfigOptions.bmi_time_index += 1

--- a/NextGen_Forcings_Engine_BMI/run_bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/run_bmi_model.py
@@ -52,19 +52,20 @@ def run_bmi(start_time: str, end_time: str, config_path: pathlib.Path = None, b_
     # Initialize arrays based on grid type
     # ===============================
     if model._grid_type in {"gridded", "hydrofabric"}:
+        varsize = len(model._WrfHydroGeoMeta.element_ids_global) if model._grid_type == "hydrofabric" else model._varsize
         # Shared initialization
-        U2D = np.zeros(model._varsize, dtype=float)
-        V2D = np.zeros(model._varsize, dtype=float)
-        LWDOWN = np.zeros(model._varsize, dtype=float)
-        SWDOWN = np.zeros(model._varsize, dtype=float)
-        T2D = np.zeros(model._varsize, dtype=float)
-        Q2D = np.zeros(model._varsize, dtype=float)
-        PSFC = np.zeros(model._varsize, dtype=float)
-        RAINRATE = np.zeros(model._varsize, dtype=float)
+        U2D = np.zeros(varsize, dtype=float)
+        V2D = np.zeros(varsize, dtype=float)
+        LWDOWN = np.zeros(varsize, dtype=float)
+        SWDOWN = np.zeros(varsize, dtype=float)
+        T2D = np.zeros(varsize, dtype=float)
+        Q2D = np.zeros(varsize, dtype=float)
+        PSFC = np.zeros(varsize, dtype=float)
+        RAINRATE = np.zeros(varsize, dtype=float)
         if model._job_meta.include_lqfrac == 1:
-            LQFRAC = np.zeros(model._varsize, dtype=float)
+            LQFRAC = np.zeros(varsize, dtype=float)
         if model._grid_type == "hydrofabric":
-            CAT_IDS = np.zeros(model._varsize, dtype=int)
+            CAT_IDS = np.zeros(varsize, dtype=int)
 
     elif model._grid_type == "unstructured":
         # Unstructured grid (element + node)


### PR DESCRIPTION
This PR adjusts BMI and MPI behavior for grid type "hydrofabric", to support the case of ngen's intentional hydrologic catchment partitioning method differing from ESMF's distribution of catchments among the PETs (MPI processors) of the `ngen-forcing` BMI model.

The solution is to have all PETs store a copy of gathered (global) results. This way ngen's MPI processors can fetch results from any BMI processor. Though this is inherently wasteful from a memory perspective, I do not think there is a memory availability/scalability concern, since currently, each catchment has at most 9 individual forcing values per timestep.

I have tested this on a small VPU (gage 01123000, 7 catchments) with `mpirun -n 2`. It would be good to test with a large VPU, with many catchments and many partitions, to confirm that MPI's `Allgatherv` does not become a bottleneck under that condition.

When testing these `ngen-forcing` changes via ngen client, it is necessary to use an ngen build that includes these changes to the client side, for ngen to properly find each catchment's results: https://github.com/NGWPC/ngen/pull/109.

## Additions

1. Added support for concurrent `debugpy` debugger client instances (it waits for them to attach).

## Removals

None

## Changes

1. See PR for general behavior changes (each BMI processor reports global results now instead of only reporting the results of its own PET).

2. Method `update_forcing_file_output` behavior changed and renamed to `gather_global_outputs`. Previously this would always write to a NetCDF file when called. Now it will only write to NetCDF file when the configuration option dictates. This method was already making a MPI gather call to support the writing of that NetCDF file, so I leveraged that functionality mostly in-place, with minor changes.

3. Method `merge_slabs_gatherv`: added Boolean parameter `allgather` which causes it to distribute the global results among all processors, rather than only to the root processor (rank 0).

4. Standalone script `run_bmi_model.py` (does not affect ngen) was updated to reflect above changes.

## Testing

1. I watched behavior in a multiprocessing debug environment.

2. I ran a calibration realization with `mpirun -n 2` as well as without MPI. All output nexus streamflow CSV files had flow, and the two execution methods resulted in identical sets of output files. The message "Unable to find divide ID ..." did not appear in the logs.

## Screenshots

None

## Notes

None

## Todos

A potential TODO was added to `ioMod.py`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux

