### PR TITLE
Regridding Weights: unique cache file names, refactor

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -62,13 +62,15 @@ class MpiConfig:
             self.wait_for_debugpy_client()
 
     def __broadcast_new_64bit_uid(self, config_options):
-        """Generate"""
+        """Broadcast a random uint64 then save the hash of that to self.uid64,
+        which effectively broadcasts the same unique string to all ranks."""
         if self.uid64 is not None:
             raise ValueError(f"self.uid64 already set: {repr(self.uid64)}")
         
         rand_uint64 = None
         if self.rank == 0:
-            rand_uint64 = np.random.randint(0, 2**64, dtype="uint64")
+            rng = np.random.default_rng()
+            rand_uint64 = rng.integers(0, 2**64, dtype=np.uint64)
         rand_uint64 = self.broadcast_parameter(rand_uint64, config_options, param_type=np.uint64)
 
         # Since based on 64-bit int, first 16 chars are 0, final 16 chars are random

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -1,3 +1,5 @@
+import uuid
+
 import mpi4py
 import numpy as np
 
@@ -28,6 +30,7 @@ class MpiConfig:
         self.comm = None
         self.rank = None
         self.size = None
+        self.uid64: str | None = None  # broadcasted random 16 chars based on random uint64
 
     def initialize_comm(self, config_options, comm=None):
         """
@@ -53,8 +56,25 @@ class MpiConfig:
             config_options.errMsg = "Unable to retrieve the MPI processor rank."
             raise mpi_exception
 
+        self.__broadcast_new_64bit_uid(config_options)
+
         if False:
             self.wait_for_debugpy_client()
+
+    def __broadcast_new_64bit_uid(self, config_options):
+        """Generate"""
+        if self.uid64 is not None:
+            raise ValueError(f"self.uid64 already set: {repr(self.uid64)}")
+        
+        rand_uint64 = None
+        if self.rank == 0:
+            rand_uint64 = np.random.randint(0, 2**64, dtype="uint64")
+        rand_uint64 = self.broadcast_parameter(rand_uint64, config_options, param_type=np.uint64)
+
+        # Since based on 64-bit int, first 16 chars are 0, final 16 chars are random
+        uid_64bit_hex = uuid.UUID(int=rand_uint64).hex
+        assert len(uid_64bit_hex) == 32  
+        self.uid64 = uid_64bit_hex[16:]
 
     def wait_for_debugpy_client(self):
         """This blocks until the debugpy clients have attached to cppdbg/gdb.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9155,8 +9155,8 @@ def load_weight_file(
 
     config_options.statusMsg = f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.productName} from {weight_file}"
     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-    err_handler.check_program_status(config_options, mpi_config)
 
+    err_handler.check_program_status(config_options, mpi_config)
     try:
         begin = time.monotonic()
         regrid = ESMF.RegridFromFile(field_in, field_out, weight_file)
