### PR TITLE
Klarkin aorc cache efficiency

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/models/aorc_proc.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/models/aorc_proc.py
@@ -35,25 +35,25 @@ def _get_cache_path(ConfigOptions) -> str:
     
     return cache_path
 
-def _load_from_cache(ConfigOptions, cache_path: str) -> xr.Dataset:
-    """
-    Load time-selected dataset from disk cache.
-    
-    :param ConfigOptions: Configuration with current_time
-    :param cache_path: Path to cached NetCDF file
-    :return: Time-selected Dataset if cache exists and is valid, None otherwise
-    """
-    
-    try:
-        if os.path.exists(cache_path):
-            LOG.debug(f"Loading from cache: {cache_path}\n")
-            ds = xr.open_dataset(cache_path, engine='netcdf4')
-            c_time_np = np.datetime64(ConfigOptions.current_time)
-            time_sel_ds = ds.sel(time=c_time_np)
-            return time_sel_ds
-    except Exception as e:
-        LOG.warning(f"Cache load failed: {e}\n")
-    return None
+#def _load_from_cache(ConfigOptions, cache_path: str) -> xr.Dataset:
+#    """
+#    Load time-selected dataset from disk cache.
+#    
+#    :param ConfigOptions: Configuration with current_time
+#    :param cache_path: Path to cached NetCDF file
+#    :return: Time-selected Dataset if cache exists and is valid, None otherwise
+#    """
+#    
+#    try:
+#        if os.path.exists(cache_path):
+#            LOG.debug(f"Loading from cache: {cache_path}\n")
+#            ds = xr.open_dataset(cache_path, engine='netcdf4')
+#            c_time_np = np.datetime64(ConfigOptions.current_time)
+#            time_sel_ds = ds.sel(time=c_time_np)
+#            return time_sel_ds
+#    except Exception as e:
+#        LOG.warning(f"Cache load failed: {e}\n")
+#    return None
 
 def _save_to_cache(ds: xr.Dataset, cache_path: str) -> None:
     """

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/models/aorc_proc.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/models/aorc_proc.py
@@ -211,35 +211,35 @@ def proc_aorc(ConfigOptions, MpiConfig, wrf_hydro_geo_meta):
                     c_time_np = np.datetime64(ConfigOptions.current_time)
                     check_bool = check_time(ConfigOptions)
                     
-                    xmax, xmin, ymax, ymin = get_bounds_quick(wrf_hydro_geo_meta)
-                    cache_path = _get_cache_path(ConfigOptions)
+                    if check_bool:
+                        # Year changed - need to load new dataset
+                        xmax, xmin, ymax, ymin = get_bounds_quick(wrf_hydro_geo_meta)
+                        cache_path = _get_cache_path(ConfigOptions)
+                        
+                        if os.path.exists(cache_path):
+                            # Load from disk cache (once per year)
+                            LOG.debug(f"Loading year dataset from cache: {cache_path}\n")
+                            _aorc_cache.final_ds = xr.open_dataset(cache_path, engine='netcdf4')
+                        else:
+                            # Cache miss - fetch from AWS
+                            url = set_year(ConfigOptions)
+                            ds = create_dataset(url)
+                            sliced_ds = slice_dataset(ds, xmax, xmin, ymax, ymin)
+                            time_sliced_ds = time_slice(ConfigOptions, sliced_ds)
+                            _aorc_cache.final_ds = compute_dataset(time_sliced_ds)
+                            
+                            # Save to disk cache
+                            _save_to_cache(_aorc_cache.final_ds, cache_path)
+                        
+                        LOG.debug("final_ds updated for new year\n")
                     
-                    # Try to load from disk cache first
-                    cached_result = _load_from_cache(ConfigOptions, cache_path)
-                    if cached_result is not None:
-                        _aorc_cache.time_sel_ds = cached_result
-                    elif check_bool:
-                        # Cache miss or new year - fetch from AWS
-                        url = set_year(ConfigOptions)
-                        ds = create_dataset(url)
-                        sliced_ds = slice_dataset(ds, xmax, xmin, ymax, ymin)
-                        time_sliced_ds = time_slice(ConfigOptions, sliced_ds)
-                        _aorc_cache.final_ds = compute_dataset(time_sliced_ds)
-                        
-                        # Save to disk cache
-                        _save_to_cache(_aorc_cache.final_ds, cache_path)
-                        
-                        _aorc_cache.time_sel_ds = _aorc_cache.final_ds.sel(time=c_time_np)
-                        LOG.debug("time_sel_ds updated\n")
-                    else:
-                        # Same year, use cached full dataset
-                        LOG.debug("time_sel_ds not updated\n")
-                        _aorc_cache.time_sel_ds = _aorc_cache.final_ds.sel(time=c_time_np)
+                    # Always select from in-memory/open dataset
+                    _aorc_cache.time_sel_ds = _aorc_cache.final_ds.sel(time=c_time_np)
                     
                 except Exception as e:
                     LOG.critical(f"Error with AORC processing: {e}")
-                    
+
     MpiConfig.comm.barrier()
     aorc_ds = MpiConfig.comm.bcast(_aorc_cache.time_sel_ds, root=0)
-    
+
     return aorc_ds


### PR DESCRIPTION
[Short description explaining the high-level reason for the pull request]

## Additions

-

## Removals

-

## Changes

- Altered the try block in proc_aorc() so that it doesn't open the cache file at every timestep, but rather only opens the cache file at every year. This dramatically reduces filesystem pressure, which may have been causing extremely poor performance on shared EFS. 

## Testing

1. Tested on local hardware to reveal slightly faster per-timestep performance. 
2. Tested on an AWS cloud instance (with an uncontested EFS) to reveal ~28% overall performance increase.
3. Confirmed via diagnostics that cache open() calls occur once per simulation year, per iteration.

## Screenshots


## Notes

-

## Todos

- Test on a contested EFS (ie: INT)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

