### PR TITLE
Downgrade certain info log msgs to debug. Remove whitespace from end of log msg.

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/log_level_set.py
@@ -45,11 +45,18 @@ class CustomFormatter(logging.Formatter):
         return s
 
     def format(self, record):
+        # Strip trailing whitespace/newlines from the message
+        if record.msg:
+            record.msg = str(record.msg).rstrip()
+
+        # Map level names
         original_levelname = record.levelname
         record.levelname = self.LEVEL_NAME_MAP.get(record.levelno, original_levelname)
         record.levelname_padded = record.levelname.ljust(7)[:7]  # Exactly 7 chars
         formatted = super().format(record)
-        record.levelname = original_levelname  # Restore original in case it's reused
+
+        # Restore original levelname in case it's reused
+        record.levelname = original_levelname
         return formatted
      
 def create_timestamp(date_only: bool = False, iso: bool = False, append_ms: bool = False) -> str:


### PR DESCRIPTION
Every timestep was being logged in the ngen log file leading to 10's of thousands of redundant messages not providing anything useful for a regular job run. These would only necessary for debugging. Also, some log messages added a newline at the end of the message causing a blank entry in the log file. This newline was unnecessary because the Python logger automatically adds a newline at the end of each message. Updated the logger custom formatter to handle this.

## Additions

- Added code to the logger custom formatter to remove whitespace, including newlines, from the end of any log message before writing it to the log file.

## Changes

- Downgraded timestep processing log messages to the DEBUG level from INFO. 10's of thousands of these were being generated and no useful information for a regular job run.

## Testing

1. Ran several calibrations through ngenCERF and confirmed the downgraded messages were no longer generated at the INFO level and extra newlines were eliminated. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