@@ -9202,10 +9202,11 @@ def make_regrid(
     if mpi_config.rank == 0:
         config_options.statusMsg = start_msg
         err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-    err_handler.check_program_status(config_options, mpi_config)
 
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
+
+    err_handler.check_program_status(config_options, mpi_config)
     try:
         begin = time.monotonic()
         regrid = (
@@ -9256,6 +9257,7 @@ def execute_regrid(
         regrid_object = input_forcings.regridObj_elem
         target_object_attr_name = "esmf_field_out_elem"
 
+    err_handler.check_program_status(config_options, mpi_config)
     try:
         setattr(input_forcings, target_object_attr_name, regrid_object(field_in, field_out))
     except ValueError as ve:
@@ -9263,10 +9265,12 @@ def execute_regrid(
         err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
         if weight_file is not None:
-            if os.path.exists(weight_file):
-                config_options.statusMsg = f"Deleting: {weight_file}"
-                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            config_options.statusMsg = f"Deleting if exists: {weight_file}"
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            try:
                 os.remove(weight_file)
+            except FileNotFoundError:
+                pass
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9568,8 +9572,6 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     # mpi_config.comm.barrier()
 
     # ## CALCULATE WEIGHT ## #
-    # Try to find a pre-existing weight file, if available
-
     common_args = (mpi_config, config_options, input_forcings)
     weight_file, weight_file_elem = get_weight_file_names(*common_args)
 
@@ -9602,6 +9604,8 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     if config_options.grid_type == "unstructured":
         execute_regrid(*common_args, weight_file, element_mode=True)
         input_forcings.regridded_mask_elem[:] = np.round(input_forcings.esmf_field_out_elem.data[:])
+
+    err_handler.check_program_status(config_options, mpi_config)
 
 
 def calculate_supp_pcp_weights(supplemental_precip, id_tmp, tmp_file, config_options, mpi_config,

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9127,17 +9127,17 @@ def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[s
 
 
 def load_weight_file(mpi_config, config_options, input_forcings, weight_file: str, element_mode: bool) -> None:
-    """`input_forcings.regridObj` is modified in-place."""
+    """`input_forcings.regridObj` or `input_forcings.regridObj_elem` is modified in-place."""
     if not os.path.exists(weight_file):
         raise FileNotFoundError(f"MPI rank {mpi_config.rank} could not find weight file: {weight_file})")
 
     if not element_mode:
-        msg_augment = " mesh element "
+        msg_augment = " "
         field_in = input_forcings.esmf_field_in
         field_out = input_forcings.esmf_field_out
         target_object_attr_name = "regridObj"
     else:
-        msg_augment = " "
+        msg_augment = " mesh element "
         field_in = input_forcings.esmf_field_in_elem
         field_out = input_forcings.esmf_field_out_elem
         target_object_attr_name = "regridObj_elem"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9238,6 +9238,36 @@ def write_element_weight_file(mpi_config, config_options, input_forcings, weight
         traceback.print_exception(etype, value, tb)
 
 
+def execute_base_regrid(mpi_config, config_options, input_forcings, weight_file: str) -> None:
+    """`input_forcings.esmf_field_out` is modified in-place. On error, weight file is deleted from disk."""
+    try:
+        input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
+                                                                    input_forcings.esmf_field_out)
+    except ValueError as ve:
+        config_options.errMsg = "Unable to extract regridded data from ESMF regridded field: " + str(ve)
+        err_handler.log_critical(config_options, mpi_config)
+        # delete bad cached file if it exists
+        if weight_file is not None:
+            if os.path.exists(weight_file):
+                os.remove(weight_file)
+    err_handler.check_program_status(config_options, mpi_config)
+
+
+def execute_element_regrid(mpi_config, config_options, input_forcings, weight_file_elem: str) -> None:
+    """`input_forcings.esmf_field_out_elem` is modified in-place. On error, weight file is deleted from disk."""
+    try:
+        input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
+                                                                            input_forcings.esmf_field_out_elem)
+    except ValueError as ve:
+        config_options.errMsg = "Unable to extract regridded data from ESMF regridded field: " + str(ve)
+        err_handler.log_critical(config_options, mpi_config)
+        # delete bad cached file if it exists
+        if weight_file_elem is not None:
+            if os.path.exists(weight_file_elem):
+                os.remove(weight_file_elem)
+    err_handler.check_program_status(config_options, mpi_config)
+
+
 def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta,
                       lat_var="latitude", lon_var="longitude", fill=False):
     """
@@ -9549,21 +9579,9 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     if input_forcings.regridObj is None:
         write_base_weight_file(mpi_config, config_options, input_forcings, weight_file=weight_file, fill=fill)
         err_handler.check_program_status(config_options, mpi_config)
+        execute_base_regrid(mpi_config, config_options, input_forcings, weight_file=weight_file)
 
-        # Run the regridding object on this test dataset. Check the output grid for
-        # any 0 values.
-        try:
-            input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
-                                                                     input_forcings.esmf_field_out)
-        except ValueError as ve:
-            config_options.errMsg = "Unable to extract regridded data from ESMF regridded field: " + str(ve)
-            err_handler.log_critical(config_options, mpi_config)
-            # delete bad cached file if it exists
-            if weight_file is not None:
-                if os.path.exists(weight_file):
-                    os.remove(weight_file)
-        err_handler.check_program_status(config_options, mpi_config)
-
+    # Apply
     if config_options.grid_type == "gridded":
         input_forcings.regridded_mask[:, :] = np.round(input_forcings.esmf_field_out.data[:, :])
     elif config_options.grid_type != "gridded":
@@ -9572,21 +9590,8 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     if config_options.grid_type == "unstructured" and input_forcings.regridObj_elem is None:
         write_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem, fill=fill)
         err_handler.check_program_status(config_options, mpi_config)
-
-        # Run the regridding object on this test dataset. Check the output grid for
-        # any 0 values.
-        try:
-            input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
-                                                                               input_forcings.esmf_field_out_elem)
-        except ValueError as ve:
-            config_options.errMsg = "Unable to extract regridded data from ESMF regridded field: " + str(ve)
-            err_handler.log_critical(config_options, mpi_config)
-            # delete bad cached file if it exists
-            if weight_file_elem is not None:
-                if os.path.exists(weight_file_elem):
-                    os.remove(weight_file_elem)
-        err_handler.check_program_status(config_options, mpi_config)
-
+        execute_element_regrid(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem)
+        # Apply
         input_forcings.regridded_mask_elem[:] = np.round(input_forcings.esmf_field_out_elem.data[:])
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9107,6 +9107,25 @@ def check_supp_pcp_regrid_status(id_tmp, supplemental_precip, config_options, wr
     return calc_regrid_flag
 
 
+def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[str | None, str | None]:
+    if not config_options.weightsDir:
+        return None, None
+
+    grid_key = input_forcings.productName
+    file_key = f"{grid_key}_{config_options.geogrid}"
+    hash_key = hashlib.md5(file_key.encode()).hexdigest()[:8]
+    # hash_key += f"_{mpi_config.uid64}"
+
+    weight_file = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}.nc4")
+
+    if config_options.grid_type == "unstructured":
+        weight_file_elem = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}_elem.nc4")
+    else:
+        weight_file_elem = None
+
+    return weight_file, weight_file_elem
+
+
 def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta,
                       lat_var="latitude", lon_var="longitude", fill=False):
     """
@@ -9406,20 +9425,9 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     # ## CALCULATE WEIGHT ## #
     # Try to find a pre-existing weight file, if available
 
-    weight_file = None
-    weight_file_elem = None
-    if config_options.weightsDir is not None:
-        grid_key = input_forcings.productName
-        file_key = f"{grid_key}_{config_options.geogrid}"
-        hash_key = hashlib.md5(file_key.encode()).hexdigest()[:8]
-        if config_options.grid_type == "gridded":
-            weight_file = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}.nc4")
-        elif config_options.grid_type == "unstructured":
-            weight_file = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}.nc4")
-            weight_file_elem = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}_elem.nc4")
-        elif config_options.grid_type == "hydrofabric":
-            weight_file = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}.nc4")
+    weight_file, weight_file_elem = get_weight_file_names(mpi_config, input_forcings, config_options)
 
