### PR TITLE
Include ewts package in base ngen-forcing installation

### DIFF
--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -153,7 +153,7 @@ COPY . /ngen-app/ngen-forcing/
 WORKDIR /ngen-app/ngen-forcing
 RUN set -eux; \
     pip install --upgrade pip setuptools wheel; \
-    pip install --no-cache-dir mpi4py . ./nextgen_forcings_ewts
+    pip install --no-cache-dir mpi4py .
 
 ARG CI_COMMIT_REF_NAME
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-where = ["NextGen_Forcings_Engine_BMI", "."]
+where = ["NextGen_Forcings_Engine_BMI", "nextgen_forcings_ewts/src", "."]
 include = ["NextGen_Forcings_Engine*", 
     "Forcing_Extraction_Scripts*", 
     "ESMF_Mesh_Domain_Configuration_Production*",


### PR DESCRIPTION
This alters the top-level pyproject.toml such that the recent `nextgen_forcings_ewts` package is included when installing the top-level ngen-forcing package, removing the need for a separate pip install directive for the `nextgen_forcings_ewts` package.

## Additions

Adds discovery of `nextgen_forcings_ewts/src/nextgen_forcings_ewts` in the base `pyproject.toml`.

## Removals

None

## Changes

`Dockerfile.bmi-forcings` no longer has separate pip install directive for package `nextgen_forcings_ewts`.

## Testing

I have confirmed that with this change, the ngen-forcing Docker image python environment is able to complete this import: `from nextgen_forcings_ewts import configure_logging`. I have also built the downstream `ngen` image and `ngen-rte` image and confirmed that log messages appear to be functioning as normal when running realizations.

Also for active development, I confirmed that when the overall `ngen-forcing` package is intentionally reinstalled from local code after the base image has been built, those local code changes affect the behavior as intended.

## Screenshots

None

## Notes

None

## Todos

None

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux

