### PR TITLE
FVCOM Download script fixes

### DIFF
--- a/Dockerfile.ngencoastal
+++ b/Dockerfile.ngencoastal
@@ -62,6 +62,7 @@ RUN set -eux && \
         which \
         xz \
         jq \
+        wget \
     && dnf clean all && rm -rf /var/cache/dnf
 
 ## FIXME: replace GNU compilers with Intel compiler ##

--- a/coastal/FVCOM_Download/README.md
+++ b/coastal/FVCOM_Download/README.md
@@ -21,21 +21,20 @@ For each of the nowcast or forecast product, there are three type of output file
 - field forecast
 
 # Script Usage
-the script has a help option (-h) for printing usage information.
+The script has a help option (-h) for printing usage information.
 
-Usage: ./download_fvcom.bash [-s <start_utcdate>(yyyymmdd)]  [-e <end_utcdate>(yyyymmdd)] [-n <domain> (one of leofs, lmhofs, loofs, or lsofs)] [-o <output path>]
-        defaults: 
-                <start_utcdate>: current utc day
-                <end_utcdate>: current utc day + 1 day
-                <domain>: all 4 domains
-                <output path>: $ROOT_SHARE/data)
+Usage:download_fvcom.bash [-s <start_utcdate>(yyyymmdd)]  [-e <end_utcdate>(yyyymmdd)] [-n <domain> (one of leofs, lmhofs, loofs, or lsofs)] [-o <output path>]
+        defaults: 
+                <start_utcdate>: current utc day
+                <end_utcdate>: current utc day + 1 day
+                <domain>: all 4 domains
+                <output path>: $ROOT_SHARE/data)
 
-   where <start_utcdate>  is the UTC date such as 20241218, default is the current date
-         <domain> is one of the Great Lakes' domains, one of leofs, lmhofs, loofs, or lsofs, default is to download all domains
-         <output path> the output directory where the downloaded files will be saved. The default value is $ROOT_SHARE/data. ROOT_SHARE is an environmental variable. If the <output path> is not given and the ROOT_SHARE environmental variable is not defined, the script will exit with an error message.
+where -s and -e specifies the start and end UTC date such as 20241218, default start date is the current day, and the default end date is the current day + 1 day. -n specifies the domain(s), it is one of the 4 Great Lakes domains (leofs, lmhofs, loofs, or lsofs). Multiple domains can be specified, each domain name is separated by a space. The -o option specifies the output directory where the downloaded files will be saved. The default value is $ROOT_SHARE/data. ROOT_SHARE is an environmental variable. If the  is not given and the ROOT_SHARE environmental variable is not defined, the script will exit with an error message.
 
 #### Examples ####
 
    ./download_fvcom.bash -s 20241218 -e 20241220 -o ./fvcom_data
    ROOT_SHARE=./fvcom_data ./download_fvcom.bash
    ./download_fvcom.bash -s 20241218 -e 20241220 -n loofs -o ./fvcom_data
+   ./download_fvcom.bash -s 20231213 -e 20231215 -n "loofs lsofs" -o ./fvcom_loofs_lsofs_20231213

--- a/coastal/FVCOM_Download/download_fvcom.bash
+++ b/coastal/FVCOM_Download/download_fvcom.bash
@@ -16,22 +16,22 @@ while :; do
         -s|--start_utcdate)
             shift
             INPUT_DATE_START=$1
-            echo "got option: $INPUT_DATE_START"
+#            echo "got option: $INPUT_DATE_START"
             ;;
         -e|--end_utcdate)
             shift
             INPUT_DATE_END=$1
-            echo "got option: $INPUT_DATE_END"
+#            echo "got option: $INPUT_DATE_END"
             ;;
         -n|--domain)
             shift
             OPTION_DOMAIN=$1
-            echo "got option: $OPTION_DOMAIN"
+#            echo "got option: $OPTION_DOMAIN"
             ;;
         -o|--output)
             shift
             OPTION_DIR=$1
-            echo "got option: $OPTION_DIR"
+#            echo "got option: $OPTION_DIR"
             ;;
         -h|--help)
             usage
@@ -77,8 +77,7 @@ else
     OUTPUT_DIR="$OPTION_DIR"
 fi
 
-pdy=$UTC_DATE_START
-recent_two_month=$(date -d "1 month ago" "+%Y%m")01
+recent_two_month=$(date -d "2 month ago" "+%Y%m")01
 
 #=========================================================
 #  https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf/[YYYYMM]/
@@ -131,7 +130,14 @@ declare -A domain_to_lake=( \
 	   [lsofs]="superior" )
 
 for domain in "${DOMAINS[@]}"; do
-     
+   
+   pdy=$UTC_DATE_START
+   echo "domain=$domain"
+   if [[ ! " leofs lmhofs loofs lsofs " =~ " $domain " ]]; then
+      echo "ERROR: Unknown domain : $domain, skipping ..."
+      continue
+   fi
+
    OFSDIR=$OUTPUT_DIR/${domain}
    if [ ! -d "${OFSDIR}" ]; then 
         mkdir -p $OFSDIR