+    if config_options.weightsDir is not None:
         # check if file exists:
         if os.path.exists(weight_file):
             # read the data

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9126,6 +9126,56 @@ def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[s
     return weight_file, weight_file_elem
 
 
+def load_base_weight_file(mpi_config, config_options, input_forcings, weight_file: str) -> None:
+    """`input_forcings.regridObj` is modified in-place."""
+    try:
+        if mpi_config.rank == 0:
+            config_options.statusMsg = "Loading cached ESMF weight object for " + input_forcings.productName + \
+                                        " from " + weight_file
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.check_program_status(config_options, mpi_config)
+
+        begin = time.monotonic()
+        input_forcings.regridObj = ESMF.RegridFromFile(input_forcings.esmf_field_in,
+                                                        input_forcings.esmf_field_out,
+                                                        weight_file)
+        end = time.monotonic()
+
+        if mpi_config.rank == 0:
+            config_options.statusMsg = "Finished loading weight object with ESMF, took {} seconds".format(
+                end - begin)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+
+    except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
+        config_options.errMsg = "Unable to load cached ESMF weight file: " + str(esmf_error)
+        err_handler.log_warning(config_options, mpi_config)
+
+
+def load_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem: str) -> None:
+    """`input_forcings.regridObj_elem` is modified in-place."""
+    try:
+        if mpi_config.rank == 0:
+            config_options.statusMsg = "Loading cached ESMF mesh element weight object for " + input_forcings.productName + \
+                                        " from " + weight_file_elem
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.check_program_status(config_options, mpi_config)
+
+        begin = time.monotonic()
+        input_forcings.regridObj_elem = ESMF.RegridFromFile(input_forcings.esmf_field_in_elem,
+                                                            input_forcings.esmf_field_out_elem,
+                                                            weight_file_elem)
+        end = time.monotonic()
+
+        if mpi_config.rank == 0:
+            config_options.statusMsg = "Finished loading mesh element weight object with ESMF, took {} seconds".format(
+                end - begin)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+
+    except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
+        config_options.errMsg = "Unable to load cached ESMF mesh element weight file: " + str(esmf_error)
+        err_handler.log_warning(config_options, mpi_config)
+
+
 def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta,
                       lat_var="latitude", lon_var="longitude", fill=False):
     """
@@ -9428,55 +9478,11 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     weight_file, weight_file_elem = get_weight_file_names(mpi_config, input_forcings, config_options)
 
     if config_options.weightsDir is not None:
-        # check if file exists:
         if os.path.exists(weight_file):
-            # read the data
-            try:
-                if mpi_config.rank == 0:
-                    config_options.statusMsg = "Loading cached ESMF weight object for " + input_forcings.productName + \
-                                               " from " + weight_file
-                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-                err_handler.check_program_status(config_options, mpi_config)
+            load_base_weight_file(mpi_config, config_options, input_forcings, weight_file=weight_file)
 
-                begin = time.monotonic()
-                input_forcings.regridObj = ESMF.RegridFromFile(input_forcings.esmf_field_in,
-                                                               input_forcings.esmf_field_out,
-                                                               weight_file)
-                end = time.monotonic()
-
-                if mpi_config.rank == 0:
-                    config_options.statusMsg = "Finished loading weight object with ESMF, took {} seconds".format(
-                        end - begin)
-                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-
-            except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-                config_options.errMsg = "Unable to load cached ESMF weight file: " + str(esmf_error)
-                err_handler.log_warning(config_options, mpi_config)
-
-        # check if unstructured mesh element weight file exists:
         if config_options.grid_type == "unstructured" and os.path.exists(weight_file_elem):
-            # read the data
-            try:
-                if mpi_config.rank == 0:
-                    config_options.statusMsg = "Loading cached ESMF mesh element weight object for " + input_forcings.productName + \
-                                               " from " + weight_file
-                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-                err_handler.check_program_status(config_options, mpi_config)
-
-                begin = time.monotonic()
-                input_forcings.regridObj_elem = ESMF.RegridFromFile(input_forcings.esmf_field_in_elem,
-                                                                    input_forcings.esmf_field_out_elem,
-                                                                    weight_file_elem)
-                end = time.monotonic()
-
-                if mpi_config.rank == 0:
-                    config_options.statusMsg = "Finished loading mesh element weight object with ESMF, took {} seconds".format(
-                        end - begin)
-                    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-
-            except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-                config_options.errMsg = "Unable to load cached ESMF mesh element weight file: " + str(esmf_error)
-                err_handler.log_warning(config_options, mpi_config)
+            load_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem)
 
     if input_forcings.regridObj is None:
         if mpi_config.rank == 0:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9114,7 +9114,7 @@ def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[s
     grid_key = input_forcings.productName
     file_key = f"{grid_key}_{config_options.geogrid}"
     hash_key = hashlib.md5(file_key.encode()).hexdigest()[:8]
-    # hash_key += f"_{mpi_config.uid64}"
+    hash_key += f"_{mpi_config.uid64}"
 
     weight_file = os.path.join(config_options.weightsDir, f"ESMF_weight_{hash_key}.nc4")
 
@@ -9126,145 +9126,123 @@ def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[s
     return weight_file, weight_file_elem
 
 
-def load_base_weight_file(mpi_config, config_options, input_forcings, weight_file: str) -> None:
+def load_weight_file(mpi_config, config_options, input_forcings, weight_file: str, element_mode: bool) -> None:
     """`input_forcings.regridObj` is modified in-place."""
+    if not os.path.exists(weight_file):
+        raise FileNotFoundError(f"MPI rank {mpi_config.rank} could not find weight file: {weight_file})")
+
+    if not element_mode:
+        msg_augment = " mesh element "
+        field_in = input_forcings.esmf_field_in
+        field_out = input_forcings.esmf_field_out
+        target_object_attr_name = "regridObj"
+    else:
+        msg_augment = " "
+        field_in = input_forcings.esmf_field_in_elem
+        field_out = input_forcings.esmf_field_out_elem
+        target_object_attr_name = "regridObj_elem"
+
+    config_options.statusMsg = f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.productName} from {weight_file}"
+    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.check_program_status(config_options, mpi_config)
+
     try:
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Loading cached ESMF weight object for " + input_forcings.productName + \
-                                        " from " + weight_file
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-        err_handler.check_program_status(config_options, mpi_config)
-
         begin = time.monotonic()
-        input_forcings.regridObj = ESMF.RegridFromFile(input_forcings.esmf_field_in,
-                                                        input_forcings.esmf_field_out,
-                                                        weight_file)
+        regrid = ESMF.RegridFromFile(field_in, field_out, weight_file)
+        setattr(input_forcings, target_object_attr_name, regrid)
         end = time.monotonic()
-
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Finished loading weight object with ESMF, took {} seconds".format(
-                end - begin)
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-
     except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = "Unable to load cached ESMF weight file: " + str(esmf_error)
+        config_options.errMsg = f"Unable to load cached ESMF{msg_augment}weight file: " + str(esmf_error)
         err_handler.log_warning(config_options, mpi_config)
+    else:
+        config_options.statusMsg = (
+            f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds"
+        )
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+
+    err_handler.check_program_status(config_options, mpi_config)
 
 
-def load_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem: str) -> None:
-    """`input_forcings.regridObj_elem` is modified in-place."""
-    try:
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Loading cached ESMF mesh element weight object for " + input_forcings.productName + \
-                                        " from " + weight_file_elem
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-        err_handler.check_program_status(config_options, mpi_config)
 
-        begin = time.monotonic()
-        input_forcings.regridObj_elem = ESMF.RegridFromFile(input_forcings.esmf_field_in_elem,
-                                                            input_forcings.esmf_field_out_elem,
-                                                            weight_file_elem)
-        end = time.monotonic()
-
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Finished loading mesh element weight object with ESMF, took {} seconds".format(
-                end - begin)
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-
-    except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = "Unable to load cached ESMF mesh element weight file: " + str(esmf_error)
-        err_handler.log_warning(config_options, mpi_config)
-
-
-def write_base_weight_file(mpi_config, config_options, input_forcings, weight_file: str, fill: bool) -> None:
-    """`input_forcings.regridObj` is modified in-place."""
+def make_regrid(
+    mpi_config, config_options, input_forcings, weight_file: str | None, fill: bool, element_mode: bool
+) -> None:
+    """`input_forcings.regridObj` or `input_forcings.regridObj_elem` is modified in-place.
+    Writes weight file to disk if weight_file is not None.
+    Operates on element object if `element_mode` is True."""
     assert isinstance(fill, bool)
+
+    if not element_mode:
+        msg_augment = " "
+        field_in = input_forcings.esmf_field_in
+        field_out = input_forcings.esmf_field_out
+        target_object_attr_name = "regridObj"
+    else:
+        msg_augment = " mesh element "
+        field_in = input_forcings.esmf_field_in_elem
+        field_out = input_forcings.esmf_field_out_elem
+        target_object_attr_name = "regridObj_elem"
+
+    start_msg = f"RANK: {mpi_config.rank}: Creating{msg_augment}weight object from ESMF. weight_file={weight_file}"
     if mpi_config.rank == 0:
-        config_options.statusMsg = "Creating weight object from ESMF"
+        config_options.statusMsg = start_msg
         err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
+
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
     try:
         begin = time.monotonic()
-        input_forcings.regridObj = ESMF.Regrid(input_forcings.esmf_field_in,
-                                                input_forcings.esmf_field_out,
-                                                src_mask_values=np.array([0, config_options.globalNdv]),
-                                                regrid_method=regrid_method,
-                                                extrap_method=extrap_method,
-                                                unmapped_action=ESMF.UnmappedAction.IGNORE,
-                                                filename=weight_file)
+        regrid = ESMF.Regrid(
+                field_in,
+                field_out,
+                src_mask_values=np.array([0, config_options.globalNdv]),
+                regrid_method=regrid_method,
+                extrap_method=extrap_method,
+                unmapped_action=ESMF.UnmappedAction.IGNORE,
+                filename=weight_file,
+            ),
+        setattr(input_forcings, target_object_attr_name, regrid)
         end = time.monotonic()
-
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Finished generating weight object with ESMF, took {} seconds".format(
-                end - begin)
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = "Unable to regrid input data from ESMF: " + str(esmf_error)
+        config_options.errMsg = f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: " + str(esmf_error)
         err_handler.log_critical(config_options, mpi_config)
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
+    else:
+        if mpi_config.rank == 0:
+            config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds"
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
-
-def write_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem: str, fill: bool) -> None:
-    """`input_forcings.regridObj_elem` is modified in-place."""
-    assert isinstance(fill, bool)
-    if mpi_config.rank == 0:
-        config_options.statusMsg = "Creating ESMF mesh element weight object from ESMF"
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
     err_handler.check_program_status(config_options, mpi_config)
-    extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
-    regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
+
+
+def execute_regrid(mpi_config, config_options, input_forcings, weight_file: str, element_mode: bool) -> None:
+    """`input_forcings.esmf_field_out` or `input_forcings.esmf_field_out_elem` is modified in-place.
+    On error, weight file is deleted from disk."""
+    if not element_mode:
+        field_in = input_forcings.esmf_field_in
+        field_out = input_forcings.esmf_field_out
+        regrid_object = input_forcings.regridObj
+        target_object_attr_name = "esmf_field_out"
+    else:
+        field_in = input_forcings.esmf_field_in_elem
+        field_out = input_forcings.esmf_field_out_elem
+        regrid_object = input_forcings.regridObj_elem
+        target_object_attr_name = "esmf_field_out_elem"
+
     try:
-        begin = time.monotonic()
-        input_forcings.regridObj_elem = ESMF.Regrid(input_forcings.esmf_field_in_elem,
-                                                    input_forcings.esmf_field_out_elem,
-                                                    src_mask_values=np.array([0, config_options.globalNdv]),
-                                                    regrid_method=regrid_method,
-                                                    extrap_method=extrap_method,
-                                                    unmapped_action=ESMF.UnmappedAction.IGNORE,
-                                                    filename=weight_file_elem)
-        end = time.monotonic()
-
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Finished generating ESMF mesh element weight object with ESMF, took {} seconds".format(
-                end - begin)
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-    except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = "Unable to regrid input data into ESMF mesh element weight object from ESMF: " + str(esmf_error)
-        err_handler.log_critical(config_options, mpi_config)
-        etype, value, tb = sys.exc_info()
-        traceback.print_exception(etype, value, tb)
-
-
-def execute_base_regrid(mpi_config, config_options, input_forcings, weight_file: str) -> None:
-    """`input_forcings.esmf_field_out` is modified in-place. On error, weight file is deleted from disk."""
-    try:
-        input_forcings.esmf_field_out = input_forcings.regridObj(input_forcings.esmf_field_in,
-                                                                    input_forcings.esmf_field_out)
+        setattr(input_forcings, target_object_attr_name, regrid_object(field_in, field_out))
     except ValueError as ve:
         config_options.errMsg = "Unable to extract regridded data from ESMF regridded field: " + str(ve)
         err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
         if weight_file is not None:
             if os.path.exists(weight_file):
+                config_options.statusMsg = f"Deleting: {weight_file}"
+                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
                 os.remove(weight_file)
-    err_handler.check_program_status(config_options, mpi_config)
 
-
-def execute_element_regrid(mpi_config, config_options, input_forcings, weight_file_elem: str) -> None:
-    """`input_forcings.esmf_field_out_elem` is modified in-place. On error, weight file is deleted from disk."""
-    try:
-        input_forcings.esmf_field_out_elem = input_forcings.regridObj_elem(input_forcings.esmf_field_in_elem,
-                                                                            input_forcings.esmf_field_out_elem)
-    except ValueError as ve:
-        config_options.errMsg = "Unable to extract regridded data from ESMF regridded field: " + str(ve)
-        err_handler.log_critical(config_options, mpi_config)
-        # delete bad cached file if it exists
-        if weight_file_elem is not None:
-            if os.path.exists(weight_file_elem):
-                os.remove(weight_file_elem)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -9568,30 +9546,36 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     # Try to find a pre-existing weight file, if available
 
     weight_file, weight_file_elem = get_weight_file_names(mpi_config, input_forcings, config_options)
+    common_args = (mpi_config, config_options, input_forcings)
 
-    if config_options.weightsDir is not None:
-        if os.path.exists(weight_file):
-            load_base_weight_file(mpi_config, config_options, input_forcings, weight_file=weight_file)
-
-        if config_options.grid_type == "unstructured" and os.path.exists(weight_file_elem):
-            load_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem)
-
+    # If regrid object has not been initialized yet, initialize it.
     if input_forcings.regridObj is None:
-        write_base_weight_file(mpi_config, config_options, input_forcings, weight_file=weight_file, fill=fill)
-        err_handler.check_program_status(config_options, mpi_config)
-        execute_base_regrid(mpi_config, config_options, input_forcings, weight_file=weight_file)
 
-    # Apply
+        # make_regrid's call to Regrid() is an implicit MPI barrier, all ranks must call it.
+        if config_options.weightsDir is not None:
+            if (not os.path.exists(weight_file)):
+                make_regrid(*common_args, weight_file=weight_file, fill=fill, element_mode=False)
+
+            if config_options.grid_type == "unstructured" and (not os.path.exists(weight_file_elem)):
+                make_regrid(*common_args, weight_file=weight_file_elem, fill=fill, element_mode=True)
+
+            load_weight_file(*common_args, weight_file, element_mode=False)
+            if config_options.grid_type == "unstructured":
+                load_weight_file(*common_args, weight_file, element_mode=True)
+        else:
+            # Make regrid object in memory without writing files
+            make_regrid(*common_args, weight_file=None, fill=fill, element_mode=False)
+            if config_options.grid_type == "unstructured":
+                make_regrid(*common_args, weight_file=None, fill=fill, element_mode=True)
+
+    execute_regrid(*common_args, weight_file, element_mode=False)
     if config_options.grid_type == "gridded":
         input_forcings.regridded_mask[:, :] = np.round(input_forcings.esmf_field_out.data[:, :])
     elif config_options.grid_type != "gridded":
         input_forcings.regridded_mask[:] = np.round(input_forcings.esmf_field_out.data[:])
 
-    if config_options.grid_type == "unstructured" and input_forcings.regridObj_elem is None:
-        write_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem, fill=fill)
-        err_handler.check_program_status(config_options, mpi_config)
-        execute_element_regrid(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem)
-        # Apply
+    if config_options.grid_type == "unstructured":
+        execute_regrid(*common_args, weight_file, element_mode=True)
         input_forcings.regridded_mask_elem[:] = np.round(input_forcings.esmf_field_out_elem.data[:])
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -29,6 +29,9 @@ import pandas as pd
 from . import err_handler
 from . import ioMod
 from . import timeInterpMod
+from .parallel import MpiConfig
+from .config import ConfigOptions
+from .geoMod import GeoMetaWrfHydro
 
 import dask
 import dask.delayed
@@ -9107,7 +9110,9 @@ def check_supp_pcp_regrid_status(id_tmp, supplemental_precip, config_options, wr
     return calc_regrid_flag
 
 
-def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[str | None, str | None]:
+def get_weight_file_names(
+    mpi_config: MpiConfig, config_options: ConfigOptions, input_forcings: GeoMetaWrfHydro
+) -> tuple[str | None, str | None]:
     if not config_options.weightsDir:
         return None, None
 
@@ -9126,7 +9131,13 @@ def get_weight_file_names(mpi_config, input_forcings, config_options) -> tuple[s
     return weight_file, weight_file_elem
 
 
-def load_weight_file(mpi_config, config_options, input_forcings, weight_file: str, element_mode: bool) -> None:
+def load_weight_file(
+    mpi_config: MpiConfig,
+    config_options: ConfigOptions,
+    input_forcings: GeoMetaWrfHydro,
+    weight_file: str,
+    element_mode: bool,
+) -> None:
     """`input_forcings.regridObj` or `input_forcings.regridObj_elem` is modified in-place."""
     if not os.path.exists(weight_file):
         raise FileNotFoundError(f"MPI rank {mpi_config.rank} could not find weight file: {weight_file})")
@@ -9163,9 +9174,13 @@ def load_weight_file(mpi_config, config_options, input_forcings, weight_file: st
     err_handler.check_program_status(config_options, mpi_config)
 
 
-
 def make_regrid(
-    mpi_config, config_options, input_forcings, weight_file: str | None, fill: bool, element_mode: bool
+    mpi_config: MpiConfig,
+    config_options: ConfigOptions,
+    input_forcings: GeoMetaWrfHydro,
+    weight_file: str | None,
+    fill: bool,
+    element_mode: bool,
 ) -> None:
     """`input_forcings.regridObj` or `input_forcings.regridObj_elem` is modified in-place.
     Writes weight file to disk if weight_file is not None.
