### PR TITLE
Enable using split schism domains

### DIFF
--- a/coastal/SFINCS/coastalforcing/download_data/data_downloader.py
+++ b/coastal/SFINCS/coastalforcing/download_data/data_downloader.py
@@ -132,24 +132,11 @@ class DataDownloader:
         base = "https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com"
         outdir = self._ensure_dir("streamflow", "nwm_retro")
 
-        if self.coastal_model == "sfincs" : 
-          for dt in self._iter_hours():
-            year = dt.strftime("%Y")
-            stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # always minute 00
-            url = f"{base}/CONUS/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
-
-            date_str = dt.strftime("%Y%m%d")
-            hour_str = f"{dt.hour:02d}"
-            dest = os.path.join(outdir, f"{stamp_ymdhm}.CHRTOUT_DOMAIN1.nc")
-
-            self._safe_download(url, dest)
-
-        else:
-          domain_str= 'CONUS' if self.domain == 'conus' \
+        domain_str= 'CONUS' if self.domain == 'conus' \
                     else 'Hawaii' if self.domain == 'hawaii' else 'PR'    \
                     if self.domain == "prvi"  else 'UNKNOWN'
 
-          for dt in self._iter_hours():
+        for dt in self._iter_hours():
             year = dt.strftime("%Y")
             stamp_ymdhm = dt.strftime("%Y%m%d%H") + "00"  # always minute 00
             url = f"{base}/{domain_str}/netcdf/CHRTOUT/{year}/{stamp_ymdhm}.CHRTOUT_DOMAIN1"
@@ -324,10 +311,10 @@ class DataDownloader:
 
     def _download_hydro(self):
         if self.hydro == "nwm" and self.meteo == "nwm_ana":
-            print("\ndownload_nwm_channel_rt_ana:")
+            print("\ndownload_nwm_channel_rt_ana: nwm_ana")
             self._download_nwm_channel_rt_ana()
         elif self.hydro == "nwm" and self.meteo == "nwm_retro":
-            print("\ndownload_nwm_channel_rt_ana:")
+            print("\ndownload_nwm_channel_rt_ana: retrospective")
             self._download_nwm_channel_rt_retrospective()
         elif self.hydro == "ngen":
             print(f"[hydro:ngen] not available yet")
@@ -360,17 +347,7 @@ class DataDownloader:
         base = "https://storage.googleapis.com/national-water-model"
         outdir = self._ensure_dir("meteo", "nwm_ana")
 
-        if self.coastal_model == "sfincs" : 
-          for dt in self._iter_hours():
-            date_str = dt.strftime("%Y%m%d")
-            hour_str = f"{dt.hour:02d}"
-            url = f"{base}/nwm.{date_str}/forcing_analysis_assim/nwm.t{hour_str}z.analysis_assim.forcing.tm00.conus.nc"
-            filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
-            dest = os.path.join(outdir, filename)
-            self._safe_download(url, dest)
-
-        else:
-          for dt in self._iter_hours():
+        for dt in self._iter_hours():
             temp_dt = dt + timedelta(hours = 2)
             date_str = temp_dt.strftime("%Y%m%d")
             hour_str = f"{temp_dt.hour:02d}"
@@ -380,8 +357,11 @@ class DataDownloader:
                     else "puertorico" if self.domain == 'prvi' else f"{self.domain}"
 
             url = f"{base}/nwm.{date_str}/forcing_analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.forcing.tm02.{domain_str2}.nc"
-            #filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
-            filename = f"{date_str}{dt.hour:02d}.LDASIN_DOMAIN1"
+            date_str = dt.strftime("%Y%m%d")
+            if self.coastal_model == "sfincs" : 
+              filename = f"nwm_forcing_{date_str}_{dt.hour:02d}.nc"
+            else:
+              filename = f"{date_str}{dt.hour:02d}.LDASIN_DOMAIN1"
             dest = os.path.join(outdir, filename)
             self._safe_download(url, dest)
 
@@ -393,17 +373,7 @@ class DataDownloader:
         base = "https://storage.googleapis.com/national-water-model"
         outdir = self._ensure_dir("hydro", "nwm")
 
-        if self.coastal_model == "sfincs" : 
-          for dt in self._iter_hours():
-            date_str = dt.strftime("%Y%m%d")
-            hour_str = f"{dt.hour:02d}"
-            url = f"{base}/nwm.{date_str}/analysis_assim/nwm.t{hour_str}z.analysis_assim.channel_rt.tm00.conus.nc"
-            filename = f"nwm_channel_rt_{date_str}_{hour_str}.nc"
-            dest = os.path.join(outdir, filename)
-            self._safe_download(url, dest)
-
-        else:
-          for dt in self._iter_hours():
+        for dt in self._iter_hours():
             temp_dt = dt + timedelta(hours = 2)
             date_str = temp_dt.strftime("%Y%m%d")
             hour_str = f"{temp_dt.hour:02d}"
@@ -545,6 +515,8 @@ class DataDownloader:
             # Only try valid STOFS cycles
             if dt.hour not in (0, 6, 12, 18):
                 continue
+
+            region = 'hawaii.cwl' if self.domain == 'hawaii' else 'conus.east.cwl' 
 
             date_str = dt.strftime("%Y%m%d")
             hour = f"{dt.hour:02d}"
@@ -691,42 +663,6 @@ class DataDownloader:
         else:
             print(f"[hydro] Unhandled hydro source '{self.hydro}'")
 