@@ -139,48 +145,52 @@ for domain in "${DOMAINS[@]}"; do
          
    cd $OFSDIR
 
-   #URLBASE=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/
-   URLBASE=https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf
+   URLBASE=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/
+   #URLBASE=https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf
   while [ $pdy -lt $UTC_DATE_END ]; do
    for cyc in 00 06 12 18; do
+     #pre 202201
+#     if [[ ${pdy} -lt 20220101 && ( $domain == 'lsofs' || $domain == 'loofs' ) ]] ; then
+#         wget -nc --no-check-certificate \
+#         ${URLBASE}/${pdy:0:4}/${pdy:4:2}/glofs.${domain}.fields.nowcast.${pdy}.t${cyc}z.nc
      #pre 202301
+#     elif [ ${pdy} -lt 20230101 ]; then
      if [ ${pdy} -lt 20230101 ]; then
         for i in {000..006}; do 
             wget -nc --no-check-certificate \
-	        ${URLBASE}/${pdy:0:-2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
-	        #${URLBASE}/${pdy:0:4}/${pdy:4:2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
+	        ${URLBASE}/${pdy:0:4}/${pdy:4:2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
+	        #${URLBASE}/${pdy:0:-2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
         done
      
      #pre 202403
      elif [ ${pdy} -lt 20240301 ]; then
         for i in {000..006}; do 
             wget -nc --no-check-certificate \
-	        ${URLBASE}/${pdy:0:-2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
-	        #${URLBASE}/${pdy:0:4}/${pdy:4:2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
+	        ${URLBASE}/${pdy:0:4}/${pdy:4:2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
+	        #${URLBASE}/${pdy:0:-2}/nos.${domain}.fields.n${i}.${pdy}.t${cyc}z.nc
         done
         wget -nc --no-check-certificate \
-	        ${URLBASE}/${pdy:0:-2}/nos.${domain}.stations.nowcast.${pdy}.t${cyc}z.nc
-	        #${URLBASE}/${pdy:0:4}/${pdy:4:2}/nos.${domain}.stations.nowcast.${pdy}.t${cyc}z.nc
+	        ${URLBASE}/${pdy:0:4}/${pdy:4:2}/nos.${domain}.stations.nowcast.${pdy}.t${cyc}z.nc
+	        #${URLBASE}/${pdy:0:-2}/nos.${domain}.stations.nowcast.${pdy}.t${cyc}z.nc
      else
-#        if [ ${pdy} -lt $recent_two_month ]; then
-#           #URL=https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf/${pdy:0:-2}
-#	   URL=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/${pdy:0:4}/${pdy:4:2}
-#        else
-#           URL=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/${pdy:0:4}/${pdy:4:2}
-#        fi
+        if [ ${pdy} -lt $recent_two_month ]; then
+           #URL=https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf/${pdy:0:-2}
+	   URL=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/${pdy:0:4}/${pdy:4:2}
+        else
+           #URL=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/${pdy:0:4}/${pdy:4:2}
+           URL=https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf/${pdy:0:4}/${pdy:4:2}/${pdy:6:2}
+        fi
 
-        #URL=https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/lake-${domain_to_lake[$domain]}-operational-forecast-system-${domain}/${pdy:0:4}/${pdy:4:2}
-        URL=https://noaa-nos-ofs-pds.s3.amazonaws.com/${domain}/netcdf/${pdy:0:-2}
 	#nowcast station
         wget -nc --no-check-certificate \
 	        ${URL}/${domain}.t${cyc}z.${pdy}.stations.nowcast.nc
 	#nowcast regulargrid and grid
-#        for i in {000..006}; do 
+        for i in {000..006}; do 
 #            wget -nc --no-check-certificate \
 #	        ${URL}/${domain}.t${cyc}z.${pdy}.regulargrid.n${i}.nc
-#            wget -nc --no-check-certificate \
-#	        ${URL}/${domain}.t${cyc}z.${pdy}.fields.n${i}.nc
-#        done
+            wget -nc --no-check-certificate \
+	        ${URL}/${domain}.t${cyc}z.${pdy}.fields.n${i}.nc
+        done
 
 	#forecast station
         wget -nc --no-check-certificate \


### PR DESCRIPTION
The NODD AWS Cloud server, https://noaa-nos-ofs-pds.s3.amazonaws.com/index.html, has been updated since the script was developed. Now it has data only back to 2024. The older data were move to the NOAA NCEI server at https://www.ncei.noaa.gov/data/operational-nowcast-and-forecast-hydrodynamic-model-systems-co-ops/access/.  Changed the script to use the NCEI server for data older than two months back to 2019. For the most recent data (in the past two month), the script will download them from the NODD AWS Cloud server.
Updated the Dockerfile.ngencoastal to include the wget program which is used by the download script.