@@ -9193,7 +9208,8 @@ def make_regrid(
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
     try:
         begin = time.monotonic()
-        regrid = ESMF.Regrid(
+        regrid = (
+            ESMF.Regrid(
                 field_in,
                 field_out,
                 src_mask_values=np.array([0, config_options.globalNdv]),
@@ -9202,10 +9218,13 @@ def make_regrid(
                 unmapped_action=ESMF.UnmappedAction.IGNORE,
                 filename=weight_file,
             ),
+        )
         setattr(input_forcings, target_object_attr_name, regrid)
         end = time.monotonic()
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: " + str(esmf_error)
+        config_options.errMsg = (
+            f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: " + str(esmf_error)
+        )
         err_handler.log_critical(config_options, mpi_config)
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
@@ -9217,7 +9236,13 @@ def make_regrid(
     err_handler.check_program_status(config_options, mpi_config)
 
 
-def execute_regrid(mpi_config, config_options, input_forcings, weight_file: str, element_mode: bool) -> None:
+def execute_regrid(
+    mpi_config: MpiConfig,
+    config_options: ConfigOptions,
+    input_forcings: GeoMetaWrfHydro,
+    weight_file: str,
+    element_mode: bool,
+) -> None:
     """`input_forcings.esmf_field_out` or `input_forcings.esmf_field_out_elem` is modified in-place.
     On error, weight file is deleted from disk."""
     if not element_mode:
@@ -9545,8 +9570,8 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
     # ## CALCULATE WEIGHT ## #
     # Try to find a pre-existing weight file, if available
 
-    weight_file, weight_file_elem = get_weight_file_names(mpi_config, input_forcings, config_options)
     common_args = (mpi_config, config_options, input_forcings)
+    weight_file, weight_file_elem = get_weight_file_names(*common_args)
 
     # If regrid object has not been initialized yet, initialize it.
     if input_forcings.regridObj is None:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9176,6 +9176,68 @@ def load_element_weight_file(mpi_config, config_options, input_forcings, weight_
         err_handler.log_warning(config_options, mpi_config)
 
 
+def write_base_weight_file(mpi_config, config_options, input_forcings, weight_file: str, fill: bool) -> None:
+    """`input_forcings.regridObj` is modified in-place."""
+    assert isinstance(fill, bool)
+    if mpi_config.rank == 0:
+        config_options.statusMsg = "Creating weight object from ESMF"
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.check_program_status(config_options, mpi_config)
+    extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
+    regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
+    try:
+        begin = time.monotonic()
+        input_forcings.regridObj = ESMF.Regrid(input_forcings.esmf_field_in,
+                                                input_forcings.esmf_field_out,
+                                                src_mask_values=np.array([0, config_options.globalNdv]),
+                                                regrid_method=regrid_method,
+                                                extrap_method=extrap_method,
+                                                unmapped_action=ESMF.UnmappedAction.IGNORE,
+                                                filename=weight_file)
+        end = time.monotonic()
+
+        if mpi_config.rank == 0:
+            config_options.statusMsg = "Finished generating weight object with ESMF, took {} seconds".format(
+                end - begin)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
+        config_options.errMsg = "Unable to regrid input data from ESMF: " + str(esmf_error)
+        err_handler.log_critical(config_options, mpi_config)
+        etype, value, tb = sys.exc_info()
+        traceback.print_exception(etype, value, tb)
+
+
+def write_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem: str, fill: bool) -> None:
+    """`input_forcings.regridObj_elem` is modified in-place."""
+    assert isinstance(fill, bool)
+    if mpi_config.rank == 0:
+        config_options.statusMsg = "Creating ESMF mesh element weight object from ESMF"
+        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.check_program_status(config_options, mpi_config)
+    extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
+    regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
+    try:
+        begin = time.monotonic()
+        input_forcings.regridObj_elem = ESMF.Regrid(input_forcings.esmf_field_in_elem,
+                                                    input_forcings.esmf_field_out_elem,
+                                                    src_mask_values=np.array([0, config_options.globalNdv]),
+                                                    regrid_method=regrid_method,
+                                                    extrap_method=extrap_method,
+                                                    unmapped_action=ESMF.UnmappedAction.IGNORE,
+                                                    filename=weight_file_elem)
+        end = time.monotonic()
+
+        if mpi_config.rank == 0:
+            config_options.statusMsg = "Finished generating ESMF mesh element weight object with ESMF, took {} seconds".format(
+                end - begin)
+            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
+        config_options.errMsg = "Unable to regrid input data into ESMF mesh element weight object from ESMF: " + str(esmf_error)
+        err_handler.log_critical(config_options, mpi_config)
+        etype, value, tb = sys.exc_info()
+        traceback.print_exception(etype, value, tb)
+
+
 def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_config, wrf_hydro_geo_meta,
                       lat_var="latitude", lon_var="longitude", fill=False):
     """
@@ -9485,33 +9547,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
             load_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem)
 
     if input_forcings.regridObj is None:
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Creating weight object from ESMF"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-        err_handler.check_program_status(config_options, mpi_config)
-        extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
-        regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
-        try:
-            begin = time.monotonic()
-            input_forcings.regridObj = ESMF.Regrid(input_forcings.esmf_field_in,
-                                                   input_forcings.esmf_field_out,
-                                                   src_mask_values=np.array([0, config_options.globalNdv]),
-                                                   regrid_method=regrid_method,
-                                                   extrap_method=extrap_method,
-                                                   unmapped_action=ESMF.UnmappedAction.IGNORE,
-                                                   filename=weight_file)
-            end = time.monotonic()
-
-            if mpi_config.rank == 0:
-                config_options.statusMsg = "Finished generating weight object with ESMF, took {} seconds".format(
-                    end - begin)
-                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-        except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-            config_options.errMsg = "Unable to regrid input data from ESMF: " + str(esmf_error)
-            err_handler.log_critical(config_options, mpi_config)
-            etype, value, tb = sys.exc_info()
-            traceback.print_exception(etype, value, tb)
-
+        write_base_weight_file(mpi_config, config_options, input_forcings, weight_file=weight_file, fill=fill)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Run the regridding object on this test dataset. Check the output grid for
@@ -9534,33 +9570,7 @@ def calculate_weights(id_tmp, force_count, input_forcings, config_options, mpi_c
         input_forcings.regridded_mask[:] = np.round(input_forcings.esmf_field_out.data[:])
 
     if config_options.grid_type == "unstructured" and input_forcings.regridObj_elem is None:
-        if mpi_config.rank == 0:
-            config_options.statusMsg = "Creating ESMF mesh element weight object from ESMF"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-        err_handler.check_program_status(config_options, mpi_config)
-        extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
-        regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[input_forcings.regridOpt - 1]
-        try:
-            begin = time.monotonic()
-            input_forcings.regridObj_elem = ESMF.Regrid(input_forcings.esmf_field_in_elem,
-                                                        input_forcings.esmf_field_out_elem,
-                                                        src_mask_values=np.array([0, config_options.globalNdv]),
-                                                        regrid_method=regrid_method,
-                                                        extrap_method=extrap_method,
-                                                        unmapped_action=ESMF.UnmappedAction.IGNORE,
-                                                        filename=weight_file_elem)
-            end = time.monotonic()
-
-            if mpi_config.rank == 0:
-                config_options.statusMsg = "Finished generating ESMF mesh element weight object with ESMF, took {} seconds".format(
-                    end - begin)
-                err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
-        except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-            config_options.errMsg = "Unable to regrid input data into ESMF mesh element weight object from ESMF: " + str(esmf_error)
-            err_handler.log_critical(config_options, mpi_config)
-            etype, value, tb = sys.exc_info()
-            traceback.print_exception(etype, value, tb)
-
+        write_element_weight_file(mpi_config, config_options, input_forcings, weight_file_elem=weight_file_elem, fill=fill)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Run the regridding object on this test dataset. Check the output grid for


### PR DESCRIPTION
A random string as added to the name of the ESMF regridding weights cache file that is created at the beginning of the realization.  This string is created by rank 0 during MPI initialization and is available to all ranks.

The regridding steps at the bottom of `calculate_weights` was refactored into smaller functions and common logic among branching flow paths were consolidated.

## Additions

- Random string MpiConfig.uid64 shared among all ranks

## Removals

-

## Changes

- Refactored the regridding steps at the bottom of `calculate_weights` to improve readability and make future changes easier.

## Testing

1. I ran a AORC calibration before and after these changes and observed identical nexus outflows.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