-    # ---------- Concrete downloaders ----------
-    def _download_nwm_meteo_ana(self):
-        """
-        Example URL pattern (provided):
-        https://storage.googleapis.com/national-water-model/nwm.{date}/forcing_analysis_assim/nwm.t{hour:02d}z.analysis_assim.forcing.tm00.conus.nc
-        - date as YYYYMMDD
-        - hour as 00..23
-        """
-        base = "https://storage.googleapis.com/national-water-model"
-        outdir = self._ensure_dir("meteo", "nwm_ana")
-
-        if self.coastal_model == "sfincs" : 
-          for dt in self._iter_hours():
-            date_str = dt.strftime("%Y%m%d")
-            hour_str = f"{dt.hour:02d}"
-            url = f"{base}/nwm.{date_str}/forcing_analysis_assim/nwm.t{hour_str}z.analysis_assim.forcing.tm00.conus.nc"
-            filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
-            dest = os.path.join(outdir, filename)
-            self._safe_download(url, dest)
-
-        else:
-          for dt in self._iter_hours():
-            temp_dt = dt + timedelta(hours = 2)
-            date_str = temp_dt.strftime("%Y%m%d")
-            hour_str = f"{temp_dt.hour:02d}"
-            domain_str= '' if self.domain == 'conus' \
-                    else "_puertorico" if self.domain == 'prvi' else f"_{self.domain}"
-            domain_str2= 'conus' if self.domain == 'conus' \
-                    else "puertorico" if self.domain == 'prvi' else f"{self.domain}"
-
-            url = f"{base}/nwm.{date_str}/forcing_analysis_assim{domain_str}/nwm.t{hour_str}z.analysis_assim.forcing.tm02.{domain_str2}.nc"
-            #filename = f"nwm_forcing_{date_str}_{hour_str}.nc"
-            filename = f"{date_str}{dt.hour:02d}.LDASIN_DOMAIN1"
-            dest = os.path.join(outdir, filename)
-            self._safe_download(url, dest)
-
     def _download_nwm_channel_rt_ana(self):
         """
         Example URL pattern (provided):
@@ -735,17 +671,7 @@ class DataDownloader:
         base = "https://storage.googleapis.com/national-water-model"
         outdir = self._ensure_dir("hydro", "nwm")
 
-        if self.coastal_model == "sfincs" : 
-          for dt in self._iter_hours():
-            date_str = dt.strftime("%Y%m%d")
-            hour_str = f"{dt.hour:02d}"
-            url = f"{base}/nwm.{date_str}/analysis_assim/nwm.t{hour_str}z.analysis_assim.channel_rt.tm00.conus.nc"
-            filename = f"nwm_channel_rt_{date_str}_{hour_str}.nc"
-            dest = os.path.join(outdir, filename)
-            self._safe_download(url, dest)
-
-        else:
-          for dt in self._iter_hours():
+        for dt in self._iter_hours():
             temp_dt = dt + timedelta(hours = 2)
             date_str = temp_dt.strftime("%Y%m%d")
             hour_str = f"{temp_dt.hour:02d}"

--- a/coastal/SFINCS/coastalforcing/main.py
+++ b/coastal/SFINCS/coastalforcing/main.py
@@ -195,7 +195,11 @@ def prepare_schism_base_simulation_folder(cfg, domain_info):
     start_iso = _parse_utc(cfg['start_time'])
     run_folder_name = f"{cfg['coastal_model']}_{start_iso}"
     sim_dir = _normpath(sim_root, run_folder_name)
+    region = domain_info['domain'][0]['region']
+    nwm_domain = region if region == 'hawaii' or region == 'prvi' else 'conus' 
     Path(sim_dir).mkdir(parents=True, exist_ok=True)
+
+    domain_path = domain_info['domain'][0]['path']
 
     dts = datetime.strptime(_parse_utc(cfg['start_time']), "%Y-%m-%dT%H-%M-%SZ")
     dte = datetime.strptime(_parse_utc(cfg['end_time']), "%Y-%m-%dT%H-%M-%SZ")
@@ -221,6 +225,8 @@ def prepare_schism_base_simulation_folder(cfg, domain_info):
       schcfg.write(f"export METEO_SOURCE={cfg['meteo_source'].upper()}\n")
       schcfg.write(f"export COASTAL_WORK_DIR={sim_dir}\n")
       schcfg.write(f"export RAW_DOWNLOAD_DIR={raw_download_dir}\n")
+      schcfg.write(f"export NWM_DOMAIN={nwm_domain}\n")
+      schcfg.write(f"export DOMAIN_PATH={domain_path}\n")
 
 
 # ---- Main ----
@@ -245,9 +251,6 @@ def main():
 
     validate_config(cfg)
 
-    nwm_domain = cfg['domain_file'] if cfg['domain_file'] == 'hawaii' or cfg['domain_file'] == 'prvi' else \
-                 'conus' 
-
     # Load domain info and normalize base path relative to the domain YAML
     domain_file = f"domain_lists/{cfg['coastal_model']}/{cfg['domain_file']}.yaml"
     with open(domain_file) as f:
@@ -256,6 +259,8 @@ def main():
     # Resolve the domain path relative to the YAML’s folder
     domain_yaml_dir = os.path.dirname(os.path.abspath(domain_file))
     raw_domain_path = domain_info['domain'][0]['path']
+    region = domain_info['domain'][0]['region']
+    nwm_domain = region if region == 'hawaii' or region == 'prvi' else 'conus' 
 
     # 🔧 Sanitize Windows-style separators for POSIX
     raw_domain_path_sanitized = raw_domain_path.replace('\\', '/')

--- a/coastal/SFINCS/coastalforcing/process_data/data_processor.py
+++ b/coastal/SFINCS/coastalforcing/process_data/data_processor.py
@@ -1,7 +1,9 @@
 import os
+import re
 import traceback
 from datetime import datetime, timedelta
 from typing import Iterable, Optional
+from pathlib import Path
 import numpy as np
 import xarray as xr
 import pyproj
@@ -66,6 +68,7 @@ class DataProcessor:
         self.domain_path = self.domain_info["domain"][0]["path"]
         self.ngen_dis_netcdf = ngen_dis_netcdf
         self.tpxo_env = tpxo_env
+        self.inp_dict = self._get_inp_dict( self.sim_dir) if self.model == 'sfincs' else None
 
         '''
         # Coastal products (optional)
@@ -177,6 +180,7 @@ class DataProcessor:
             end_date=self.end_dt,
             mode="ana",
             domain_nc_path=os.path.join(self.domain_path, "sfincs.nc"),   # <- make this a full path in your environment
+            inp_dict=self.inp_dict,
             out_dir=self.sim_dir,                               # where to write sfincs.amu/.amv/.ampr/.amp
             raw_root=self.raw_root,                           # root containing the daily NWM folders
             target_epsg=self.target_epsg,
@@ -241,9 +245,12 @@ class DataProcessor:
         rows = []
         ref_time = self.start_dt.replace(tzinfo=None)  # seconds since start_time
 
-        for dt in self._iter_hours():
-            date_str = dt.strftime("%Y%m%d"); hour_str = f"{dt.hour:02d}"
-            path = os.path.join(self.raw_root, "hydro", "nwm", f"nwm_channel_rt_{date_str}_{hour_str}.nc")
+        #for dt in self._iter_hours():
+        for dt in self._iter_hydro():
+            date_str = dt.strftime("%Y%m%d"); 
+            hour_str = dt.strftime("%H%M");
+            #path = os.path.join(self.raw_root, "hydro", "nwm", f"nwm_channel_rt_{date_str}_{hour_str}.nc")
+            path = os.path.join(self.raw_root, "hydro", "nwm", f"{date_str}{hour_str}.CHRTOUT_DOMAIN1")
             if not os.path.exists(path):
                 # skip silently; downloader may have partial hours
                 continue
@@ -587,6 +594,13 @@ class DataProcessor:
             yield current
             current += timedelta(hours=1)
 
+    def _iter_hydro(self) -> Iterable[datetime]:
+        current = self.start_dt
+        while current < self.end_dt:
+            yield current
+            current += timedelta(hours=1) if self.domain_info['domain'][0]['name'] != 'hawaii' \
+                    else timedelta(minutes=15)
+
     @staticmethod
     def _parse_time(s: str) -> datetime:
         fmts = ["%Y-%m-%dT%H-%M-%SZ", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d %H:%M:%S"]
@@ -596,6 +610,26 @@ class DataProcessor:
             except ValueError:
                 pass
         return datetime.fromisoformat(s.replace("Z", "+00:00")).replace(tzinfo=None)
+
+    @staticmethod
+    def _normpath(*parts) -> str:
+       return str(Path(*parts).resolve())
+
+    @staticmethod
+    def _get_inp_dict(sim_dir: str) -> datetime:
+       inp_path = Path(DataProcessor._normpath(sim_dir, "sfincs.inp"))
+       if Path(inp_path).exists():
+          with open(inp_path, "r") as f:
+            lines = f.readlines()
+
+       out = {}
+       pat = re.compile(rf'^\s*([^\n\t\r= ]+)\s*=\s*(.*?)(\s*(#.*)?)$', re.IGNORECASE)
+       for ln in lines:
+         m = pat.match(ln)
+         if m:
+            out[ m.group(1) ] = m.group(2)
+       return out
+
 
 
     import pandas as pd
@@ -628,7 +662,7 @@ class DataProcessor:
             import numpy as np
             import pandas as pd
             import pyproj
-            from scipy.interpolate import RegularGridInterpolator, interp1d
+            from scipy.interpolate import RegularGridInterpolator, NearestNDInterpolator, interp1d, LinearNDInterpolator
         except Exception as e:
             print(f"[process][coastal:stofs] missing dep: {e}")
             return
@@ -657,6 +691,7 @@ class DataProcessor:
             print(f"[process][coastal:stofs] empty boundary file: {bnd_file}")
             return
 
+        domain = self.domain_info['domain'][0]['name']
         # ---------- discover STOFS files from window ----------
         outdir = os.path.join(self.raw_root, "coastal", "stofs")
         wanted = []
@@ -664,7 +699,8 @@ class DataProcessor:
         for dt in self._iter_hours():
             if dt.hour not in (0, 6, 12, 18):
                 continue
-            fname = f"stofs_2d_glo.t{dt.hour:02d}z.conus.east.cwl.grib2"
+            fname = f"stofs_2d_glo.t{dt.hour:02d}z.conus.east.cwl.grib2" if self.domain_info['domain'][0]['name'] != 'hawaii' \
+                    else f"stofs_2d_glo.t{dt.hour:02d}z.hawaii.cwl.grib2" 
             fpath = os.path.join(outdir, fname)
             if os.path.exists(fpath) and fpath not in seen:
                 wanted.append(fpath)
@@ -681,24 +717,27 @@ class DataProcessor:
         # ---------- define CRS and grid geometry ----------
         # SFINCS boundary CRS (UTM) and STOFS Lambert Conformal CRS
         utm = pyproj.CRS(f"EPSG:{self.target_epsg}")
-        lcc = pyproj.CRS.from_proj4(
+        if domain != 'hawaii':
+           lcc = pyproj.CRS.from_proj4(
             "+proj=lcc +lat_1=25 +lat_2=25 +lat_0=25 +lon_0=265 +x_0=0 +y_0=0 +R=6371200 +units=m +no_defs"
-        )
-        to_lcc = pyproj.Transformer.from_crs(utm, lcc, always_xy=True)
+           )
+           to_lcc = pyproj.Transformer.from_crs(utm, lcc, always_xy=True)
 
-        # STOFS grid spacing and a consistent Lambert origin used to reconstruct X/Y axes
-        dx = 2539.703
-        dy = 2539.703
-        # Origin reference given in (lon0, lat0) – we only need its *Lambert* coordinates
-        # so compute once via WGS84→LCC.
-        wgs84 = pyproj.CRS("EPSG:4326")
-        wgs_to_lcc = pyproj.Transformer.from_crs(wgs84, lcc, always_xy=True)
-        lon0, lat0 = 238.445999, 20.191999
-        x0, y0 = wgs_to_lcc.transform(lon0, lat0)
+           # STOFS grid spacing and a consistent Lambert origin used to reconstruct X/Y axes
+           dx = 2539.703
+           dy = 2539.703
+           # Origin reference given in (lon0, lat0) – we only need its *Lambert* coordinates
+           # so compute once via WGS84→LCC.
+           wgs84 = pyproj.CRS("EPSG:4326")
+           wgs_to_lcc = pyproj.Transformer.from_crs(wgs84, lcc, always_xy=True)
+           lon0, lat0 = 238.445999, 20.191999
+           x0, y0 = wgs_to_lcc.transform(lon0, lat0)
 
-        # Convert boundary points to Lambert coordinates
-        xb, yb = to_lcc.transform(bnd_df["x"].values, bnd_df["y"].values)
-        sample_pts = np.column_stack([yb, xb])  # (y, x) order for RegularGridInterpolator
+           # Convert boundary points to Lambert coordinates
+           xb, yb = to_lcc.transform(bnd_df["x"].values, bnd_df["y"].values)
+           sample_pts = np.column_stack([yb, xb])  # (y, x) order for RegularGridInterpolator
+        else:
+           sample_pts = np.column_stack([bnd_df['y'].values, bnd_df['x'].values])  
 
         # Containers for raw samples and matching seconds since start
         all_rows = []
@@ -717,7 +756,7 @@ class DataProcessor:
                     backend_kwargs={"indexpath": "", "filter_by_keys": {"typeOfLevel": "surface"}},
                 )
             except Exception as e:
-                print(f"[process][coastal:stofs] failed to open default: {e}")
+                print(f"[process][coastal:stofs] {path} failed to open default: {e}")
                 continue
 
             # pick variable name
@@ -736,15 +775,23 @@ class DataProcessor:
             print(f"[process][coastal:stofs] {fname}: var='{varname}', dims={dims}, shape={shape}")
 
             # Expect (step, y, x)
-            if len(shape) != 3 or dims[1] != "y" or dims[2] != "x":
+            if ( len(shape) != 3 or dims[1] != "y" or dims[2] != "x" ) and  \
+               ( len(shape) != 2 or dims[1] != "values" ) :
                 print(f"[process][coastal:stofs] {fname}: unexpected dims {dims}; skipping")
                 continue
 
-            nframes, ny, nx = shape
+            if domain == 'hawaii':
+              nframes, n = shape 
 
-            # Build LCC grid axes (meters) so we can use RegularGridInterpolator
-            x_axis = x0 + np.arange(nx) * dx
-            y_axis = y0 + np.arange(ny) * dy
+              to_utm = pyproj.Transformer.from_crs("EPSG:4326", utm, always_xy=True)
+              x_axis, y_axis = to_utm.transform(ds["longitude"].values, ds["latitude"].values)
+
+            else:
+              nframes, ny, nx = shape
+
+              # Build LCC grid axes (meters) so we can use RegularGridInterpolator
+              x_axis = x0 + np.arange(nx) * dx
+              y_axis = y0 + np.arange(ny) * dy
 
             # ---- robust time handling (handles scalar 'time', 1-D 'valid_time', and 'step') ----
             try:
@@ -801,14 +848,21 @@ class DataProcessor:
             try:
                 for k in range(nframes):
                     frame = np.asarray(data.isel(step=k).values)
-                    # Build interpolator over (y, x)
-                    rgi = RegularGridInterpolator(
+                    if domain == 'hawaii':
+                      # Build interpolator over (y, x)
+                      nni = NearestNDInterpolator(list( zip(y_axis, x_axis) ), frame)
+                      #lni = LinearNDInterpolator(list( zip(y_axis, x_axis) ), frame)
+                      vals = nni(sample_pts)  # shape: (n_points,)
+                    else:
+                      # Build interpolator over (y, x)
+                      rgi = RegularGridInterpolator(
                         (y_axis, x_axis),
                         frame,
                         bounds_error=False,
                         fill_value=np.nan,
-                    )
-                    vals = rgi(sample_pts)  # shape: (n_points,)
+                      )
+                      vals = rgi(sample_pts)  # shape: (n_points,)
+
                     all_rows.append(vals.astype(float))
                 all_times.extend(sec_since_start.tolist())
                 print(f"[process][coastal:stofs] {fname}: sampled {nframes} frames at {sample_pts.shape[0]} points")
@@ -843,7 +897,7 @@ class DataProcessor:
                 # add +0.25 to all values
                 temp=row
                 # row = row + 1.0
-                print(f"{temp} : {row}")
+                #print(f"{temp} : {row}")
                 line = f"{int(t)} " + " ".join(f"{v:.4f}" if np.isfinite(v) else "0.0000" for v in row)
                 f.write(line + "\n")
         print(f"[process][coastal:stofs] wrote {raw_path} ({values.shape[0]} rows, {values.shape[1]} points)")
@@ -878,7 +932,7 @@ class DataProcessor:
                 # add +0.25 to all values
                 temp=row
                 # row = row + 1.0
-                print(f"{temp} : {row}")
+                #print(f"{temp} : {row}")
                 line = f"{int(t)} " + " ".join(f"{v:.4f}" if np.isfinite(v) else "0.0000" for v in row)
                 f.write(line + "\n")
         print(f"[process][coastal:stofs] wrote {final_path} ({interp_mat.shape[0]} rows @10-min)")

--- a/coastal/SFINCS/coastalforcing/process_data/data_processor.py
+++ b/coastal/SFINCS/coastalforcing/process_data/data_processor.py
@@ -1204,7 +1204,7 @@ class DataProcessor:
             print(f"[process] Model '{self.model}' not implemented yet.")
             return
         else:
-            if self.domain_info['domain'][0]['name'] == 'prvi' and self.meteo == "nwm_retro":
+            if self.domain_info['domain'][0]['region'] == 'prvi' and self.meteo == "nwm_retro":
               path = os.path.join(self.raw_root, "meteo", "nwm_retro")
               retro_files = os.listdir(path)
               for f in retro_files:

--- a/coastal/SFINCS/coastalforcing/process_data/mateo_sfincs.py
+++ b/coastal/SFINCS/coastalforcing/process_data/mateo_sfincs.py
@@ -95,6 +95,7 @@ def write_sfincs_meteo_from_nwm(
     *,
     mode: str,                # "ana" or "retro"
     domain_nc_path: str,      # path to sfincs.nc
+    inp_dict: dict,           # sfincs.inp dict
     raw_root: str,            # root containing meteo/{nwm_ana|nwm_retro}
     out_dir: str,             # where sfincs.amu/.amv/.ampr/.amp go
     target_epsg: str = "32614",
@@ -118,14 +119,25 @@ def write_sfincs_meteo_from_nwm(
     os.makedirs(out_dir, exist_ok=True)
 
     # --- SFINCS domain + buffered, rotated bbox ---
-    sfgrid = xr.open_dataset(domain_nc_path)
-    x0 = float(sfgrid.attrs["x0"])
-    y0 = float(sfgrid.attrs["y0"])
-    nmax = int(sfgrid.attrs["nmax"])
-    mmax = int(sfgrid.attrs["mmax"])
-    dx_sf = float(sfgrid.attrs["dx"])
-    dy_sf = float(sfgrid.attrs["dy"])
-    rotation = float(sfgrid.attrs.get("rotation", 0.0))
+    if "qtrfile" in inp_dict: 
+      sfgrid = xr.open_dataset(domain_nc_path)
+      x0 = float(sfgrid.attrs["x0"])
+      y0 = float(sfgrid.attrs["y0"])
+      nmax = int(sfgrid.attrs["nmax"])
+      mmax = int(sfgrid.attrs["mmax"])
+      dx_sf = float(sfgrid.attrs["dx"])
+      dy_sf = float(sfgrid.attrs["dy"])
+      rotation = float(sfgrid.attrs.get("rotation", 0.0))
+      sfgrid.close()
+    else:
+      x0 = float(inp_dict["x0"])
+      y0 = float(inp_dict["y0"])
+      nmax = int(inp_dict["nmax"])
+      mmax = int(inp_dict["mmax"])
+      dx_sf = float(inp_dict["dx"])
+      dy_sf = float(inp_dict["dy"])
+      rotation = float(inp_dict.get("rotation", 0.0))
+
     width = mmax * dx_sf
     height = nmax * dy_sf
     domain_box = box(x0, y0, x0 + width, y0 + height)
@@ -133,7 +145,6 @@ def write_sfincs_meteo_from_nwm(
     xsf, ysf = rotated_domain.exterior.xy
     xmin, xmax = np.min(xsf) - buffer_m, np.max(xsf) + buffer_m
     ymin, ymax = np.min(ysf) - buffer_m, np.max(ysf) + buffer_m
-    sfgrid.close()
 
     # Writers (lazy)
     u_writer = v_writer = rr_writer = p_writer = None

--- a/coastal/calib/initial_discharge.bash
+++ b/coastal/calib/initial_discharge.bash
@@ -80,7 +80,7 @@ nwm_coastal_initial_discharge() {
    fi
 
   export NWM_ANA_DIR=${nwm_ana_dir}
-  cp ${PARMnwm}/coastal/$COASTAL_DOMAIN/nwmReaches.csv $DATAexec
+#  cp ${PARMnwm}/coastal/$COASTAL_DOMAIN/nwmReaches.csv $DATAexec
 
   python -u $USHnwm/wrf_hydro_workflow_dev/coastal/makeDischarge.py >> $DATAlogs/${nwm_cycle}.${PDY}${cyc}.log 2>&1
 

--- a/coastal/calib/make_tpxo_ocean.bash
+++ b/coastal/calib/make_tpxo_ocean.bash
@@ -15,15 +15,14 @@ make_tpxo_ocean() {
    export LENGTH_HRS=$2
    export OTPSnc_DIR=$3
    export NGEN_FORCING_DIR=$4
-   export SCHISM_PARM_DIR=$5
-   export COASTAL_DOMAIN=$6
-   export TIME_STEP_IN_SECS=$7
+   export SCHISM_BOUNDARY_FILE=$5
+   export TIME_STEP_IN_SECS=$6
 
 #   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/contrib/software/gcc/8.5.0/lib64:/contrib/software/netcdf/4.7.4/lib
 
    export END_DATETIME=$(${USHnwm}/utils/advance_time.sh $PDY$cyc $LENGTH_HRS)
    python $NGEN_FORCING_DIR/coastal/tidal/tpxo_to_open_bnds_hgrid/make_otps_input.py \
-	  $SCHISM_PARM_DIR/prvi/open_bnds_hgrid.nc \
+	  $SCHISM_BOUNDARY_FILE \
 	  $PDY$cyc $END_DATETIME $TIME_STEP_IN_SECS  \
 	  $DATAexec/otps_lat_lon_time.txt
 
@@ -39,7 +38,7 @@ make_tpxo_ocean() {
 
    python $NGEN_FORCING_DIR/coastal/tidal/tpxo_to_open_bnds_hgrid/otps_to_open_bnds_hgrid.py  \
 	  ./otps_out.txt                                                               \
-          $SCHISM_PARM_DIR/$COASTAL_DOMAIN/open_bnds_hgrid.nc                          \
+	  $SCHISM_BOUNDARY_FILE                          \
 	  ./elev2D.th.nc
 
    local _correction_file=$DATAexec/elevation_correction.csv

--- a/coastal/calib/post_regrid_stofs.bash
+++ b/coastal/calib/post_regrid_stofs.bash
@@ -32,7 +32,6 @@ post_nwm_coastal_regrid_estofs() {
 
    start_date=${PDY}
    start_hour=${cyc}
-   #estofs_data=$DATAexec/estofs.t${start_hour}z.fields.cwl.nc
    estofs_data=$DATAexec/stofs_2d_glo.t${start_hour}z.fields.cwl.nc
    output_file=$DATAexec/elev2D.th.nc
 
@@ -43,7 +42,7 @@ post_nwm_coastal_regrid_estofs() {
            old_length_hrs=$LENGTH_HRS
            export LENGTH_HRS=$(($LENGTH_HRS+$diffhrs))
            export TIDAL_CONSTANTS_DIR=$COASTAL_ROOT_DIR/Tides/TidalConst
-           export COASTAL_DOMAIN_GR3=$PARMnwm/coastal/$COASTAL_DOMAIN/hgrid.gr3
+           export COASTAL_DOMAIN_GR3=$DATAexec/hgrid.gr3
 
            python $USHnwm/wrf_hydro_workflow_dev/coastal/Tides/makeOceanTide.py >> $DATAlogs/regrid_stofs.{PDY}${cyc}.log 2>&1
            export LENGTH_HRS=${old_length_hrs}

--- a/coastal/calib/pre_regrid_stofs.bash
+++ b/coastal/calib/pre_regrid_stofs.bash
@@ -32,7 +32,6 @@ pre_nwm_coastal_regrid_estofs() {
 
    start_date=${PDY}
    start_hour=${cyc}
-   #estofs_data=$DATAexec/estofs.t${start_hour}z.fields.cwl.nc
    estofs_data=$DATAexec/stofs_2d_glo.t${start_hour}z.fields.cwl.nc
    output_file=$DATAexec/elev2D.th.nc
 
@@ -89,8 +88,6 @@ pre_nwm_coastal_regrid_estofs() {
        #cpfs $estofs_file $estofs_data
 
        hgrid_file=$DATAexec/open_bnds_hgrid.nc
-       ln -sf ${PARMnwm}/coastal/$COASTAL_DOMAIN/open_bnds_hgrid.nc $hgrid_file
-       #cpfs ${PARMnwm}/coastal/$COASTAL_DOMAIN/open_bnds_hgrid.nc $hgrid_file
 
        export ESTOFS_INPUT_FILE=$estofs_data
        export OPEN_BNDS_HGRID_FILE=$hgrid_file

--- a/coastal/calib/pre_schism.bash
+++ b/coastal/calib/pre_schism.bash
@@ -22,7 +22,7 @@ pre_nwm_coastal() {
    export NWM_CYCLE=forecast
    export WRF_HYDRO_ROOT=$DATAexec/nwm_output
 
-   nwm_coastal_initial_discharge ${STARTPDY}${STARTCYC} $FCST_LENGTH_HRS $COASTAL_DOMAIN $NWM_CHROUT_DIR
+   nwm_coastal_initial_discharge ${STARTPDY}${STARTCYC} $FCST_LENGTH_HRS $NWM_DOMAIN $NWM_CHROUT_DIR
 
    nwm_coastal_combine_sink_source
 
@@ -30,12 +30,15 @@ pre_nwm_coastal() {
 
    nwm_coastal_merge_source_sink "" "forecast" "forecast"
 
-   export NSCRIBES=2
+   #export NSCRIBES=2
 
    #create offline partition
-   create_offline_partition $NPROCS "${NSCRIBES}"
+   #create_offline_partition $NPROCS "${NSCRIBES}"
    #cpfs ${EXECnwm}/pschism_wcoss2_NO_PARMETIS_TVD-VL .
    #cpfs ${EXECnwm}/pschism_mistral_NOPM_VL .
+   cp ${EXECnwm}/metis_prep ./
+   cp ${EXECnwm}/gpmetis ./
+  ./metis_prep ./hgrid.gr3 ./vgrid.in
    cp ${EXECnwm}/pschism_wcoss2_NO_PARMETIS_TVD-VL.openmpi .
 
 }

--- a/coastal/calib/run_sing_coastal_workflow_make_tpxo_ocean.bash
+++ b/coastal/calib/run_sing_coastal_workflow_make_tpxo_ocean.bash
@@ -27,9 +27,5 @@ ngen_forcing_dir=$(pwd)/../../
 make_tpxo_ocean ${STARTPDY}${STARTCYC} $FCST_LENGTH_HRS \
 	$OTPSDIR \
 	$ngen_forcing_dir\
-	$PARMnwm/coastal \
-	$COASTAL_DOMAIN  \
+	${OPEN_BNDS_HGRID_FILE} \
 	$FCST_TIMESTEP_LENGTH_SECS
-
-
-

--- a/coastal/calib/run_sing_coastal_workflow_post_schism.bash
+++ b/coastal/calib/run_sing_coastal_workflow_post_schism.bash
@@ -4,6 +4,4 @@
 
 source ./post_schism.bash
 
-export NSCRIBES=2
-
 post_nwm_coastal

--- a/coastal/calib/run_sing_coastal_workflow_pre_schism2.bash
+++ b/coastal/calib/run_sing_coastal_workflow_pre_schism2.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+
+ cd $DATAexec
+./gpmetis ./graphinfo $((${NPROCS} - ${NSCRIBES})) -ufactor=1.01 -seed=15
+awk '{print NR,$0}' graphinfo.part.$((${NPROCS} - ${NSCRIBES})) > partition.prop

--- a/coastal/calib/run_sing_coastal_workflow_update_params.bash
+++ b/coastal/calib/run_sing_coastal_workflow_update_params.bash
@@ -25,7 +25,5 @@ source ./update_param.bash
 
 export RESTART_WRITE_HR=2
 
-nwm_coastal_update_params ${STARTPDY}${STARTCYC} $COASTAL_DOMAIN $FCST_LENGTH_HRS $HOT_START_FILE 
-
-
-
+nwm_coastal_update_params ${STARTPDY}${STARTCYC} $COASTAL_DOMAIN $NWM_DOMAIN \
+	$FCST_LENGTH_HRS "$HOT_START_FILE" $DOMAIN_PATH

--- a/coastal/calib/sing_run.bash
+++ b/coastal/calib/sing_run.bash
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-##SBATCH --job-name=sing_schism  #job name
-##SBATCH -N 1                     #number of nodes to use
-##SBATCH --partition=compute      #the patition
-##SBATCH --ntasks-per-node=18     #numebr of cores per node
-##SBATCH --exclusive
+#SBATCH --job-name=sing_schism  #job name
+#SBATCH -N 1                     #number of nodes to use
+#SBATCH --partition=compute      #the patition
+#SBATCH --ntasks-per-node=18     #numebr of cores per node
+#SBATCH --exclusive
 
 export NODES=1          #this must match the number of nodes defined above by slurm
-export NCORES=4
+export NCORES=18
 export NPROCS=$((NODES*NCORES))
 
 set -x

--- a/coastal/calib/sing_run.bash
+++ b/coastal/calib/sing_run.bash
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-#SBATCH --job-name=sing_mpi  #job name
-#SBATCH -N 2                     #number of nodes to use
-#SBATCH --partition=compute      #the patition
-#SBATCH --ntasks-per-node=18     #numebr of cores per node
-#SBATCH --exclusive
+##SBATCH --job-name=sing_schism  #job name
+##SBATCH -N 1                     #number of nodes to use
+##SBATCH --partition=compute      #the patition
+##SBATCH --ntasks-per-node=18     #numebr of cores per node
+##SBATCH --exclusive
 
-export NODES=2          #this must match the number of nodes defined above by slurm
-export NCORES=18        #this must match the number of cores per node defined above by slurm
+export NODES=1          #this must match the number of nodes defined above by slurm
+export NCORES=4
 export NPROCS=$((NODES*NCORES))
 
 set -x
@@ -14,20 +14,8 @@ set -x
 #load the configuration file
 . ./schism_calib.cfg
 
-export NGWPC_COASTAL_PARM_DIR=/ngen-test/coastal/ngwpc-coastal
-
 export NGEN_APP_DIR=/ngen-app
 #
-# define the model time step in seconds
-export FCST_TIMESTEP_LENGTH_SECS=3600
-#
-# location of the OTPSnc program and TPXO10_atlas model data
-# the OTPSnc program can be downloaded from https://www.tpxo.net/otps
-# the TPXO10_atlas data is available on the AWS s3 bucket
-# s3://ngwpc-data/Coastal_and_atmospheric_forcing_for_calibration/TPXO_atlas/TPXO10_atlas_v2_nc.zip
-# The zip file must be unpacked and extracted folders are put inside the OTPSnc directory
-export OTPSDIR=$NGEN_APP_DIR/OTPSnc
-
 export USHnwm=$NGEN_APP_DIR/nwm.v3.0.6/ush
 export PARMnwm=$NGWPC_COASTAL_PARM_DIR/parm
 export EXECnwm=$NGEN_APP_DIR/nwm.v3.0.6/exec
@@ -50,192 +38,23 @@ export FI_OFI_RXM_SAR_LIMIT=3145728
 export FI_MR_CACHE_MAX_COUNT=0
 export FI_EFA_RECVWIN_SIZE=65536
 
-# User specific aliases and functions
-# >>> conda initialize >>>
-# !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/opt/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then
-        . "/opt/conda/etc/profile.d/conda.sh"
-    else
-        export PATH="/opt/conda/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-# <<< conda initialize <<<
-#
-
 export NFS_MOUNT=/efs
-export PATH=/opt/conda/bin:${PATH}
-export CONDA_ENVS_PATH=$NFS_MOUNT/ngen-app/conda/envs
-export CONDA_ENV_NAME=ngen_forcing_coastal
-export PATH=${CONDA_ENVS_PATH}/${CONDA_ENV_NAME}/bin:${PATH}
 
-SIF_PATH=/ngencerf-app/singularity/ngen-coastal.sif
-
-conda activate ${CONDA_ENVS_PATH}/$CONDA_ENV_NAME
-
-export LD_LIBRARY_PATH=/opt/conda/lib:${CONDA_ENVS_PATH}/lib:$LD_LIBRARY_PATH
-
-#
-# location of the NWM retrospective or archieved forcing files
-# note that the time span of the files must cover the whole simulation period
-#export NWM_FORCING_DIR=/efs/schism_use_case/hi_nwm_ana_forcing_20240913/
-export NWM_FORCING_DIR=$RAW_DOWNLOAD_DIR/meteo/${METEO_SOURCE,,} #to lower case
-#
-# location of the NWM retrospective or archieved streamflow files
-# note that the time span of the files must cover the whole simulation period
-if [[ ${METEO_SOURCE} == "NWM_RETRO" ]]; then
-   export NWM_CHROUT_DIR=$RAW_DOWNLOAD_DIR/streamflow/nwm_retro
-elif [[ ${METEO_SOURCE} == "NWM_ANA" ]]; then
-   export NWM_CHROUT_DIR=$RAW_DOWNLOAD_DIR/hydro/nwm
-else
-   echo "Unknown METEO_SOURCE type: $METEO_SOURCE!"
-   exit 1
-fi
+#SIF_PATH=/ngencerf-app/singularity/ngen-coastal.sif
+SIF_PATH=/contrib/Zhengtao.Cui/home/ngwpc/singularity/ngen_coastal_sing.sif
 
 export MPICOMMAND2="mpiexec -n ${NPROCS} "
-export MPICOMMAND3="mpiexec -n 4 "
-
-declare -A coastal_domain_to_inland_domain=( \
-	   [prvi]="domain_puertorico" \
-	   [hawaii]="domain_hawaii" \
-	   [atlgulf]="domain" \
-	   [pacific]="domain" )
-
-declare -A coastal_domain_to_nwm_domain=( \
-	   [prvi]="prvi" \
-	   [hawaii]="hawaii" \
-	   [atlgulf]="conus" \
-	   [pacific]="conus" )
-
-declare -A coastal_domain_to_geo_grid=( \
-	   [prvi]="geo_em_PRVI.nc" \
-	   [hawaii]="geo_em_HI.nc" \
-	   [atlgulf]="geo_em_CONUS.nc" \
-	   [pacific]="geo_em_CONUS.nc" )
-
-export SCHISM_ESMFMESH=${PARMnwm}/coastal/${COASTAL_DOMAIN}/hgrid.nc
-export GEOGRID_FILE=${PARMnwm}/${coastal_domain_to_inland_domain[$COASTAL_DOMAIN]}/${coastal_domain_to_geo_grid[$COASTAL_DOMAIN]}
-
-export DATAlogs=$DATAexec
-
-if [[ ! -d $DATAexec ]]; then
-   mkdir -p $DATAexec
-fi
 
 export NSCRIBES=2
 
-export BINDINGS="$NFS_MOUNT,$CONDA_ENVS_PATH,$NGWPC_COASTAL_PARM_DIR,/usr/bin/bc,/usr/bin/srun,/usr/lib64/libpmi2.so,/usr/lib64/libefa.so,/usr/lib64/libibmad.so,/usr/lib64/libibnetdisc.so,/usr/lib64/libibumad.so,/usr/lib64/libibverbs.so,/usr/lib64/libmana.so,/usr/lib64/libmlx4.so,/usr/lib64/libmlx5.so,/usr/lib64/librdmacm.so"
+export BINDINGS="$NFS_MOUNT,$DOMAIN_PATH,/usr/bin/bc,/usr/bin/srun,/usr/lib64/libpmi2.so,/usr/lib64/libefa.so,/usr/lib64/libibmad.so,/usr/lib64/libibnetdisc.so,/usr/lib64/libibumad.so,/usr/lib64/libibverbs.so,/usr/lib64/libmana.so,/usr/lib64/libmlx4.so,/usr/lib64/libmlx5.so,/usr/lib64/librdmacm.so"
 
 work_dir=${NGEN_APP_DIR}/ngen-forcing/coastal/calib
 
-start_itime=$(date -u -d "${STARTPDY} ${STARTCYC}" +"%s")
-end_itime=$(( $start_itime + $FCST_LENGTH_HRS * 3600 + 3600 ))
-export start_dt=$(date -u -d "@${start_itime}" +"%Y-%m-%dT%H-%M-%SZ")
-export end_dt=$(date -u -d "@${end_itime}" +"%Y-%m-%dT%H-%M-%SZ")
-
-export COASTAL_SOURCE='stofs'
-if [[ $USE_TPXO == "YES" ]]; then
-    export COASTAL_SOURCE=''
-fi
-
-#singularity exec -B $BINDINGS --pwd ${work_dir} $SIF_PATH \
-#	/bin/bash -c \
-# 	 '__conda_setup="$('/opt/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"; \
-#         if [ $? -eq 0 ]; then \
-#                eval "$__conda_setup"; \
-#         else \
-#                if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then \
-#                     . "/opt/conda/etc/profile.d/conda.sh" ; \
-#                else \
-#                      export PATH="/opt/conda/bin:$PATH" ;\
-#                fi;                                              \
-#          fi;                                               \
-#         conda run -n $CONDA_ENV_NAME python \
-#	../forcing_downloader/main.py \
-#	"$COASTAL_WORK_DIR" \
-#	"${coastal_domain_to_nwm_domain[$COASTAL_DOMAIN]}"
-#	"$start_dt" \
-#	"$end_dt" \
-#	"$METEO_SOURCE" "nwm" "$COASTAL_SOURCE"'
-
-#
-# location of the archived STOFS file if STOFS data is
-# going to be used for the boundary nodes
-export STOFS_FILE=''
-if [[ $USE_TPXO == "NO" ]]; then
-  export STOFS_FILE=$(ls -1 $RAW_DOWNLOAD_DIR/coastal/stofs/* | head -n 1)
-fi
-
-singularity exec -B $BINDINGS --pwd ${work_dir} $SIF_PATH \
-	 ./run_sing_coastal_workflow_pre_forcing_coastal.bash
-
-export LENGTH_HRS=$FCST_LENGTH_HRS
-export FORCING_BEGIN_DATE=${STARTPDY}${STARTCYC}00
-
-start_timestamp=$(date -u -d "${STARTPDY} ${STARTCYC}" +"%s")
-itime=$(( 10#${LENGTH_HRS} * 3600 + $start_timestamp ))
-export FORCING_END_DATE=$(date -u -d "@${itime}" +"%Y%m%d%H00")
-
-export NWM_FORCING_OUTPUT_DIR=$DATAexec/forcing_input
-export COASTAL_FORCING_OUTPUT_DIR=$DATAexec/coastal_forcing_output
-
-export FECPP_JOB_INDEX=0
-export FECPP_JOB_COUNT=1
-
-${MPICOMMAND3} singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 $CONDA_ENVS_PATH/$CONDA_ENV_NAME/bin/python \
-         $USHnwm/wrf_hydro_workflow_dev/forcings/WrfHydroFECPP/workflow_driver.py
-
 singularity exec -B $BINDINGS \
 	  --pwd ${work_dir} \
          $SIF_PATH \
-	 ./run_sing_coastal_workflow_post_forcing_coastal.bash
-
-singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 ./run_sing_coastal_workflow_update_params.bash
-
-if [[ $USE_TPXO == "YES" ]]; then
-   singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 ./run_sing_coastal_workflow_make_tpxo_ocean.bash
-else
-   export CYCLE_DATE=$STARTPDY
-   export CYCLE_TIME=${STARTCYC}00
-   export LENGTH_HRS=$(singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 ./run_sing_coastal_workflow_pre_make_stofs_ocean.bash)
-
-   export ESTOFS_INPUT_FILE=$STOFS_FILE
-   export SCHISM_OUTPUT_FILE=$DATAexec/elev2D.th.nc
-   export OPEN_BNDS_HGRID_FILE=$DATAexec/open_bnds_hgrid.nc
-
-   ${MPICOMMAND3} singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 $CONDA_ENVS_PATH/$CONDA_ENV_NAME/bin/python \
-         $USHnwm/wrf_hydro_workflow_dev/coastal/regrid_estofs.py $ESTOFS_INPUT_FILE $OPEN_BNDS_HGRID_FILE $SCHISM_OUTPUT_FILE
-
-   singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 ./run_sing_coastal_workflow_post_make_stofs_ocean.bash
-
-fi
-
-singularity exec -B $BINDINGS \
-	  --pwd ${work_dir} \
-         $SIF_PATH \
-	 ./run_sing_coastal_workflow_pre_schism.bash
+	 ./run_sing_coastal_workflow_pre_schism2.bash
 
 
 export PATH=/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin
@@ -243,6 +62,8 @@ export PATH=/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/local/bin:/usr/bin:
 export LD_LIBRARY_PATH=/opt/amazon/openmpi/lib:/opt/amazon/openmpi/lib64
 export OMPI_ALLOW_RUN_AS_ROOT=1
 export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+
+date
 
 ${MPICOMMAND2} singularity exec -B $BINDINGS --pwd $COASTAL_WORK_DIR \
          $SIF_PATH \
@@ -253,5 +74,5 @@ singularity exec -B $BINDINGS \
 	  --pwd ${work_dir} \
          $SIF_PATH \
 	 ./run_sing_coastal_workflow_post_schism.bash
-
+date
 

--- a/coastal/calib/sing_schism_forcing.bash
+++ b/coastal/calib/sing_schism_forcing.bash
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=sing_mpi  #job name
+#SBATCH -N 1                     #number of nodes to use
+#SBATCH --partition=compute      #the patition
+#SBATCH --ntasks-per-node=18     #numebr of cores per node
+#SBATCH --exclusive
+
+export NODES=1          #this must match the number of nodes defined above by slurm
+export NCORES=18        #this must match the number of cores per node defined above by slurm
+export NPROCS=$((NODES*NCORES))
+
+set -x
+
+#load the configuration file
+. ./schism_calib.cfg
+
+#export NGWPC_COASTAL_PARM_DIR=/ngen-test/coastal/ngwpc-coastal
+export NGWPC_COASTAL_PARM_DIR=/efs/ngwpc-coastal
+
+export NGEN_APP_DIR=/ngen-app
+#
+# define the model time step in seconds
+export FCST_TIMESTEP_LENGTH_SECS=3600
+#
+# location of the OTPSnc program and TPXO10_atlas model data
+# the OTPSnc program can be downloaded from https://www.tpxo.net/otps
+# the TPXO10_atlas data is available on the AWS s3 bucket
+# s3://ngwpc-data/Coastal_and_atmospheric_forcing_for_calibration/TPXO_atlas/TPXO10_atlas_v2_nc.zip
+# The zip file must be unpacked and extracted folders are put inside the OTPSnc directory
+export OTPSDIR=$NGEN_APP_DIR/OTPSnc
+
+export USHnwm=$NGEN_APP_DIR/nwm.v3.0.6/ush
+export PARMnwm=$NGWPC_COASTAL_PARM_DIR/parm
+export EXECnwm=$NGEN_APP_DIR/nwm.v3.0.6/exec
+export DATAexec=$COASTAL_WORK_DIR
+
+export SAVE_ALL_TASKS=yes
+export OMP_NUM_THREADS=2
+export IOBUF_PARAMS='*.LAKEOUT_DOMAIN1:size=64M:count=2:prefetch=1,*:size=32M:count=4:vbuffer_count=4096:prefetch=1'
+#export IOBUF_PARAMS='*:verbose'
+export OMP_PLACES=cores
+# ----------------: added (WCOSS2/Pete)
+# set up MPI connections and buffers at start of run - helps efficiency of MPI later in run
+export MPICH_OFI_STARTUP_CONNECT=1
+# pace MPI_Bcast messaging when reading and distributing initial conditions - prevents the Bcast hangs
+export MPICH_COLL_SYNC=MPI_Bcast
+# turn off MPI_Reduce on node optimization - prevent MPI_Reduce hangs during time stepping
+export MPICH_REDUCE_NO_SMP=1
+
+export FI_OFI_RXM_SAR_LIMIT=3145728
+export FI_MR_CACHE_MAX_COUNT=0
+export FI_EFA_RECVWIN_SIZE=65536
+
+# User specific aliases and functions
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$('/opt/conda/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "/opt/conda/etc/profile.d/conda.sh" ]; then
+        . "/opt/conda/etc/profile.d/conda.sh"
+    else
+        export PATH="/opt/conda/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+#
+
+export NFS_MOUNT=/efs
+export PATH=/opt/conda/bin:${PATH}
+export CONDA_ENVS_PATH=$NFS_MOUNT/ngen-app/conda/envs
+export CONDA_ENV_NAME=ngen_forcing_coastal
+export PATH=${CONDA_ENVS_PATH}/${CONDA_ENV_NAME}/bin:${PATH}
+
+#SIF_PATH=/ngencerf-app/singularity/ngen-coastal.sif
+SIF_PATH=/contrib/Zhengtao.Cui/home/ngwpc/singularity/ngen_coastal_sing.sif
+
+conda activate ${CONDA_ENVS_PATH}/$CONDA_ENV_NAME
+
+export LD_LIBRARY_PATH=/opt/conda/lib:${CONDA_ENVS_PATH}/lib:$LD_LIBRARY_PATH
+
+#
+# location of the NWM retrospective or archieved forcing files
+# note that the time span of the files must cover the whole simulation period
+#export NWM_FORCING_DIR=/efs/schism_use_case/hi_nwm_ana_forcing_20240913/
+export NWM_FORCING_DIR=$RAW_DOWNLOAD_DIR/meteo/${METEO_SOURCE,,} #to lower case
+#
+# location of the NWM retrospective or archieved streamflow files
+# note that the time span of the files must cover the whole simulation period
+if [[ ${METEO_SOURCE} == "NWM_RETRO" ]]; then
+   export NWM_CHROUT_DIR=$RAW_DOWNLOAD_DIR/streamflow/nwm_retro
+elif [[ ${METEO_SOURCE} == "NWM_ANA" ]]; then
+   export NWM_CHROUT_DIR=$RAW_DOWNLOAD_DIR/hydro/nwm
+else
+   echo "Unknown METEO_SOURCE type: $METEO_SOURCE!"
+   exit 1
+fi
+
+export MPICOMMAND2="mpiexec -n ${NPROCS} "
+export MPICOMMAND3="mpiexec -n ${NPROCS} "
+
+declare -A coastal_domain_to_inland_domain=( \
+	   [prvi]="domain_puertorico" \
+	   [hawaii]="domain_hawaii" \
+	   [atlgulf]="domain" \
+	   [pacific]="domain" )
+
+declare -A coastal_domain_to_nwm_domain=( \
+	   [prvi]="prvi" \
+	   [hawaii]="hawaii" \
+	   [atlgulf]="conus" \
+	   [pacific]="conus" )
+
+declare -A coastal_domain_to_geo_grid=( \
+	   [prvi]="geo_em_PRVI.nc" \
+	   [hawaii]="geo_em_HI.nc" \
+	   [atlgulf]="geo_em_CONUS.nc" \
+	   [pacific]="geo_em_CONUS.nc" )
+
+export SCHISM_ESMFMESH=${DOMAIN_PATH}/hgrid.nc
+export GEOGRID_FILE=${PARMnwm}/${coastal_domain_to_inland_domain[$NWM_DOMAIN]}/${coastal_domain_to_geo_grid[$NWM_DOMAIN]}
+
+export DATAlogs=$DATAexec
+
+if [[ ! -d $DATAexec ]]; then
+   mkdir -p $DATAexec
+fi
+
+export BINDINGS="$NFS_MOUNT,$CONDA_ENVS_PATH,$NGWPC_COASTAL_PARM_DIR,$DOMAIN_PATH,/usr/bin/bc,/usr/bin/srun,/usr/lib64/libpmi2.so,/usr/lib64/libefa.so,/usr/lib64/libibmad.so,/usr/lib64/libibnetdisc.so,/usr/lib64/libibumad.so,/usr/lib64/libibverbs.so,/usr/lib64/libmana.so,/usr/lib64/libmlx4.so,/usr/lib64/libmlx5.so,/usr/lib64/librdmacm.so"
+
+work_dir=${NGEN_APP_DIR}/ngen-forcing/coastal/calib
+
+start_itime=$(date -u -d "${STARTPDY} ${STARTCYC}" +"%s")
+end_itime=$(( $start_itime + $FCST_LENGTH_HRS * 3600 + 3600 ))
+export start_dt=$(date -u -d "@${start_itime}" +"%Y-%m-%dT%H-%M-%SZ")
+export end_dt=$(date -u -d "@${end_itime}" +"%Y-%m-%dT%H-%M-%SZ")
+
+export COASTAL_SOURCE='stofs'
+if [[ $USE_TPXO == "YES" ]]; then
+    export COASTAL_SOURCE=''
+fi
+
+#
+# location of the archived STOFS file if STOFS data is
+# going to be used for the boundary nodes
+export STOFS_FILE=''
+if [[ $USE_TPXO == "NO" ]]; then
+  export STOFS_FILE=$(ls -1 $RAW_DOWNLOAD_DIR/coastal/stofs/* | head -n 1)
+fi
+
+singularity exec -B $BINDINGS --pwd ${work_dir} $SIF_PATH \
+	 ./run_sing_coastal_workflow_pre_forcing_coastal.bash
+
+export LENGTH_HRS=$FCST_LENGTH_HRS
+export FORCING_BEGIN_DATE=${STARTPDY}${STARTCYC}00
+
+start_timestamp=$(date -u -d "${STARTPDY} ${STARTCYC}" +"%s")
+itime=$(( 10#${LENGTH_HRS} * 3600 + $start_timestamp ))
+export FORCING_END_DATE=$(date -u -d "@${itime}" +"%Y%m%d%H00")
+
+export NWM_FORCING_OUTPUT_DIR=$DATAexec/forcing_input
+export COASTAL_FORCING_OUTPUT_DIR=$DATAexec/coastal_forcing_output
+
+export FECPP_JOB_INDEX=0
+export FECPP_JOB_COUNT=1
+
+${MPICOMMAND3} singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 $CONDA_ENVS_PATH/$CONDA_ENV_NAME/bin/python \
+         $USHnwm/wrf_hydro_workflow_dev/forcings/WrfHydroFECPP/workflow_driver.py
+
+singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 ./run_sing_coastal_workflow_post_forcing_coastal.bash
+
+singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 ./run_sing_coastal_workflow_update_params.bash
+   
+export OPEN_BNDS_HGRID_FILE=$DATAexec/open_bnds_hgrid.nc
+
+if [[ $USE_TPXO == "YES" ]]; then
+   singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 ./run_sing_coastal_workflow_make_tpxo_ocean.bash
+else
+   export CYCLE_DATE=$STARTPDY
+   export CYCLE_TIME=${STARTCYC}00
+   export LENGTH_HRS=$(singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 ./run_sing_coastal_workflow_pre_make_stofs_ocean.bash)
+
+   export ESTOFS_INPUT_FILE=$STOFS_FILE
+   export SCHISM_OUTPUT_FILE=$DATAexec/elev2D.th.nc
+
+   ${MPICOMMAND3} singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 $CONDA_ENVS_PATH/$CONDA_ENV_NAME/bin/python \
+         $USHnwm/wrf_hydro_workflow_dev/coastal/regrid_estofs.py $ESTOFS_INPUT_FILE $OPEN_BNDS_HGRID_FILE $SCHISM_OUTPUT_FILE
+
+   singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 ./run_sing_coastal_workflow_post_make_stofs_ocean.bash
+
+fi
+
+singularity exec -B $BINDINGS \
+	  --pwd ${work_dir} \
+         $SIF_PATH \
+	 ./run_sing_coastal_workflow_pre_schism.bash
+

--- a/coastal/calib/update_param.bash
+++ b/coastal/calib/update_param.bash
@@ -39,12 +39,14 @@ nwm_coastal_update_params() {
   PDY=${1:0:8}
   cyc=${1:8}
   coastal_domain=$2
-  export LENGTH_HRS=$3
-  local _hotstartfile=$4
+  local _nwm_domain=$3
+  export LENGTH_HRS=$4
+  local _hotstartfile=$5
+  local _domain_path=$6
 
   local _cold_restart=0
   coastal_param=$DATAexec/param.nml
-  cp ${PARMnwm}/coastal/$coastal_domain/param.nml $coastal_param
+  cp ${PARMnwm}/coastal/${_nwm_domain}/param.nml $coastal_param
 
   if [[ "$_hotstartfile" == "" ]]; then
 	  _cold_restart=1
@@ -205,15 +207,15 @@ nwm_coastal_update_params() {
 
 
 # COPY STATIC FILES
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/hgrid.gr3 $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/hgrid.ll $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/manning.gr3 $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/vgrid.in $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/bctides.in $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/windrot_geo2proj.gr3 $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/hgrid.utm $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/hgrid.cpp $DATAexec
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/elev.ic $DATAexec
+ln -sf ${_domain_path}/hgrid.gr3 $DATAexec
+ln -sf ${_domain_path}/hgrid.ll $DATAexec
+ln -sf ${_domain_path}/manning.gr3 $DATAexec
+ln -sf ${PARMnwm}/coastal/${_nwm_domain}/vgrid.in $DATAexec
+ln -sf ${_domain_path}/bctides.in $DATAexec
+ln -sf ${_domain_path}/windrot_geo2proj.gr3 $DATAexec
+ln -sf ${PARMnwm}/coastal/${_nwm_domain}/hgrid.utm $DATAexec
+ln -sf ${_domain_path}/hgrid.cpp $DATAexec
+ln -sf ${_domain_path}/elev.ic $DATAexec
 #cpfs ${PARMnwm}/coastal/${coastal_domain}/hgrid.gr3 $DATAexec
 #cpfs ${PARMnwm}/coastal/${coastal_domain}/hgrid.ll $DATAexec
 #cpfs ${PARMnwm}/coastal/${coastal_domain}/manning.gr3 $DATAexec
@@ -226,23 +228,25 @@ ln -sf ${PARMnwm}/coastal/${coastal_domain}/elev.ic $DATAexec
 # ln -sf %ECF_HOME%/coastal/${coastal_domain}/tvd.prop $DATAexec
 
 
-if [[ -f ${PARMnwm}/coastal/${coastal_domain}/station.in ]]; then
-    ln -sf ${PARMnwm}/coastal/${coastal_domain}/station.in $DATAexec
+if [[ -f ${_domain_path}/station.in ]]; then
+    ln -sf ${_domain_path}/station.in $DATAexec
     #cpfs ${PARMnwm}/coastal/${coastal_domain}/station.in $DATAexec
 fi
 
-ln -sf ${PARMnwm}/coastal/${coastal_domain}/element_areas.txt $DATAexec
+ln -sf ${_domain_path}/element_areas.txt $DATAexec
+ln -sf ${_domain_path}/nwmReaches.csv $DATAexec
+ln -sf ${_domain_path}/open_bnds_hgrid.nc $DATAexec
 
 mkdir -p $DATAexec/sflux
-for f in ${PARMnwm}/coastal/${coastal_domain}/sflux/*; do
+for f in ${PARMnwm}/coastal/${_nwm_domain}/sflux/*; do
   cp $f $DATAexec/sflux/
 done
 
 #cp --no-preserve=mode -r ${PARMnwm}/coastal/${coastal_domain}/sflux $DATAexec
 #
 #for the elevation correction
-if [[ -f ${PARMnwm}/coastal/${coastal_domain}/elevation_correction.csv ]]; then
-      ln -sf ${PARMnwm}/coastal/${coastal_domain}/elevation_correction.csv $DATAexec
+if [[ -f ${PARMnwm}/coastal/${_nwm_domain}/elevation_correction.csv ]]; then
+      ln -sf ${PARMnwm}/coastal/${_nwm_domain}/elevation_correction.csv $DATAexec
 fi
 
 }


### PR DESCRIPTION
The original code use 4 fixed NWM v3 domains, atlgulf, pacific, hawaii and purtorico. Now a subsetting tool that can be used to split these domains into small subdomains is developed. The code of the SCHISM workflow is updated to be able to use any of the subdomains created by the SCHISM domain subsetting tool.
The SCHISM workflow is also divided into two workflows. The first workflow creates all input files for the SCHISM model, and the second workflow runs the SCHSIM model. This is required for consistency between the ways how the SFINCS and SCHSIM simulations are performed.

## Additions

-coastal/calib/run_sing_coastal_workflow_pre_schism2.bash
-coastal/calib/sing_schism_forcing.bash
-In the configuration a domain list yaml file is required to specific the model grids and parameters. This is an example of the domain list file

domain:

name: mesh_a
path: ......\coastalmodels\schism\mesh_a\ # path to base model files
region: hawaii # General region or basin group
epsg: 32604
notes: >
Example SCHISM domain

## Removals

-None

## Changes

coastal/SFINCS/coastalforcing/main.py
coastal/SFINCS/coastalforcing/process_data/data_processor.py
coastal/calib/initial_discharge.bash
coastal/calib/make_tpxo_ocean.bash
coastal/calib/post_regrid_stofs.bash
coastal/calib/pre_regrid_stofs.bash
coastal/calib/pre_schism.bash
coastal/calib/run_sing_coastal_workflow_make_tpxo_ocean.bash
coastal/calib/run_sing_coastal_workflow_post_schism.bash
coastal/calib/run_sing_coastal_workflow_update_params.bash
coastal/calib/sing_run.bash
coastal/calib/update_param.bash

## Testing

1.Tested Hawaii mesh_a domain on the compute nodes. Test passed.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

