### PR TITLE
Have rank 0 use the reduced any_error value

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -79,7 +79,7 @@ def check_program_status(ConfigOptions, MpiConfig):
     # Reduce version:
     any_error = MpiConfig.comm.reduce(ConfigOptions.errFlag)
     if MpiConfig.rank == 0:
-        if ConfigOptions.errFlag:
+        if ConfigOptions.errFlag or any_error:
             # print("any_error: ", any_error, type(any_error), flush=True)
             stack = traceback.format_stack()[:-1]
             for frame in stack:


### PR DESCRIPTION
When `reduce()` is called, the value sent from the other ranks is returned to rank 0 (in this case, returned as `any_error`). But the send buffer object (in this case, `ConfigOptions.errFlag`) is not modified in-place.

This PR changes rank 0 behavior s.t. it aborts `if ConfigOptions.errFlag or any_error:` (if any rank sends an error flag), rather than `if ConfigOptions.errFlag:` (if current rank has an error flag).

Thanks @idtodd for raising this.