### PR TITLE
Cosmetic Refactor of regrid.py

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -112,7 +112,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"{name} file being used: {input_file}",
-            )  # log at debug level
+            )
 
             os.symlink(input_file, tmpFile)
         except:
@@ -160,7 +160,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg="No AK AnA in_2 file found for this timestep.",
-                )  # log at debug level
+                )
             return
 
         # Check to see if the regrid complete flag for this
@@ -173,7 +173,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg="No AK AnA regridding required for this timestep.",
-                )  # log at debug level
+                )
             return
 
         # Only rank‐0 opens the file
@@ -365,7 +365,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}",
-                )  # log at debug level
+                )
                 LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
                     try:
@@ -521,7 +521,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 mpi_config,
                 debug=True,
                 msg="No StageIV regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -565,7 +565,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             if mpi_config.rank == 0:
                 err_handler.log_msg(
                     config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
-                )  # log at debug level
+                )
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -601,7 +601,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     mpi_config,
                     debug=True,
                     msg="Calculating STAGE IV regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -623,7 +623,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -656,7 +656,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -689,7 +689,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -723,7 +723,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1109,7 +1109,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 mpi_config,
                 debug=True,
                 msg="No StageIV regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -1152,7 +1152,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             if mpi_config.rank == 0:
                 err_handler.log_msg(
                     config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
-                )  # log at debug level
+                )
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -1188,7 +1188,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     mpi_config,
                     debug=True,
                     msg="Calculating STAGE IV regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -1210,7 +1210,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1243,7 +1243,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1276,7 +1276,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1310,7 +1310,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1693,7 +1693,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 mpi_config,
                 debug=True,
                 msg="No HRRR in_2 file found for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Check to see if the regrid complete flag for this
@@ -1706,7 +1706,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 mpi_config,
                 debug=True,
                 msg="No HRRR regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -1748,7 +1748,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Converting HRRR Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 if 0 < input_forcings.cycle_freq < 60:
                     time_str = (
                         f"{input_forcings.fcst_min1}-{input_forcings.fcst_min2} min acc fcst"
@@ -1804,7 +1804,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg=f"Processing HRRR Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -1823,7 +1823,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg="Calculating HRRR regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -1837,7 +1837,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # # Read in the HRRR height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in HRRR elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -1880,7 +1880,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -1955,7 +1955,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2026,7 +2026,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -2103,7 +2103,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2167,7 +2167,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2215,7 +2215,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2274,7 +2274,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2322,7 +2322,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2380,7 +2380,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp_elem = id_tmp.variables[
@@ -2428,7 +2428,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -2489,7 +2489,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2537,7 +2537,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2643,7 +2643,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 mpi_config,
                 debug=True,
                 msg="No RAP regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -2686,7 +2686,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Converting CONUS RAP Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
@@ -2732,7 +2732,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     mpi_config,
                     debug=True,
                     msg=f"Processing Conus RAP Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -2751,7 +2751,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg="Calculating RAP regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -2765,7 +2765,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in RAP elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -2807,7 +2807,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2882,7 +2882,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2956,7 +2956,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -3033,7 +3033,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -3127,7 +3127,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3233,7 +3233,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3338,7 +3338,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -3447,7 +3447,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3573,7 +3573,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 mpi_config,
                 debug=True,
                 msg="No need to read in new CFSv2 data at this time.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -3616,7 +3616,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         mpi_config,
                         debug=True,
                         msg=f"Converting CFSv2 Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -3657,7 +3657,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     mpi_config,
                     debug=True,
                     msg=f"Processing CFSv2 Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -3676,7 +3676,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         mpi_config,
                         debug=True,
                         msg="Calculate CFSv2 regridding weights.",
-                    )  # log at debug level
+                    )
 
                 calculate_weights(
                     id_tmp,
@@ -3691,7 +3691,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in CFSv2 elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 #
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
@@ -3735,7 +3735,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3811,7 +3811,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3886,7 +3886,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -3964,7 +3964,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -4032,7 +4032,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4179,7 +4179,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4325,7 +4325,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4474,7 +4474,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4672,7 +4672,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No NWM NetCDF regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4691,7 +4691,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-            )  # log at debug level
+            )
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4718,7 +4718,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
-            )  # log at debug level
+            )
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
@@ -4729,7 +4729,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4800,7 +4800,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4870,7 +4870,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4941,7 +4941,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -5037,7 +5037,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 mpi_config,
                 debug=True,
                 msg="No NWM NetCDF regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -5072,7 +5072,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 mpi_config,
                 debug=True,
                 msg=f"Processing Custom zarr Forcing Variable: {nc_var}",
-            )  # log at debug level
+            )
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -5108,7 +5108,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5179,7 +5179,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5249,7 +5249,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5320,7 +5320,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5436,7 +5436,7 @@ def regrid_custom_hourly_netcdf(
                     mpi_config,
                     debug=True,
                     msg="No Custom Hourly NetCDF regridding required for this timestep.",
-                )  # log at debug level
+                )
             return
 
         # Open the input NetCDF file containing necessary data.
@@ -5468,7 +5468,7 @@ def regrid_custom_hourly_netcdf(
                     mpi_config,
                     debug=True,
                     msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-                )  # log at debug level
+                )
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
                 force_count,
@@ -5527,7 +5527,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5598,7 +5598,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5670,7 +5670,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out_elem = (
                                 esmf_regridobj_call_retry_partial(
@@ -5741,7 +5741,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5808,14 +5808,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -5923,14 +5923,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -6036,14 +6036,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -6155,14 +6155,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -6300,7 +6300,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No ERA5-Interim regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -6334,7 +6334,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}",
-            )  # log at debug level
+            )
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -6381,14 +6381,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6498,14 +6498,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6614,14 +6614,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.0)[
                         ind, :, :
                     ]
@@ -6738,14 +6738,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6888,7 +6888,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No 13km GFS regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a temporary NetCDF file name to hold converted GRIB2 data.
@@ -6944,7 +6944,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Converting 13km GFS Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
                     # By far the most complicated of output variables. We need to calculate
@@ -7002,7 +7002,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Processing 13km GFS Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -7021,7 +7021,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg="Calculating 13km GFS regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -7035,7 +7035,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # Read in the GFS height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #    config_options.statusMsg = "Reading in 13km GFS elevation data."
-                #    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #    err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #    "\":(HGT):(surface):\" " + \
                 #    " -netcdf " + input_forcings.tmpFileHeight
@@ -7130,7 +7130,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain.",
-                    )  # log at debug level
+                    )
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.esmf_field_out = (
@@ -7487,7 +7487,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -7502,7 +7502,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7552,7 +7552,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -7567,7 +7567,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Node Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7616,7 +7616,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out_elem = (
@@ -7633,7 +7633,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Element Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7683,7 +7683,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -7698,7 +7698,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Element Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7800,7 +7800,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             mpi_config,
             debug=True,
             msg="No regridding of NAM nest data necessary for this timestep - already completed.",
-        )  # log at debug level
+        )
         return
 
     # Create a path for a temporary NetCDF file
@@ -7839,7 +7839,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Converting NAM-Nest Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -7883,7 +7883,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     mpi_config,
                     debug=True,
                     msg=f"Processing NAM Nest Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -7902,7 +7902,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg="Calculating NAM nest regridding weights....",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -7916,7 +7916,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in NAM nest elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -7952,7 +7952,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -8021,7 +8021,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -8089,7 +8089,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -8160,7 +8160,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -8226,7 +8226,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8312,7 +8312,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8397,7 +8397,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8485,7 +8485,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8635,7 +8635,7 @@ def regrid_mrms_hourly(
                 mpi_config,
                 debug=True,
                 msg="No MRMS regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -8785,7 +8785,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg="Calculating MRMS regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config
             )
@@ -8829,7 +8829,7 @@ def regrid_mrms_hourly(
                         mpi_config,
                         debug=True,
                         msg="Regridding MRMS RQI Field.",
-                    )  # log at debug level
+                    )
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -8856,7 +8856,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"{n_masked} masked cells in RQI field, will remove",
-                            )  # log at debug level
+                            )
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
@@ -8905,7 +8905,7 @@ def regrid_mrms_hourly(
                         mpi_config,
                         debug=True,
                         msg="Regridding MRMS RQI Field.",
-                    )  # log at debug level
+                    )
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -8932,7 +8932,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"{n_masked} masked cells in RQI field, will remove",
-                            )  # log at debug level
+                            )
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
@@ -8980,7 +8980,7 @@ def regrid_mrms_hourly(
                         mpi_config,
                         debug=True,
                         msg="Regridding MRMS RQI Field.",
-                    )  # log at debug level
+                    )
                 try:
                     supplemental_precip.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -9007,7 +9007,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"{n_masked} masked cells in RQI field, will remove",
-                            )  # log at debug level
+                            )
 
                     supplemental_precip.esmf_field_out_elem.data[
                         np.where(supplemental_precip.regridded_mask_elem == 0)
@@ -9036,7 +9036,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg="MRMS Will not be filtered using RQI values.",
-                )  # log at debug level
+                )
 
         elif supplemental_precip.rqiMethod == 2:
             # Read in the RQI field from monthly climatological files.
@@ -9072,7 +9072,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9148,7 +9148,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
@@ -9200,7 +9200,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9276,7 +9276,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
@@ -9327,7 +9327,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9408,7 +9408,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = (
                         config_options.globalNdv
                     )
@@ -9459,7 +9459,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9535,7 +9535,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
@@ -9910,7 +9910,7 @@ def regrid_hourly_wrf_arw(
             mpi_config,
             debug=True,
             msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed.",
-        )  # log at debug level
+        )
         return
 
     # Create a path for a temporary NetCDF file
@@ -9951,7 +9951,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Converting WRF-ARW Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
@@ -10000,7 +10000,7 @@ def regrid_hourly_wrf_arw(
                     mpi_config,
                     debug=True,
                     msg=f"Processing WRF-ARW Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -10019,7 +10019,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg="Calculating WRF-ARW regridding weights....",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -10033,7 +10033,7 @@ def regrid_hourly_wrf_arw(
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in WRF-ARW elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -10069,7 +10069,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -10137,7 +10137,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -10205,7 +10205,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -10276,7 +10276,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -10342,7 +10342,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10452,7 +10452,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10561,7 +10561,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10674,7 +10674,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10834,7 +10834,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 mpi_config,
                 debug=True,
                 msg="No ARW regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -10911,7 +10911,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     mpi_config,
                     debug=True,
                     msg="Calculating WRF ARW regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config
             )
@@ -10927,7 +10927,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11020,7 +11020,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11112,7 +11112,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11208,7 +11208,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11364,7 +11364,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 mpi_config,
                 debug=True,
                 msg="Calculating SBCv2 Liquid Water Fraction regridding weights.",
-            )  # log at debug level
+            )
         calculate_supp_pcp_weights(
             supplemental_forcings,
             id_tmp,
@@ -11466,7 +11466,7 @@ def regrid_sbcv2_liquid_water_fraction(
                     mpi_config,
                     debug=True,
                     msg="Regridding SBCv2 Liquid Water Fraction - unstructured",
-                )  # log at debug level
+                )
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -11546,7 +11546,7 @@ def regrid_sbcv2_liquid_water_fraction(
                     mpi_config,
                     debug=True,
                     msg="Regridding SBCv2 Liquid Water Fraction input variable.",
-                )  # log at debug level
+                )
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_forcings.netcdf_var_names[0]
@@ -11781,7 +11781,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Converting NBM Variable: {grib_var}",
-                )  # log at debug level
+                )
             time_str = (
                 f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
@@ -11823,7 +11823,7 @@ def regrid_hourly_nbm(
                 mpi_config,
                 debug=True,
                 msg=f"Processing NBM Variable: {nc_var}",
-            )  # log at debug level
+            )
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -11856,7 +11856,7 @@ def regrid_hourly_nbm(
                         mpi_config,
                         debug=True,
                         msg=f"Calculating NBM {tag} regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_supp_pcp_weights(
                     forcings_or_precip,
                     id_tmp,
@@ -11872,7 +11872,7 @@ def regrid_hourly_nbm(
                         mpi_config,
                         debug=True,
                         msg=f"Calculating NBM {tag} regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -11940,7 +11940,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -12012,7 +12012,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -12084,7 +12084,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -12155,7 +12155,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the unstructured domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out_elem = (
                                 esmf_regridobj_call_retry_partial(
@@ -12209,7 +12209,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12314,7 +12314,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12418,7 +12418,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12522,7 +12522,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12660,7 +12660,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No NDFD regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     err_handler.log_msg(config_options, mpi_config, msg="Regrid NDFD")
@@ -12694,7 +12694,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Deleting old temporary file: {tmp_file}",
-                )  # log at debug level
+                )
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
@@ -12714,7 +12714,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Cycle unchanged, reusing temporary file: {tmp_file}",
-                    )  # log at debug level
+                    )
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
@@ -12723,7 +12723,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}",
-                    )  # log at debug level
+                    )
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
                 else:
@@ -12749,7 +12749,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg="Forecast time beyond NDFD range, skipping",
-                        )  # log at debug level
+                        )
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
@@ -12758,7 +12758,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}",
-                        )  # log at debug level
+                        )
                     else:
                         time_index = min(
                             range(len(times)),
@@ -12769,7 +12769,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}",
-                        )  # log at debug level
+                        )
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
@@ -12778,7 +12778,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg="Forecast time beyond NDFD precip range, skipping",
-                        )  # log at debug level
+                        )
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
@@ -12787,7 +12787,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}",
-                        )  # log at debug level
+                        )
 
             skip_file = mpi_config.broadcast_parameter(
                 skip_file, config_options, param_type=np.ubyte
@@ -12818,7 +12818,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Processing NDFD variable: {ndfd_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -12837,7 +12837,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg="Calculating NDFD regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     i,
@@ -13112,7 +13112,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     mpi_config,
                     debug=True,
                     msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-                )  # log at debug level
+                )
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
             ):
@@ -13163,14 +13163,14 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
                         err_handler.log_critical(
@@ -13278,14 +13278,14 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
                         err_handler.log_critical(
@@ -13391,14 +13391,14 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
                         err_handler.log_critical(
@@ -13517,7 +13517,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                        )  # log at debug level
+                        )
                     try:
                         with timing_block(
                             f"regrid step 2.5.2 | {mpi_config.rank}: messages2"
@@ -13527,7 +13527,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                                 mpi_config,
                                 debug=True,
                                 msg=f"Using {fill} to replace missing values in input",
-                            )  # log at debug level
+                            )
                         with timing_block(
                             f"regrid step 2.5.3 | {mpi_config.rank}: fill missing"
                         ):
@@ -14088,7 +14088,7 @@ def load_weight_file(
         mpi_config,
         debug=True,
         msg=f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}",
-    )  # log at debug level
+    )
 
     err_handler.check_program_status(config_options, mpi_config)
     try:
@@ -14110,7 +14110,7 @@ def load_weight_file(
             mpi_config,
             debug=True,
             msg=f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds",
-        )  # log at debug level
+        )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14144,9 +14144,7 @@ def make_regrid(
 
     start_msg = f"RANK: {mpi_config.rank}: Creating{msg_augment}weight object from ESMF. weight_file={weight_file}"
     if mpi_config.rank == 0:
-        err_handler.log_msg(
-            config_options, mpi_config, debug=True, msg=start_msg
-        )  # log at debug level
+        err_handler.log_msg(config_options, mpi_config, debug=True, msg=start_msg)
 
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[
@@ -14185,7 +14183,7 @@ def make_regrid(
                 mpi_config,
                 debug=True,
                 msg=f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds",
-            )  # log at debug level
+            )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14230,7 +14228,7 @@ def execute_regrid(
                 mpi_config,
                 debug=True,
                 msg=f"Deleting if exists: {weight_file}",
-            )  # log at debug level
+            )
             try:
                 os_utils.os_remove_retry(weight_file)
             except FileNotFoundError:
@@ -14269,9 +14267,7 @@ def calculate_weights(
         esmf_grid_retry, mpi_config, config_options, err_handler
     )
 
-    err_handler.log_msg(
-        config_options, mpi_config, debug=True, msg="Calculate Weights"
-    )  # log at debug level
+    err_handler.log_msg(config_options, mpi_config, debug=True, msg="Calculate Weights")
 
     if mpi_config.rank == 0:
         if config_options.aws:
@@ -14393,7 +14389,7 @@ def calculate_weights(
                     mpi_config,
                     debug=True,
                     msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells",
-                )  # log at debug level
+                )
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
             gmask[:+border, :] = 0.0  # top edge

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -111,7 +111,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
                 config_options,
                 mpi_config,
                 debug=True,
-                msg=name + " file being used: " + input_file,
+                msg=f"{name} file being used: {input_file}",
             )  # log at debug level
 
             os.symlink(input_file, tmpFile)
@@ -119,7 +119,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create link: " + input_file + " to: " + tmpFile,
+                msg=f"Unable to create link: {input_file} to: {tmpFile}",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -418,8 +418,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract ExtAnA forcing data from the AK AnA field: "
-                        + str(err),
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -442,8 +441,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err),
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -468,8 +466,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err),
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -547,9 +544,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + stage4_tmp_nc
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
@@ -643,11 +638,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -680,11 +671,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -717,11 +704,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -755,11 +738,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -775,8 +754,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -790,8 +768,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -804,8 +781,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -827,8 +803,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -847,8 +822,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -862,8 +836,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -876,8 +849,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -899,8 +871,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -918,8 +889,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -935,8 +905,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -949,8 +918,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -973,8 +941,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -993,8 +960,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1008,8 +974,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1022,8 +987,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1045,8 +1009,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1168,9 +1131,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + stage4_tmp_nc
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
@@ -1264,11 +1225,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1301,11 +1258,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1338,11 +1291,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1376,11 +1325,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1396,8 +1341,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1411,8 +1355,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1425,8 +1368,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1448,8 +1390,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1468,8 +1409,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1483,8 +1423,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1497,8 +1436,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1520,8 +1458,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1539,8 +1476,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1556,8 +1492,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1570,8 +1505,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1594,8 +1528,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1614,8 +1547,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1629,8 +1561,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1643,8 +1574,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1671,8 +1601,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
@@ -1835,13 +1764,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         else f"{input_forcings.fcst_hour2} hour fcst"
                     )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
@@ -1850,7 +1773,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 pattern = "|".join(fields)
                 cmd = f'$WGRIB2 -match "({pattern})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -1880,7 +1803,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing HRRR Variable: " + grib_var,
+                    msg=f"Processing HRRR Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -1932,12 +1855,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1952,8 +1870,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1976,8 +1893,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1990,8 +1906,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2001,8 +1916,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2016,12 +1930,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2036,8 +1945,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2060,8 +1968,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2074,8 +1981,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2085,8 +1991,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2096,12 +2001,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2116,8 +2016,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2140,8 +2039,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2154,8 +2052,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2167,8 +2064,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2182,12 +2078,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2202,8 +2093,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2226,8 +2116,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2240,8 +2129,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2251,8 +2139,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2279,8 +2166,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2304,13 +2190,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2325,8 +2205,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2335,8 +2214,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2348,7 +2226,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2361,8 +2239,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2374,8 +2251,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2397,8 +2273,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2422,13 +2297,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2443,8 +2312,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2453,8 +2321,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2466,7 +2333,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2479,8 +2346,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2492,8 +2358,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2514,8 +2379,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2539,13 +2403,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2560,8 +2418,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2570,8 +2427,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -2585,7 +2441,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2598,8 +2454,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2611,8 +2466,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2634,8 +2488,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2659,13 +2512,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2680,8 +2527,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2690,8 +2536,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2703,7 +2548,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2716,8 +2561,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2729,8 +2573,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2823,9 +2666,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -2833,7 +2674,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to remove file: " + input_forcings.tmpFile,
+                            msg=f"Unable to remove file: {input_forcings.tmpFile}",
                         )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -2844,38 +2685,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting CONUS RAP Variable: " + grib_var,
+                        msg=f"Converting CONUS RAP Variable: {grib_var}",
                     )  # log at debug level
                 time_str = (
-                    "{}-{} hour acc fcst".format(
-                        input_forcings.fcst_hour1, input_forcings.fcst_hour2
-                    )
+                    f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
-                    else str(input_forcings.fcst_hour2) + " hour fcst"
+                    else f"{input_forcings.fcst_hour2} hour fcst"
                 )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -2905,7 +2731,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing Conus RAP Variable: " + grib_var,
+                    msg=f"Processing Conus RAP Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -2956,11 +2782,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2975,8 +2797,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2999,8 +2820,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3013,8 +2833,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3024,8 +2843,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3039,11 +2857,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3058,8 +2872,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3082,8 +2895,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3096,8 +2908,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3107,8 +2918,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3121,11 +2931,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3140,8 +2946,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3164,8 +2969,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3178,8 +2982,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3191,8 +2994,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3206,11 +3008,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3225,8 +3023,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3249,8 +3046,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3263,8 +3059,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3274,8 +3069,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3308,13 +3102,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3329,8 +3117,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3339,8 +3126,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3352,9 +3138,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3367,11 +3151,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3384,8 +3164,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3429,13 +3208,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3450,8 +3223,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3460,8 +3232,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3473,9 +3244,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3488,11 +3257,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3505,8 +3270,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3549,13 +3313,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3570,8 +3328,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3580,8 +3337,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -3595,9 +3351,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3610,11 +3364,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3627,8 +3377,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF element data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF element data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3673,13 +3422,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3694,8 +3437,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3704,8 +3446,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3717,9 +3458,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3732,11 +3471,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3749,8 +3484,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3862,9 +3596,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -3872,9 +3604,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to remove previous temporary file: "
-                            + input_forcings.tmpFile
-                            + str(err),
+                            msg=f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err}",
                         )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -3885,31 +3615,18 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting CFSv2 Variable: " + grib_var,
+                        msg=f"Converting CFSv2 Variable: {grib_var}",
                     )  # log at debug level
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + str(input_forcings.fcst_hour2)
-                    + " hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -3939,7 +3656,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing CFSv2 Variable: " + grib_var,
+                    msg=f"Processing CFSv2 Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -3993,11 +3710,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4012,8 +3725,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4037,8 +3749,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4051,8 +3762,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4062,8 +3772,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4077,11 +3786,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4096,8 +3801,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4121,8 +3825,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4135,8 +3838,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4146,8 +3848,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4160,11 +3861,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4179,8 +3876,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4204,8 +3900,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4218,8 +3913,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4231,8 +3925,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4246,11 +3939,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4265,8 +3954,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4290,8 +3978,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4304,8 +3991,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4315,8 +4001,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4346,8 +4031,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -4357,13 +4041,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4404,13 +4082,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4434,8 +4106,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4451,11 +4122,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4468,11 +4135,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4484,8 +4147,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4516,8 +4178,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -4527,13 +4188,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4574,13 +4229,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4604,8 +4253,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4621,11 +4269,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4638,11 +4282,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4654,8 +4294,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4685,8 +4324,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -4696,13 +4334,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4745,13 +4377,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count})
 
@@ -4775,8 +4401,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4792,11 +4417,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4809,11 +4430,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4825,8 +4442,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4857,8 +4473,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -4868,13 +4483,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4915,13 +4524,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4945,8 +4548,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4962,11 +4564,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4979,11 +4577,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4995,8 +4589,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5097,7 +4690,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+                msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
             )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
@@ -5135,7 +4728,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
@@ -5143,13 +4736,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5164,8 +4751,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5179,8 +4765,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5192,8 +4777,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5215,7 +4799,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
@@ -5223,13 +4807,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5244,8 +4822,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5259,8 +4836,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5272,8 +4848,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5294,7 +4869,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
@@ -5302,13 +4877,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5323,8 +4892,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5338,8 +4906,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5351,8 +4918,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5374,7 +4940,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
@@ -5382,13 +4948,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5403,8 +4963,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5418,8 +4977,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5431,8 +4989,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5451,7 +5008,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -5514,7 +5071,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing Custom zarr Forcing Variable: " + nc_var,
+                msg=f"Processing Custom zarr Forcing Variable: {nc_var}",
             )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
@@ -5550,7 +5107,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
@@ -5558,13 +5115,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5579,8 +5130,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5594,8 +5144,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5607,8 +5156,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5630,7 +5178,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
@@ -5638,13 +5186,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5659,8 +5201,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5674,8 +5215,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5687,8 +5227,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5709,7 +5248,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
@@ -5717,13 +5256,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5738,8 +5271,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5753,8 +5285,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5766,8 +5297,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5789,7 +5319,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
@@ -5797,13 +5327,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5822,8 +5346,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5837,8 +5360,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5850,8 +5372,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5870,7 +5391,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -5946,7 +5467,7 @@ def regrid_custom_hourly_netcdf(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
                 )  # log at debug level
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -5996,8 +5517,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6020,8 +5540,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6034,8 +5553,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6047,8 +5565,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6071,8 +5588,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6095,8 +5611,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6109,8 +5624,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6122,8 +5636,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6147,8 +5660,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6171,8 +5683,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6185,8 +5696,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6198,8 +5708,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6222,8 +5731,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6246,8 +5754,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6260,8 +5767,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6273,8 +5779,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6302,7 +5807,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6316,13 +5821,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6337,8 +5836,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6352,8 +5850,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6366,8 +5863,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6389,8 +5885,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6402,8 +5897,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6428,7 +5922,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6442,13 +5936,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6463,8 +5951,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6478,8 +5965,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6492,8 +5978,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6514,8 +5999,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6527,8 +6011,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6552,7 +6035,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6566,13 +6049,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6587,8 +6064,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6604,8 +6080,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6618,8 +6093,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6643,8 +6117,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6656,8 +6129,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6682,7 +6154,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6696,13 +6168,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6716,8 +6182,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6731,8 +6196,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6745,8 +6209,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6772,8 +6235,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6785,8 +6247,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6805,7 +6266,7 @@ def regrid_custom_hourly_netcdf(
                 id_tmp.close()
             except OSError:
                 config_options.errMsg = (
-                    "Unable to close NetCDF file: " + input_forcings.tmpFile
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
                 )
                 err_handler.err_out(config_options)
 
@@ -6872,7 +6333,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing ERA-5 Interim Forcing Variable: " + nc_var,
+                msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}",
             )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
@@ -6919,7 +6380,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -6944,13 +6405,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6965,8 +6420,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6980,8 +6434,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6994,8 +6447,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7011,8 +6463,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7024,8 +6475,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7047,7 +6497,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -7072,13 +6522,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7093,8 +6537,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7108,8 +6551,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7122,8 +6564,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7139,8 +6580,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7152,8 +6592,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7174,7 +6613,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -7203,13 +6642,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7224,8 +6657,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7239,8 +6671,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7253,8 +6684,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7272,8 +6702,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7286,8 +6715,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7309,7 +6737,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -7334,13 +6762,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7355,8 +6777,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7370,8 +6791,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7384,8 +6804,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7401,8 +6820,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7414,8 +6832,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7435,7 +6852,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -7507,9 +6924,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_warning(
                     config_options,
                     mpi_config,
-                    msg="Found old temporary file: "
-                    + input_forcings.tmpFile
-                    + " - Removing.....",
+                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                 )
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -7517,7 +6932,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to remove file: " + input_forcings.tmpFile,
+                        msg=f"Unable to remove file: {input_forcings.tmpFile}",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7528,7 +6943,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting 13km GFS Variable: " + grib_var,
+                        msg=f"Converting 13km GFS Variable: {grib_var}",
                     )  # log at debug level
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
@@ -7544,40 +6959,19 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         tmp_hr_previous = input_forcings.fcst_hour1
 
                     fields.append(
-                        ":"
-                        + grib_var
-                        + ":"
-                        + input_forcings.grib_levels[force_count]
-                        + ":"
-                        + str(tmp_hr_previous)
-                        + "-"
-                        + str(input_forcings.fcst_hour2)
-                        + " hour ave fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{tmp_hr_previous}-{input_forcings.fcst_hour2} hour ave fcst:"
                     )
                 else:
                     fields.append(
-                        ":"
-                        + grib_var
-                        + ":"
-                        + input_forcings.grib_levels[force_count]
-                        + ":"
-                        + str(input_forcings.fcst_hour2)
-                        + " hour fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                     )
 
             # if calc_regrid_flag:
             fields.append(":(HGT):(surface):")
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -7607,7 +7001,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing 13km GFS Variable: " + grib_var,
+                    msg=f"Processing 13km GFS Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -7660,11 +7054,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7681,11 +7071,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7702,11 +7088,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7723,11 +7105,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7742,8 +7120,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local GFS array into an ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local GFS array into an ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7767,7 +7144,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data: " + str(ve),
+                            msg=f"Unable to regrid GFS elevation data: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7780,8 +7157,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7798,8 +7174,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data with ESMF mesh nodes: "
-                            + str(ve),
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7809,8 +7184,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place local GFS array into an ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place local GFS array into an ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7826,8 +7200,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data with ESMF mesh elements: "
-                            + str(ve),
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7840,8 +7213,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7854,8 +7226,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
@@ -7871,7 +7242,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data: " + str(ve),
+                            msg=f"Unable to regrid GFS elevation data: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7884,8 +7255,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7896,8 +7266,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -7907,8 +7276,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7920,8 +7288,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field with mesh elements: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7932,8 +7299,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7964,13 +7330,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
@@ -7984,13 +7344,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8004,13 +7358,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -8024,13 +7372,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8105,8 +7447,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
@@ -8116,8 +7457,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
@@ -8126,8 +7466,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -8137,8 +7476,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8148,8 +7486,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8164,17 +7501,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding took {} seconds".format(end - begin),
+                            msg=f"Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8187,11 +7520,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8203,8 +7532,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8223,8 +7551,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field for Mesh nodes: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8239,17 +7566,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Node Regridding took {} seconds".format(end - begin),
+                            msg=f"Node Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable for Mesh Nodes: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8262,11 +7585,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8278,8 +7597,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8297,8 +7615,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field for Mesh elements: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8315,19 +7632,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Element Regridding took {} seconds".format(
-                                end - begin
-                            ),
+                            msg=f"Element Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8340,11 +7651,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8356,8 +7663,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8376,8 +7682,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8392,19 +7697,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Element Regridding took {} seconds".format(
-                                end - begin
-                            ),
+                            msg=f"Element Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable for Mesh Element: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8417,11 +7716,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8433,8 +7728,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8529,9 +7823,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -8546,31 +7838,18 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting NAM-Nest Variable: " + grib_var,
+                        msg=f"Converting NAM-Nest Variable: {grib_var}",
                     )  # log at debug level
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + str(input_forcings.fcst_hour2)
-                    + " hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -8603,7 +7882,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing NAM Nest Variable: " + grib_var,
+                    msg=f"Processing NAM Nest Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -8663,8 +7942,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8687,8 +7965,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8701,8 +7978,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8712,8 +7988,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8736,8 +8011,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8760,8 +8034,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8774,8 +8047,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8785,8 +8057,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8808,8 +8079,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8832,8 +8102,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8846,8 +8115,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8859,8 +8127,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8883,8 +8150,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8907,8 +8173,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8921,8 +8186,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8932,8 +8196,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8962,8 +8225,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -8973,13 +8235,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8994,8 +8250,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9009,8 +8264,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9023,8 +8277,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9036,8 +8289,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9059,8 +8311,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -9070,13 +8321,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9091,8 +8336,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9106,8 +8350,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9120,8 +8363,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9133,8 +8375,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9155,8 +8396,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -9166,13 +8406,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9187,8 +8421,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9204,8 +8437,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9218,8 +8450,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9231,8 +8462,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9254,8 +8484,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -9265,13 +8494,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9286,8 +8509,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9301,8 +8523,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9315,8 +8536,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9328,8 +8548,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9496,7 +8715,7 @@ def regrid_mrms_hourly(
 
             # Perform a GRIB dump to NetCDF for the MRMS precip and RQI data.
             if WGRIB2_env:
-                cmd1 = "$WGRIB2 " + mrms_tmp_grib2 + " -netcdf " + mrms_tmp_nc
+                cmd1 = f"$WGRIB2 {mrms_tmp_grib2} -netcdf {mrms_tmp_nc}"
             else:
                 cmd1 = mrms_tmp_grib2
 
@@ -9513,9 +8732,7 @@ def regrid_mrms_hourly(
 
             if supplemental_precip.rqiMethod == 1:
                 if WGRIB2_env:
-                    cmd2 = (
-                        "$WGRIB2 " + mrms_tmp_rqi_grib2 + " -netcdf " + mrms_tmp_rqi_nc
-                    )
+                    cmd2 = f"$WGRIB2 {mrms_tmp_rqi_grib2} -netcdf {mrms_tmp_rqi_nc}"
                 else:
                     cmd2 = mrms_tmp_rqi_grib2
 
@@ -9587,13 +8804,7 @@ def regrid_mrms_hourly(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9608,8 +8819,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place MRMS data into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9632,7 +8842,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid MRMS RQI field: " + str(ve),
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9655,8 +8865,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation for MRMS RQI data: "
-                        + str(npe),
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9671,13 +8880,7 @@ def regrid_mrms_hourly(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9692,8 +8895,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place MRMS data into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9716,7 +8918,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid MRMS RQI field: " + str(ve),
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9739,8 +8941,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation for MRMS RQI data: "
-                        + str(npe),
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9754,13 +8955,7 @@ def regrid_mrms_hourly(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9775,8 +8970,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place MRMS data into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9799,7 +8993,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid MRMS RQI field: " + str(ve),
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9822,8 +9016,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation for MRMS RQI data: "
-                        + str(npe),
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9878,7 +9071,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
@@ -9888,13 +9081,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9916,7 +9103,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9937,8 +9124,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9971,7 +9157,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9990,8 +9176,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe),
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10014,7 +9199,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
@@ -10024,13 +9209,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10052,7 +9231,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10073,8 +9252,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10107,7 +9285,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10126,8 +9304,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe),
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10149,7 +9326,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_mrms.variables[
@@ -10159,13 +9336,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10189,7 +9360,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10213,8 +9384,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10247,7 +9417,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10265,8 +9435,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run global NDV search on MRMS regridded precip: "
-                    + str(npe),
+                    msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10289,7 +9458,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
@@ -10299,13 +9468,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10327,7 +9490,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10348,8 +9511,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10382,7 +9544,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10401,8 +9563,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe),
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10495,7 +9656,7 @@ def regrid_mrms_precip_flag(
     err_handler.check_program_status(config_options, mpi_config)
 
     # Perform a GRIB dump to NetCDF for the MRMS precip and RQI data.
-    cmd1 = "$WGRIB2 " + mrms_tmp_grib2 + " -netcdf " + mrms_tmp_nc
+    cmd1 = f"$WGRIB2 {mrms_tmp_grib2} -netcdf {mrms_tmp_nc}"
     id_tmp = ioMod.open_grib2(
         mrms_tmp_grib2,
         mrms_tmp_nc,
@@ -10541,11 +9702,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to extract PrecipFlag from file: "
-                + supplemental_precip.file_in2
-                + " ("
-                + str(err)
-                + ")",
+                msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10563,7 +9720,7 @@ def regrid_mrms_precip_flag(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to place MRMS PrecipFlag into local ESMF field: " + str(err),
+            msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10577,7 +9734,7 @@ def regrid_mrms_precip_flag(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+            msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10593,7 +9750,7 @@ def regrid_mrms_precip_flag(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
+            msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10626,11 +9783,7 @@ def regrid_mrms_precip_flag(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract PrecipFlag from file: "
-                    + supplemental_precip.file_in2
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10652,8 +9805,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place MRMS PrecipFlag into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10667,7 +9819,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+                msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10683,7 +9835,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
+                msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10783,9 +9935,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -10800,38 +9950,23 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting WRF-ARW Variable: " + grib_var,
+                        msg=f"Converting WRF-ARW Variable: {grib_var}",
                     )  # log at debug level
                 time_str = (
-                    "{}-{} hour acc fcst".format(
-                        input_forcings.fcst_hour1, input_forcings.fcst_hour2
-                    )
+                    f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
-                    else str(input_forcings.fcst_hour2) + " hour fcst"
+                    else f"{input_forcings.fcst_hour2} hour fcst"
                 )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -10864,7 +9999,7 @@ def regrid_hourly_wrf_arw(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing WRF-ARW Variable: " + grib_var,
+                    msg=f"Processing WRF-ARW Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -10924,8 +10059,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10948,8 +10082,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10962,8 +10095,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10973,8 +10105,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -10996,8 +10127,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11020,8 +10150,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11034,8 +10163,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11045,8 +10173,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11068,8 +10195,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11092,8 +10218,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11106,8 +10231,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11119,8 +10243,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11143,8 +10266,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11167,8 +10289,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11181,8 +10302,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11192,8 +10312,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11222,8 +10341,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -11233,13 +10351,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11254,8 +10366,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11269,8 +10380,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11283,8 +10393,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11308,8 +10417,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11321,8 +10429,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11344,8 +10451,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -11355,13 +10461,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11376,8 +10476,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11391,8 +10490,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11405,8 +10503,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11430,8 +10527,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11443,8 +10539,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11465,8 +10560,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -11476,13 +10570,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11497,8 +10585,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11514,8 +10601,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11528,8 +10614,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11554,8 +10639,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11567,8 +10651,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11590,8 +10673,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -11601,13 +10683,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11622,8 +10698,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11637,8 +10712,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11651,8 +10725,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11676,8 +10749,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11689,8 +10761,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11783,9 +10854,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + arw_tmp_nc
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {arw_tmp_nc} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(arw_tmp_nc)
@@ -11805,26 +10874,9 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    "$WGRIB2 "
-                    + supplemental_precip.file_in1
-                    + ' -match ":('
-                    + "APCP):(surface):("
-                    + str(supplemental_precip.fcst_hour1 - 1)
-                    + "-"
-                    + str(supplemental_precip.fcst_hour1)
-                    + ' hour acc fcst):"'
-                    + " -netcdf "
-                    + arw_tmp_nc
-                )
+                cmd = f'$WGRIB2 {supplemental_precip.file_in1} -match ":(APCP):(surface):({supplemental_precip.fcst_hour1 - 1}-{supplemental_precip.fcst_hour1} hour acc fcst):" -netcdf {arw_tmp_nc}'
             else:
-                cmd = (
-                    "(APCP):(surface):("
-                    + str(supplemental_precip.fcst_hour1 - 1)
-                    + "-"
-                    + str(supplemental_precip.fcst_hour1)
-                    + " hour acc fcst)"
-                )
+                cmd = f"(APCP):(surface):({supplemental_precip.fcst_hour1 - 1}-{supplemental_precip.fcst_hour1} hour acc fcst)"
 
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in1,
@@ -11882,11 +10934,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11901,8 +10949,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11916,8 +10963,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11930,8 +10976,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11953,8 +10998,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11983,11 +11027,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12002,8 +11042,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12017,8 +11056,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12031,8 +11069,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12054,8 +11091,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12083,11 +11119,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12102,8 +11134,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12119,8 +11150,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12133,8 +11163,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12157,8 +11186,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12187,11 +11215,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12206,8 +11230,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12221,8 +11244,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12235,8 +11257,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12258,8 +11279,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12372,11 +11392,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12393,8 +11409,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12408,7 +11423,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12424,8 +11439,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12459,11 +11473,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12480,8 +11490,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12495,7 +11504,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12511,8 +11520,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12547,11 +11555,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12568,8 +11572,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12585,7 +11588,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12601,8 +11604,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12635,11 +11637,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12656,8 +11654,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12671,7 +11668,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12687,8 +11684,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12713,7 +11709,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to close NetCDF file: " + supplemental_forcings.file_in1,
+                msg=f"Unable to close NetCDF file: {supplemental_forcings.file_in1}",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12764,7 +11760,7 @@ def regrid_hourly_nbm(
             err_handler.log_warning(
                 config_options,
                 mpi_config,
-                msg="Found old temporary file: " + nbm_tmp_nc + " - Removing.....",
+                msg=f"Found old temporary file: {nbm_tmp_nc} - Removing.....",
             )
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
@@ -12772,7 +11768,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to remove file: " + nbm_tmp_nc,
+                    msg=f"Unable to remove file: {nbm_tmp_nc}",
                 )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12784,57 +11780,27 @@ def regrid_hourly_nbm(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Converting NBM Variable: " + grib_var,
+                    msg=f"Converting NBM Variable: {grib_var}",
                 )  # log at debug level
             time_str = (
-                "{}-{} hour acc fcst".format(
-                    forcings_or_precip.fcst_hour1, forcings_or_precip.fcst_hour2
-                )
+                f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
-                else str(forcings_or_precip.fcst_hour2) + " hour fcst"
+                else f"{forcings_or_precip.fcst_hour2} hour fcst"
             )
             fields.append(
-                ":"
-                + grib_var
-                + ":"
-                + forcings_or_precip.grib_levels[force_count]
-                + ":"
-                + time_str
-                + ":"
+                f":{grib_var}:{forcings_or_precip.grib_levels[force_count]}:{time_str}:"
             )
         # fields.append(":(HGT):(surface):")
         # Create a temporary NetCDF file from the GRIB2 file.
-        cmd = (
-            '$WGRIB2 -match "('
-            + "|".join(fields)
-            + ')" -not "prob" -not "ens" '
-            + forcings_or_precip.file_in1
-            + " -netcdf "
-            + nbm_tmp_nc
-        )
+        cmd = f'$WGRIB2 -match "({"|".join(fields)})" -not "prob" -not "ens" {forcings_or_precip.file_in1} -netcdf {nbm_tmp_nc}'
     else:
         # Perform a GRIB dump to NetCDF for the precip data.
         fieldnbm_match1 = '":APCP:"'
         fieldnbm_match2 = (
-            '"'
-            + str(forcings_or_precip.fcst_hour1)
-            + "-"
-            + str(forcings_or_precip.fcst_hour2)
-            + '"'
+            f'"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2}"'
         )
         fieldnbm_notmatch1 = '"prob"'  # We don't want the probabilistic QPF layers
-        cmd = (
-            "$WGRIB2 "
-            + forcings_or_precip.file_in1
-            + " -match "
-            + fieldnbm_match1
-            + " -match "
-            + fieldnbm_match2
-            + " -not "
-            + fieldnbm_notmatch1
-            + " -netcdf "
-            + nbm_tmp_nc
-        )
+        cmd = f"$WGRIB2 {forcings_or_precip.file_in1} -match {fieldnbm_match1} -match {fieldnbm_match2} -not {fieldnbm_notmatch1} -netcdf {nbm_tmp_nc}"
 
     id_tmp = ioMod.open_grib2(
         forcings_or_precip.file_in1,
@@ -12856,7 +11822,7 @@ def regrid_hourly_nbm(
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing NBM Variable: " + nc_var,
+                msg=f"Processing NBM Variable: {nc_var}",
             )  # log at debug level
 
         # Check to see if we need to calculate regridding weights.
@@ -12964,8 +11930,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12988,8 +11953,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13002,8 +11966,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13015,8 +11978,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13040,8 +12002,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13064,8 +12025,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13078,8 +12038,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13091,8 +12050,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13116,8 +12074,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13140,8 +12097,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13154,8 +12110,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13167,8 +12122,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13191,8 +12145,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13215,8 +12168,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the unstructured domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13229,8 +12181,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute element mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute element mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13242,8 +12193,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13266,11 +12216,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13285,7 +12231,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13299,7 +12245,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13312,8 +12258,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13351,8 +12296,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13377,11 +12321,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13396,7 +12336,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13410,7 +12350,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -13422,8 +12362,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13461,8 +12400,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13487,11 +12425,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13506,7 +12440,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13520,7 +12454,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -13532,8 +12466,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13571,8 +12504,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13597,11 +12529,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13616,7 +12544,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13632,7 +12560,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -13644,8 +12572,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13687,8 +12614,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13891,7 +12817,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing NDFD variable: " + ndfd_var,
+                    msg=f"Processing NDFD variable: {ndfd_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -13967,8 +12893,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -14114,8 +13039,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
         finally:
@@ -14187,7 +13111,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
                 )  # log at debug level
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
@@ -14238,7 +13162,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -14252,13 +13176,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14273,8 +13191,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14288,8 +13205,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14302,8 +13218,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14325,8 +13240,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14338,8 +13252,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14364,7 +13277,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -14378,13 +13291,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14399,8 +13306,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14414,8 +13320,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14428,8 +13333,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14450,8 +13354,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14463,8 +13366,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14488,7 +13390,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -14502,13 +13404,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14523,8 +13419,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14540,8 +13435,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14554,8 +13448,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14579,8 +13472,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14592,8 +13484,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14625,7 +13516,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding Custom netCDF input variable: " + nc_var,
+                            msg=f"Regridding Custom netCDF input variable: {nc_var}",
                         )  # log at debug level
                     try:
                         with timing_block(
@@ -14673,8 +13564,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place local array into local ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place local array into local ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14693,8 +13583,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14710,8 +13599,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                            + str(npe),
+                            msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14741,8 +13629,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to run NDV search on Custom netCDF precipitation: "
-                                + str(npe),
+                                msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -14757,8 +13644,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place local ESMF regridded data into local array: "
-                            + str(err),
+                            msg=f"Unable to place local ESMF regridded data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14801,16 +13687,13 @@ def check_regrid_status(
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}",
                 )
 
         elif config_options.grid_type == "unstructured":
@@ -14818,47 +13701,38 @@ def check_regrid_status(
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.NODE,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field node mesh object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}",
                 )
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field element mesh object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
                 )
         elif config_options.grid_type == "hydrofabric":
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field element mesh object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
                 )
 
     err_handler.check_program_status(config_options, mpi_config)
@@ -14970,45 +13844,30 @@ def check_supp_pcp_regrid_status(
             try:
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF field object: {esmf_error}"
                 err_handler.err_out(config_options)
         elif config_options.grid_type == "unstructured":
             try:
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.NODE,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF node field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF node field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
             try:
                 supplemental_precip.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF element field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
         elif config_options.grid_type == "hydrofabric":
@@ -15016,15 +13875,10 @@ def check_supp_pcp_regrid_status(
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF element field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
     # Determine if we need to calculate a regridding object. The following situations warrant the calculation of
@@ -15248,8 +14102,7 @@ def load_weight_file(
         err_handler.log_warning(
             config_options,
             mpi_config,
-            msg=f"Unable to load cached ESMF{msg_augment}weight file: "
-            + str(esmf_error),
+            msg=f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error}",
         )
     else:
         err_handler.log_msg(
@@ -15321,8 +14174,7 @@ def make_regrid(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
-            + str(esmf_error),
+            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error}",
         )
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
@@ -15369,8 +14221,7 @@ def execute_regrid(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to extract regridded data from ESMF regridded field: "
-            + str(ve),
+            msg=f"Unable to extract regridded data from ESMF regridded field: {ve}",
         )
         # delete bad cached file if it exists
         if weight_file is not None:
@@ -15432,9 +14283,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Y shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object",
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
                 )
             try:
                 input_forcings.nx_global = id_tmp.variables[
@@ -15444,9 +14293,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract X shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object",
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
                 )
         else:
             try:
@@ -15457,13 +14304,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Y shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from: "
-                    + input_forcings.tmpFile
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                 )
             try:
                 input_forcings.nx_global = id_tmp.variables[
@@ -15473,13 +14314,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract X shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from: "
-                    + input_forcings.tmpFile
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                 )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15504,11 +14339,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to create source ESMF grid from temporary file: "
-            + input_forcings.tmpFile
-            + " ("
-            + str(esmf_error)
-            + ")",
+            msg=f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15535,12 +14366,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to extract local X/Y boundaries from global grid from temporary "
-            + "file: "
-            + input_forcings.tmpFile
-            + " ("
-            + str(err)
-            + ")",
+            msg=f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15550,9 +14376,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="You have either specified too many cores for: "
-            + input_forcings.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+            msg=f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15568,9 +14392,7 @@ def calculate_weights(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Trimming input forcing `{}` by {} grid cells".format(
-                        input_forcings.product_name, border
-                    ),
+                    msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells",
                 )  # log at debug level
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
@@ -15683,8 +14505,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to locate latitude coordinate object within input ESMF grid: "
-            + str(ge),
+            msg=f"Unable to locate latitude coordinate object within input ESMF grid: {ge}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15694,8 +14515,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to locate longitude coordinate object within input ESMF grid: "
-            + str(ge),
+            msg=f"Unable to locate longitude coordinate object within input ESMF grid: {ge}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15711,13 +14531,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15726,13 +14546,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15740,13 +14560,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in_elem = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE_ELEMENT",
+                name=f"{input_forcings.product_name}_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15755,13 +14575,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15900,7 +14720,7 @@ def calculate_supp_pcp_weights(
         else:
             latdim = londim = -1
             config_options.errMsg = (
-                "Unable to determine lat/lon grid size from " + tmp_file
+                f"Unable to determine lat/lon grid size from {tmp_file}"
             )
             err_handler.err_out(config_options)
 
@@ -15909,34 +14729,14 @@ def calculate_supp_pcp_weights(
                 supplemental_precip.netcdf_var_names[0]
             ].shape[latdim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = (
-                "Unable to extract Y shape size from: "
-                + supplemental_precip.netcdf_var_names[0]
-                + " from: "
-                + tmp_file
-                + " ("
-                + str(err)
-                + ", "
-                + type(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract Y shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err}, {type(err)})"
             err_handler.err_out(config_options)
         try:
             supplemental_precip.nx_global = id_tmp.variables[
                 supplemental_precip.netcdf_var_names[0]
             ].shape[londim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = (
-                "Unable to extract X shape size from: "
-                + supplemental_precip.netcdf_var_names[0]
-                + " from: "
-                + tmp_file
-                + " ("
-                + str(err)
-                + ", "
-                + type(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract X shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err}, {type(err)})"
             err_handler.err_out(config_options)
 
     # mpi_config.comm.barrier()
@@ -15958,13 +14758,7 @@ def calculate_supp_pcp_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = (
-            "Unable to create source ESMF grid from temporary file: "
-            + tmp_file
-            + " ("
-            + str(esmf_error)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {tmp_file} ({esmf_error})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -15988,14 +14782,7 @@ def calculate_supp_pcp_weights(
             supplemental_precip.y_upper_bound - supplemental_precip.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to extract local X/Y boundaries from global grid from temporary "
-            + "file: "
-            + tmp_file
-            + " ("
-            + str(err)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {tmp_file} ({err})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -16005,9 +14792,7 @@ def calculate_supp_pcp_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="You have either specified too many cores for: "
-            + supplemental_precip.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+            msg=f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -16057,20 +14842,14 @@ def calculate_supp_pcp_weights(
     try:
         supplemental_precip.esmf_lats = supplemental_precip.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate latitude coordinate object within supplemental precip ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate latitude coordinate object within supplemental precip ESMF grid: {ge}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
     try:
         supplemental_precip.esmf_lons = supplemental_precip.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate longitude coordinate object within supplemental precip ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate longitude coordinate object within supplemental precip ESMF grid: {ge}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -16085,7 +14864,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -16140,7 +14919,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -16203,7 +14982,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in_elem = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -16260,7 +15039,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -1027,24 +1027,25 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
             except FileNotFoundError:
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {stage4_tmp_nc}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {stage4_tmp_nc}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -1618,24 +1619,25 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
             except FileNotFoundError:
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {stage4_tmp_nc}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {stage4_tmp_nc}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2593,24 +2595,19 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -3520,24 +3517,19 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -4617,24 +4609,19 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -7747,10 +7734,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
 
             # reinstituting removal - overwriting can cause issues on some file systems
             # benefits of reuse seem unclear
@@ -7758,16 +7742,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -8568,24 +8550,19 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -9857,25 +9834,23 @@ def regrid_mrms_precip_flag(
         try:
             id_tmp.close()
         except Exception as e:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {mrms_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
-            )
+            config_options.errMsg = f"Unable to close NetCDF file: {mrms_tmp_nc} - {e}\n{traceback.format_exc()}"
         try:
             os_utils.os_remove_retry(mrms_tmp_nc)
         except FileNotFoundError:
             # File doesn't exist
-            config_options.statusMsg = (
-                f"NetCDF file not found, continuing: {mrms_tmp_nc}"
+            err_handler.log_warning(
+                config_options,
+                mpi_config,
+                msg=f"NetCDF file not found, continuing: {mrms_tmp_nc}",
             )
-            err_handler.log_warning(config_options, mpi_config)
         except Exception as e:
             # Any other exception is critical
-            config_options.errMsg = (
-                f"Unable to remove NetCDF file: {mrms_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to remove NetCDF file: {mrms_tmp_nc} - {e}\n{traceback.format_exc()}",
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -10781,24 +10756,19 @@ def regrid_hourly_wrf_arw(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
-                )
+                config_options.errMsg = f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}"
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11297,26 +11267,27 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {arw_tmp_nc} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {arw_tmp_nc} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(arw_tmp_nc)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {arw_tmp_nc}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {arw_tmp_nc}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {arw_tmp_nc} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {arw_tmp_nc} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -12629,17 +12600,11 @@ def regrid_hourly_nbm(
         try:
             id_tmp.close()
         except Exception as e:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {nbm_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
-            )
+            config_options.errMsg = f"Unable to close NetCDF file: {nbm_tmp_nc} - {e}\n{traceback.format_exc()}"
         try:
             os_utils.os_remove_retry(nbm_tmp_nc)
         except Exception as e:
-            config_options.errMsg = (
-                f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
-            )
+            config_options.errMsg = f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc} - {e}\n{traceback.format_exc()}"
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -13063,17 +13028,18 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except FileNotFoundError:
-                    config_options.statusMsg = (
-                        f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
 
                 except Exception as e:
-                    config_options.errMsg = (
-                        f"Unable to remove scratch file {tmp_file}: {e}\n"
-                        f"{traceback.format_exc()}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove scratch file {tmp_file}: {e}\n{traceback.format_exc()}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -107,15 +107,20 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
     """Create a symbolic link to the input file for processing."""
     if mpi_config.rank == 0:
         try:
-            config_options.statusMsg = name + " file being used: " + input_file
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=name + " file being used: " + input_file,
+            )  # log at debug level
 
             os.symlink(input_file, tmpFile)
         except:
-            config_options.errMsg = (
-                "Unable to create link: " + input_file + " to: " + tmpFile
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create link: " + input_file + " to: " + tmpFile,
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -150,11 +155,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # exit out of this routine as the regridded fields have already been set to NDV.
         if not os.path.isfile(input_forcings.file_in2):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No AK AnA in_2 file found for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No AK AnA in_2 file found for this timestep.",
                 )  # log at debug level
             return
 
@@ -163,11 +168,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No AK AnA regridding required for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No AK AnA regridding required for this timestep.",
                 )  # log at debug level
             return
 
@@ -178,10 +183,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds = Dataset(input_forcings.file_in2, "r")
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
             # turn off automatic masking but keep scaling
             ds.set_auto_scale(True)
@@ -211,8 +217,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         coord_sys=ESMF.CoordSys.SPH_DEG,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -243,8 +252,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.y_upper_bound - input_forcings.y_lower_bound
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
                 try:
@@ -257,8 +269,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -275,8 +290,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in_elem.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
@@ -285,8 +303,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -297,8 +318,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Create out regridded numpy arrays to hold the regridded data.
@@ -336,9 +360,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             var_tmp = None
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}",
                 )  # log at debug level
                 LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
@@ -347,8 +373,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
                 elif config_options.grid_type == "unstructured":
                     try:
                         var_tmp = ds.variables[nc_var][0, :]
@@ -357,16 +386,22 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp_elem = ds.variables[nc_var][0, :]
                         var_tmp_elem = np.float32(var_tmp_elem)
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
                 elif config_options.grid_type == "hydrofabric":
                     try:
                         var_tmp = ds.variables[nc_var][0, :]
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
 
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -380,11 +415,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract ExtAnA forcing data from the AK AnA field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -403,11 +439,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds_elem]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -428,11 +465,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -447,10 +485,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close input NetCDF file: {input_forcings.file_in2}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close input NetCDF file: {input_forcings.file_in2}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -480,10 +519,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No StageIV regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No StageIV regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -503,19 +544,21 @@ def _regrid_ak_ext_ana_pcp_stage4(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + stage4_tmp_nc
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove temporary file: {stage4_tmp_nc}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Create a temporary NetCDF file from the GRIB2 file.
@@ -525,9 +568,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-6 hour acc fcst"
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"WGRIB2 command: {cmd}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
                 )  # log at debug level
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
@@ -559,9 +601,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating STAGE IV regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating STAGE IV regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip,
@@ -579,9 +623,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -594,14 +640,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -613,9 +660,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -628,14 +677,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -647,9 +697,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[
@@ -662,14 +714,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -682,9 +735,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -697,14 +752,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -716,11 +772,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -730,10 +787,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -742,11 +801,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -764,11 +824,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -783,11 +844,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -797,10 +859,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -809,11 +873,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -831,11 +896,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -849,11 +915,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -865,10 +932,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -877,11 +946,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -900,11 +970,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -919,11 +990,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -933,10 +1005,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -945,11 +1019,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -967,11 +1042,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1065,10 +1141,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No StageIV regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No StageIV regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -1087,19 +1165,21 @@ def _regrid_conus_ext_ana_pcp_stage4(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + stage4_tmp_nc
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove temporary file: {stage4_tmp_nc}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Create a temporary NetCDF file from the GRIB2 file.
@@ -1109,9 +1189,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-1 hour acc fcst"
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"WGRIB2 command: {cmd}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
                 )  # log at debug level
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
@@ -1143,9 +1222,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating STAGE IV regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating STAGE IV regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip,
@@ -1163,9 +1244,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -1178,14 +1261,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1197,9 +1281,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -1212,14 +1298,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1231,9 +1318,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[
@@ -1246,14 +1335,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp_elem,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -1266,9 +1356,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -1281,14 +1373,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1300,11 +1393,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1314,10 +1408,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1326,11 +1422,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -1348,11 +1445,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1367,11 +1465,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1381,10 +1480,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1393,11 +1494,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -1415,11 +1517,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1433,11 +1536,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1449,10 +1553,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1461,11 +1567,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -1484,11 +1591,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1503,11 +1611,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1517,10 +1626,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1529,11 +1640,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -1556,11 +1668,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 del ind_valid
                 del invalid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
             # the latest as there are no states for time 0.
@@ -1646,8 +1759,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # exit out of this routine as the regridded fields have already been set to NDV.
     if not os.path.isfile(input_forcings.file_in2):
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No HRRR in_2 file found for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No HRRR in_2 file found for this timestep.",
+            )  # log at debug level
         return
 
     # Check to see if the regrid complete flag for this
@@ -1655,8 +1772,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No HRRR regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No HRRR regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -1668,33 +1789,36 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CONUS HRRR"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS HRRR")
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = (
-                    f"Found old temporary file: {input_forcings.tmpFile} - Removing..."
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing...",
                 )
-                err_handler.log_warning(config_options, mpi_config)
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
-                    config_options.errMsg = (
-                        f"Unable to remove temporary file: {input_forcings.tmpFile}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove temporary file: {input_forcings.tmpFile}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Build GRIB2 to NetCDF conversion
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Converting HRRR Variable: {grib_var}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting HRRR Variable: {grib_var}",
                     )  # log at debug level
                 if 0 < input_forcings.cycle_freq < 60:
                     time_str = (
@@ -1752,9 +1876,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing HRRR Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing HRRR Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -1769,9 +1895,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating HRRR regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating HRRR regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -1821,17 +1949,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -1842,11 +1973,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1855,21 +1987,23 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -1899,17 +2033,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -1920,11 +2057,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1933,21 +2071,23 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -1973,17 +2113,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -1994,11 +2137,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2007,11 +2151,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -2019,11 +2164,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -2053,17 +2199,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -2074,11 +2223,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2087,21 +2237,23 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -2123,12 +2275,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2149,16 +2301,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2169,19 +2322,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2190,10 +2345,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2202,11 +2358,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2214,11 +2371,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2235,12 +2393,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2261,16 +2419,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2281,19 +2440,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2302,10 +2463,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2314,11 +2476,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2326,11 +2489,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2346,12 +2510,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2372,16 +2536,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2392,19 +2557,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -2415,10 +2582,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2427,11 +2595,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2439,11 +2608,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2460,12 +2630,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2486,16 +2656,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2506,19 +2677,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2527,10 +2700,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2539,11 +2713,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2551,11 +2726,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2578,7 +2754,6 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
@@ -2593,7 +2768,6 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -2621,8 +2795,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No RAP regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No RAP regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -2636,36 +2814,37 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CONUS RAP"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS RAP")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
-                        config_options.errMsg = (
-                            "Unable to remove file: " + input_forcings.tmpFile
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to remove file: " + input_forcings.tmpFile,
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting CONUS RAP Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting CONUS RAP Variable: " + grib_var,
                     )  # log at debug level
                 time_str = (
                     "{}-{} hour acc fcst".format(
@@ -2722,9 +2901,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing Conus RAP Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing Conus RAP Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -2739,9 +2920,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating RAP regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating RAP regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -2770,14 +2953,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2788,17 +2972,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -2809,10 +2996,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2821,21 +3010,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -2845,14 +3036,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2863,17 +3055,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -2884,10 +3079,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2896,21 +3093,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -2919,14 +3118,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2937,17 +3137,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -2958,10 +3161,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2970,11 +3175,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -2982,11 +3188,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -2996,14 +3203,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3014,17 +3222,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -3035,10 +3246,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3047,21 +3260,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -3090,16 +3305,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3110,19 +3326,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3131,12 +3349,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3145,14 +3364,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3161,11 +3381,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3205,16 +3426,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3225,19 +3447,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3246,12 +3470,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3260,14 +3485,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3276,11 +3502,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3319,16 +3546,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp_elem /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -3339,19 +3567,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -3362,12 +3592,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3376,14 +3607,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3392,11 +3624,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF element data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF element data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3437,16 +3670,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3457,19 +3691,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3478,12 +3714,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3492,14 +3729,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3508,11 +3746,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3551,7 +3790,6 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
@@ -3566,7 +3804,6 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -3597,8 +3834,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         # correction on incoming CFSv2 data. Because of the nature, we
         # need to regrid bias-corrected data every hour.
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No need to read in new CFSv2 data at this time."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No need to read in new CFSv2 data at this time.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -3612,36 +3853,39 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CFSv2"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CFSv2")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError as err:
-                        config_options.errMsg = (
-                            "Unable to remove previous temporary file: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to remove previous temporary file: "
                             + input_forcings.tmpFile
-                            + str(err)
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Converting CFSv2 Variable: " + grib_var
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting CFSv2 Variable: " + grib_var,
                     )  # log at debug level
                 fields.append(
                     ":"
@@ -3691,9 +3935,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing CFSv2 Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing CFSv2 Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -3708,9 +3954,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculate CFSv2 regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculate CFSv2 regridding weights.",
                     )  # log at debug level
 
                 calculate_weights(
@@ -3742,14 +3990,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3760,19 +4009,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3784,11 +4034,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3797,21 +4048,23 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -3821,14 +4074,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3839,19 +4093,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3863,11 +4118,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3876,21 +4132,23 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -3899,14 +4157,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -3917,19 +4176,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3941,11 +4201,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3954,11 +4215,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3966,11 +4228,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -3980,14 +4243,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3998,19 +4262,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -4022,11 +4287,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4035,21 +4301,23 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -4074,28 +4342,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4162,11 +4431,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4178,14 +4448,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4194,14 +4465,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4209,10 +4481,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4238,28 +4512,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4326,11 +4601,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4342,14 +4618,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4358,14 +4635,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4373,10 +4651,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4401,28 +4681,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4491,11 +4772,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4507,14 +4789,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4523,14 +4806,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4538,10 +4822,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4567,28 +4853,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4655,11 +4942,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4671,14 +4959,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4687,14 +4976,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4702,10 +4992,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4736,7 +5028,6 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
@@ -4751,7 +5042,6 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -4784,10 +5074,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No NWM NetCDF regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NWM NetCDF regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4795,15 +5087,18 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         input_forcings.file_in2, config_options, mpi_config, open_on_all_procs=True
     )
 
-    config_options.statusMsg = "Regrid NWM Custom NetCDF Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid NWM Custom NetCDF Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Processing Custom NetCDF Forcing Variable: " + nc_var
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+            )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4825,35 +5120,37 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                f"Downscaling will not be available."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
+            )  # log at debug level
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4864,10 +5161,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4877,11 +5176,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4889,11 +5189,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4910,25 +5211,26 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4939,10 +5241,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4952,11 +5256,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4964,11 +5269,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4984,25 +5290,26 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -5013,10 +5320,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5026,11 +5335,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5038,11 +5348,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5059,25 +5370,26 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5088,10 +5400,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5101,11 +5415,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5113,11 +5428,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5159,10 +5475,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No NWM NetCDF regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NWM NetCDF regridding required for this timestep.",
+            )  # log at debug level
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -5186,15 +5504,18 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 longitude=(["y", "x"], lon_coords), latitude=(["y", "x"], lat_coords)
             )
 
-    config_options.statusMsg = "Regrid NWM Custom zarr Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid NWM Custom zarr Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Processing Custom zarr Forcing Variable: " + nc_var
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing Custom zarr Forcing Variable: " + nc_var,
+            )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -5215,35 +5536,36 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                f"Downscaling will not be available."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
             )
-            err_handler.log_msg(config_options, mpi_config)
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5254,10 +5576,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5267,11 +5591,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5279,11 +5604,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5300,25 +5626,26 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5329,10 +5656,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5342,11 +5671,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5354,11 +5684,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5374,25 +5705,26 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -5403,10 +5735,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5416,11 +5750,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5428,11 +5763,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5449,25 +5785,26 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # convert to array for NWM
@@ -5482,10 +5819,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5495,11 +5834,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5507,11 +5847,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5569,11 +5910,11 @@ def regrid_custom_hourly_netcdf(
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No Custom Hourly NetCDF regridding required for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No Custom Hourly NetCDF regridding required for this timestep.",
                 )  # log at debug level
             return
 
@@ -5593,16 +5934,19 @@ def regrid_custom_hourly_netcdf(
             "DLWRF": 310.0,
         }
 
-        config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            msg="Regrid Custom Hourly NetCDF Forcing Variables",
+        )
 
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Processing Custom NetCDF Forcing Variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
                 )  # log at debug level
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -5649,19 +5993,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out = (
@@ -5672,11 +6017,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5685,10 +6031,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5696,11 +6044,12 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                     elif config_options.grid_type == "unstructured":
@@ -5719,19 +6068,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out = (
@@ -5742,11 +6092,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5755,10 +6106,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5766,11 +6119,12 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Regrid the height variable.
@@ -5790,19 +6144,20 @@ def regrid_custom_hourly_netcdf(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out_elem = (
@@ -5813,11 +6168,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5826,10 +6182,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5837,11 +6195,12 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                     elif config_options.grid_type == "hydrofabric":
@@ -5860,19 +6219,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out = (
@@ -5883,11 +6243,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5896,10 +6257,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5907,21 +6270,22 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                 else:
                     input_forcings.height = None
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                            f"Downscaling will not be available."
+                        err_handler.log_msg(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
                         )
-                        err_handler.log_msg(config_options, mpi_config)
 
                 # close netCDF file on non-root ranks
                 if mpi_config.rank != 0:
@@ -5934,31 +6298,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -5969,10 +6334,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5982,11 +6349,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -5995,11 +6363,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -6017,11 +6386,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6029,11 +6399,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6053,31 +6424,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -6088,10 +6460,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6101,11 +6475,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6114,11 +6489,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -6135,11 +6511,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6147,11 +6524,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6170,31 +6548,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -6205,10 +6584,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6220,11 +6601,12 @@ def regrid_custom_hourly_netcdf(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6233,11 +6615,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -6257,11 +6640,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6269,11 +6653,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6293,31 +6678,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -6327,10 +6713,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6340,11 +6728,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6353,11 +6742,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if nc_var == "DSWRF_surface":
@@ -6379,11 +6769,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6391,11 +6782,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6442,10 +6834,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No ERA5-Interim regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No ERA5-Interim regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -6468,15 +6862,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     )
     ind = np.where(seconds_index == np.min(seconds_index))[0][0]
 
-    config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid Custom Hourly NetCDF Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Processing ERA-5 Interim Forcing Variable: " + nc_var
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing ERA-5 Interim Forcing Variable: " + nc_var,
+            )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -6503,11 +6900,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             else:
                 input_forcings.height = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Unable to locate Geopoential height in: {input_forcings.file_in2}. "
-                        f"Downscaling will not be available."
+                    err_handler.log_msg(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to locate Geopoential height in: {input_forcings.file_in2}. Downscaling will not be available.",
                     )
-                    err_handler.log_msg(config_options, mpi_config)
 
             # close netCDF file on non-root ranks
             if mpi_config.rank != 0:
@@ -6518,18 +6915,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
@@ -6544,16 +6941,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6564,10 +6962,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6577,11 +6977,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6590,11 +6991,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6606,11 +7008,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6618,11 +7021,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6639,18 +7043,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
@@ -6665,16 +7069,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6685,10 +7090,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6698,11 +7105,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6711,11 +7119,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6727,11 +7136,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6739,11 +7149,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6759,18 +7170,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.0)[
                         ind, :, :
@@ -6789,16 +7200,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -6809,10 +7221,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6822,11 +7236,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6835,11 +7250,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask_elem == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6853,11 +7269,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6866,11 +7283,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ] = input_forcings.esmf_field_out_elem.data
 
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6887,18 +7305,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
@@ -6913,16 +7331,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6933,10 +7352,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6946,11 +7367,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6959,11 +7381,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6975,11 +7398,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6987,11 +7411,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -7041,10 +7466,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No 13km GFS regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No 13km GFS regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a temporary NetCDF file name to hold converted GRIB2 data.
@@ -7069,36 +7496,39 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regridding 13km GFS Variables."
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(
+            config_options, mpi_config, msg="Regridding 13km GFS Variables."
+        )
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = (
-                    "Found old temporary file: "
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg="Found old temporary file: "
                     + input_forcings.tmpFile
-                    + " - Removing....."
+                    + " - Removing.....",
                 )
-                err_handler.log_warning(config_options, mpi_config)
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
-                    config_options.errMsg = (
-                        "Unable to remove file: " + input_forcings.tmpFile
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to remove file: " + input_forcings.tmpFile,
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting 13km GFS Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting 13km GFS Variable: " + grib_var,
                     )  # log at debug level
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
@@ -7173,9 +7603,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing 13km GFS Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing 13km GFS Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -7190,11 +7622,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating 13km GFS regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating 13km GFS regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -7225,14 +7657,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -7245,14 +7678,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -7265,14 +7699,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -7285,14 +7720,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -7303,17 +7739,20 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local GFS array into an ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local GFS array into an ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding 13km GFS surface elevation data to the WRF-Hydro domain."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain.",
                     )  # log at debug level
                 if config_options.grid_type == "gridded":
                     try:
@@ -7325,10 +7764,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data: " + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7337,11 +7777,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -7354,21 +7795,23 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data with ESMF mesh nodes: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data with ESMF mesh nodes: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local GFS array into an ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place local GFS array into an ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -7380,11 +7823,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data with ESMF mesh elements: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data with ESMF mesh elements: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7393,11 +7837,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7406,11 +7851,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
                     try:
@@ -7422,10 +7868,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data: " + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7434,32 +7881,35 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -7467,22 +7917,24 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field with mesh elements: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field with mesh elements: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -7509,16 +7961,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
                 var_tmp = None
@@ -7528,16 +7981,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_tmp_elem = None
@@ -7547,16 +8001,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 var_tmp = None
@@ -7566,16 +8021,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are regridding GFS data, and this is precipitation, we need to run calculations
@@ -7646,50 +8102,54 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if config_options.grid_type == "gridded":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7700,21 +8160,22 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding took {} seconds".format(
-                            end - begin
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding took {} seconds".format(end - begin),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7723,14 +8184,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7738,11 +8200,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7756,12 +8219,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "unstructured":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh nodes: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field for Mesh nodes: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7772,21 +8235,22 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Node Regridding took {} seconds".format(end - begin)
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Node Regridding took {} seconds".format(end - begin),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Nodes: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable for Mesh Nodes: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7795,14 +8259,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7810,11 +8275,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7827,12 +8293,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field for Mesh elements: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7845,21 +8311,24 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Element Regridding took {} seconds".format(end - begin)
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Element Regridding took {} seconds".format(
+                                end - begin
+                            ),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Elements: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable for Mesh Elements: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7868,14 +8337,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7883,11 +8353,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7901,12 +8372,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "hydrofabric":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field for Mesh Elements: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7917,21 +8388,24 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Element Regridding took {} seconds".format(end - begin)
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Element Regridding took {} seconds".format(
+                                end - begin
+                            ),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Element: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable for Mesh Element: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7940,14 +8414,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7955,11 +8430,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7981,7 +8457,6 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
             # reinstituting removal - overwriting can cause issues on some file systems
             # benefits of reuse seem unclear
@@ -7999,7 +8474,6 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -8027,8 +8501,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        config_options.statusMsg = "No regridding of NAM nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="No regridding of NAM nest data necessary for this timestep - already completed.",
+        )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -8042,19 +8520,19 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regridding NAM nest data"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regridding NAM nest data")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
@@ -8064,11 +8542,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting NAM-Nest Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting NAM-Nest Variable: " + grib_var,
                     )  # log at debug level
                 fields.append(
                     ":"
@@ -8121,9 +8599,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing NAM Nest Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing NAM Nest Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -8138,11 +8618,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating NAM nest regridding weights...."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating NAM nest regridding weights....",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -8180,17 +8660,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -8201,11 +8684,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8214,21 +8698,23 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -8247,17 +8733,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -8268,11 +8757,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8281,21 +8771,23 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -8313,17 +8805,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -8334,11 +8829,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8347,11 +8843,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -8359,11 +8856,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -8382,17 +8880,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -8403,11 +8904,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8416,21 +8918,23 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -8454,28 +8958,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -8486,10 +8991,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8499,11 +9006,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8512,11 +9020,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8524,11 +9033,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8545,28 +9055,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -8577,10 +9088,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8590,11 +9103,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8603,11 +9117,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8615,11 +9130,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8635,28 +9151,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -8667,10 +9184,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8682,11 +9201,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8695,11 +9215,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8707,11 +9228,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8728,28 +9250,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -8760,10 +9283,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8773,11 +9298,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8786,11 +9312,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8798,11 +9325,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8825,7 +9353,6 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
@@ -8840,7 +9367,6 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -8864,8 +9390,11 @@ def regrid_mrms_hourly(
     # Do we want to use MRMS data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Exceeded max hours for MRMS precipitation"
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Exceeded max hours for MRMS precipitation",
+            )
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -8882,8 +9411,12 @@ def regrid_mrms_hourly(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No MRMS regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No MRMS regridding required for this timestep.",
+            )  # log at debug level
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -8915,11 +9448,11 @@ def regrid_mrms_hourly(
     # alert the user, and set the final output grids to be the global NDV and return.
     if not supplemental_precip.file_in1 or not supplemental_precip.file_in2:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No MRMS Precipitation available. Supplemental precipitation will "
-                "not be used."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="No MRMS Precipitation available. Supplemental precipitation will not be used.",
             )
-            err_handler.log_msg(config_options, mpi_config)
         supplemental_precip.regridded_precip2 = None
         supplemental_precip.regridded_precip1 = None
         if config_options.grid_type == "unstructured":
@@ -8943,8 +9476,7 @@ def regrid_mrms_hourly(
     id_mrms = None
     id_mrms_rqi = None
     try:
-        config_options.statusMsg = "Rrgrid MRMS"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Rrgrid MRMS")
 
         if supplemental_precip.file_type != NETCDF:
             # Unzip MRMS files to temporary locations.
@@ -9031,9 +9563,11 @@ def regrid_mrms_hourly(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating MRMS regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating MRMS regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config
@@ -9050,16 +9584,17 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + supplemental_precip.rqi_netcdf_var_names[0]
                             + " from: "
                             + mrms_tmp_rqi_grib2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9070,16 +9605,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place MRMS data into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
                     )  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out = (
@@ -9090,10 +9629,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid MRMS RQI field: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9101,21 +9641,23 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
                             )  # log at debug level
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation for MRMS RQI data: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             elif config_options.grid_type == "unstructured":
@@ -9126,16 +9668,17 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + supplemental_precip.rqi_netcdf_var_names[0]
                             + " from: "
                             + mrms_tmp_rqi_grib2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9146,16 +9689,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place MRMS data into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
                     )  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out = (
@@ -9166,10 +9713,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid MRMS RQI field: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9177,21 +9725,23 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
                             )  # log at debug level
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation for MRMS RQI data: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_tmp_elem = None
@@ -9201,16 +9751,17 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + supplemental_precip.rqi_netcdf_var_names[0]
                             + " from: "
                             + mrms_tmp_rqi_grib2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9221,16 +9772,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place MRMS data into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
                     )  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out_elem = (
@@ -9241,10 +9796,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid MRMS RQI field: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9252,21 +9808,23 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask_elem == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
                             )  # log at debug level
 
                     supplemental_precip.esmf_field_out_elem.data[
                         np.where(supplemental_precip.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation for MRMS RQI data: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
         if not supplemental_precip.rqiMethod:
@@ -9280,9 +9838,11 @@ def regrid_mrms_hourly(
                 supplemental_precip.regridded_rqi2[:] = 1.0
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = "MRMS Will not be filtered using RQI values."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="MRMS Will not be filtered using RQI values.",
                 )  # log at debug level
 
         elif supplemental_precip.rqiMethod == 2:
@@ -9314,27 +9874,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9352,10 +9913,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9372,10 +9934,12 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -9393,19 +9957,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -9420,11 +9987,12 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run global NDV search on MRMS regridded precip: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9442,27 +10010,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9480,10 +10049,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9500,10 +10070,12 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -9521,19 +10093,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -9548,11 +10123,12 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run global NDV search on MRMS regridded precip: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9569,27 +10145,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9609,10 +10186,11 @@ def regrid_mrms_hourly(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9632,10 +10210,12 @@ def regrid_mrms_hourly(
                     # err_handler.log_warning(config_options, mpi_config)
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -9653,19 +10233,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter_elem) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = (
                         config_options.globalNdv
                     )
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -9679,11 +10262,12 @@ def regrid_mrms_hourly(
                 )
                 del ind_valid_elem
             except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run global NDV search on MRMS regridded precip: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run global NDV search on MRMS regridded precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9701,27 +10285,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9739,10 +10324,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9759,10 +10345,12 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -9780,19 +10368,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -9807,11 +10398,12 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run global NDV search on MRMS regridded precip: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9831,17 +10423,21 @@ def regrid_mrms_hourly(
             try:
                 id_mrms.close()
             except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {mrms_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {mrms_tmp_nc}",
+                )
 
         if id_mrms_rqi is not None:
             try:
                 id_mrms_rqi.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
         if mpi_config.rank == 0:
             for f in (mrms_tmp_grib2, mrms_tmp_nc, mrms_tmp_rqi_grib2, mrms_tmp_rqi_nc):
@@ -9849,8 +10445,11 @@ def regrid_mrms_hourly(
                     try:
                         os_utils.os_remove_retry(f)
                     except OSError:
-                        config_options.errMsg = f"Unable to remove scratch file: {f}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove scratch file: {f}",
+                        )
         mpi_config.comm.barrier()
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -9915,8 +10514,11 @@ def regrid_mrms_precip_flag(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Calculating MRMS PrecipFlag regridding weights."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Calculating MRMS PrecipFlag regridding weights.",
+            )
         calculate_supp_pcp_weights(
             supplemental_precip,
             id_tmp,
@@ -9930,19 +10532,21 @@ def regrid_mrms_precip_flag(
     var_tmp = None
     if mpi_config.rank == 0:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Regridding MRMS PrecipFlag Fraction."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options, mpi_config, msg="Regridding MRMS PrecipFlag Fraction."
+            )
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to extract PrecipFlag from file: "
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to extract PrecipFlag from file: "
                 + supplemental_precip.file_in2
                 + " ("
                 + str(err)
-                + ")"
+                + ")",
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     var_sub_tmp = mpi_config.scatter_array(supplemental_precip, var_tmp, config_options)
@@ -9956,10 +10560,11 @@ def regrid_mrms_precip_flag(
 
         supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to place MRMS PrecipFlag into local ESMF field: " + str(err)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to place MRMS PrecipFlag into local ESMF field: " + str(err),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -9969,8 +10574,11 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_out,
         )
     except ValueError as ve:
-        config_options.errMsg = "Unable to regrid MRMS PrecipFlag: " + str(ve)
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -9982,10 +10590,11 @@ def regrid_mrms_precip_flag(
             np.where(supplemental_precip.esmf_field_out.data < 0)
         ] = 1.0
     except (ValueError, ArithmeticError) as npe:
-        config_options.errMsg = "Unable to run mask search on MRMS PrecipFlag: " + str(
-            npe
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     supplemental_precip.regridded_precip2[:] = supplemental_precip.esmf_field_out.data
@@ -10004,21 +10613,25 @@ def regrid_mrms_precip_flag(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding MRMS PrecipFlag Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding MRMS PrecipFlag Fraction.",
+                )
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_precip.netcdf_var_names[0]
                 ][0, :, :]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract PrecipFlag from file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract PrecipFlag from file: "
                     + supplemental_precip.file_in2
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp_elem = mpi_config.scatter_array(
@@ -10036,10 +10649,12 @@ def regrid_mrms_precip_flag(
 
             supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place MRMS PrecipFlag into local ESMF field: " + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place MRMS PrecipFlag into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -10049,8 +10664,11 @@ def regrid_mrms_precip_flag(
                 supplemental_precip.esmf_field_out_elem,
             )
         except ValueError as ve:
-            config_options.errMsg = "Unable to regrid MRMS PrecipFlag: " + str(ve)
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10062,10 +10680,11 @@ def regrid_mrms_precip_flag(
                 np.where(supplemental_precip.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on MRMS PrecipFlag: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_precip.regridded_precip2_elem[:] = (
@@ -10090,7 +10709,6 @@ def regrid_mrms_precip_flag(
                 f"Unable to close NetCDF file: {mrms_tmp_nc} - {e}\n"
                 f"{traceback.format_exc()}"
             )
-            err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(mrms_tmp_nc)
         except FileNotFoundError:
@@ -10135,8 +10753,12 @@ def regrid_hourly_wrf_arw(
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        config_options.statusMsg = "No regridding of WRF-ARW nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed.",
+        )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -10151,20 +10773,20 @@ def regrid_hourly_wrf_arw(
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid WRF-ARW nest data"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid WRF-ARW nest data")
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
@@ -10174,11 +10796,11 @@ def regrid_hourly_wrf_arw(
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting WRF-ARW Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting WRF-ARW Variable: " + grib_var,
                     )  # log at debug level
                 time_str = (
                     "{}-{} hour acc fcst".format(
@@ -10238,9 +10860,11 @@ def regrid_hourly_wrf_arw(
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing WRF-ARW Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing WRF-ARW Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -10255,11 +10879,11 @@ def regrid_hourly_wrf_arw(
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating WRF-ARW regridding weights...."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating WRF-ARW regridding weights....",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -10297,19 +10921,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -10320,11 +10945,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10333,21 +10959,23 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     # Regrid the height variable.
@@ -10365,19 +10993,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -10388,11 +11017,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10401,21 +11031,23 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -10433,19 +11065,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -10456,11 +11089,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10469,11 +11103,12 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -10481,11 +11116,12 @@ def regrid_hourly_wrf_arw(
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -10504,19 +11140,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -10527,11 +11164,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10540,21 +11178,23 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -10578,28 +11218,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -10610,10 +11251,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10623,11 +11266,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10636,11 +11280,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10660,11 +11305,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10672,11 +11318,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10693,28 +11340,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -10725,10 +11373,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10738,11 +11388,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10751,11 +11402,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10775,11 +11427,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10787,11 +11440,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10807,28 +11461,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -10839,10 +11494,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10854,11 +11511,12 @@ def regrid_hourly_wrf_arw(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10867,11 +11525,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10892,11 +11551,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10904,11 +11564,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10925,28 +11586,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -10957,10 +11619,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10970,11 +11634,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10983,11 +11648,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -11007,11 +11673,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11019,11 +11686,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -11046,7 +11714,6 @@ def regrid_hourly_wrf_arw(
                     f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
@@ -11061,7 +11728,6 @@ def regrid_hourly_wrf_arw(
                     f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
                     f"{traceback.format_exc()}"
                 )
-                err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11092,8 +11758,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No ARW regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No ARW regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -11104,17 +11774,19 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid ARW"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid ARW")
 
         if supplemental_precip.file_type != NETCDF:
             # These files shouldn't exist. If they do, remove them.
             if mpi_config.rank == 0:
                 if os.path.isfile(arw_tmp_nc):
-                    config_options.statusMsg = (
-                        "Found old temporary file: " + arw_tmp_nc + " - Removing....."
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
+                        + arw_tmp_nc
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(arw_tmp_nc)
                     except IOError:
@@ -11182,9 +11854,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating WRF ARW regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating WRF ARW regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config
@@ -11196,21 +11870,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11221,11 +11898,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11235,10 +11913,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11247,11 +11927,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -11269,11 +11950,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11289,21 +11971,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11314,11 +11999,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11328,10 +12014,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11340,11 +12028,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -11362,11 +12051,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11381,21 +12071,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -11406,11 +12099,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11422,10 +12116,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11434,11 +12130,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -11457,11 +12154,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid_elem
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11477,21 +12175,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11502,11 +12203,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11516,10 +12218,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11528,11 +12232,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -11550,11 +12255,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11633,10 +12339,12 @@ def regrid_sbcv2_liquid_water_fraction(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Calculating SBCv2 Liquid Water Fraction regridding weights."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Calculating SBCv2 Liquid Water Fraction regridding weights.",
+            )  # log at debug level
         calculate_supp_pcp_weights(
             supplemental_forcings,
             id_tmp,
@@ -11653,19 +12361,23 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding SBCv2 Liquid Water Fraction.",
+                )
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -11678,11 +12390,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11692,10 +12405,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11707,10 +12421,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -11731,23 +12447,24 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction - unstructured"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding SBCv2 Liquid Water Fraction - unstructured",
                 )  # log at debug level
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -11760,11 +12477,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11774,10 +12492,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11789,10 +12508,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -11812,25 +12533,26 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction input variable."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding SBCv2 Liquid Water Fraction input variable.",
                 )  # log at debug level
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_forcings.netcdf_var_names[0]
                 ][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp_elem = mpi_config.scatter_array(
@@ -11843,11 +12565,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp_elem / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11859,10 +12582,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 )
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11874,10 +12598,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2_elem[:] = (
@@ -11898,21 +12624,23 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction - hydrofabric"
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding SBCv2 Liquid Water Fraction - hydrofabric",
                 )
-                err_handler.log_msg(config_options, mpi_config)
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -11925,11 +12653,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11939,10 +12668,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11954,10 +12684,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -11978,10 +12710,11 @@ def regrid_sbcv2_liquid_water_fraction(
         try:
             id_tmp.close()
         except OSError:
-            config_options.errMsg = (
-                "Unable to close NetCDF file: " + supplemental_forcings.file_in1
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to close NetCDF file: " + supplemental_forcings.file_in1,
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -12004,10 +12737,11 @@ def regrid_hourly_nbm(
     # Do we want to use NBM data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Exceeded max hours for NBM data, will not use NBM in final layering."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Exceeded max hours for NBM data, will not use NBM in final layering.",
             )
-            err_handler.log_msg(config_options, mpi_config)
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -12027,24 +12761,30 @@ def regrid_hourly_nbm(
 
     if mpi_config.rank == 0:
         if os.path.isfile(nbm_tmp_nc):
-            config_options.statusMsg = (
-                "Found old temporary file: " + nbm_tmp_nc + " - Removing....."
+            err_handler.log_warning(
+                config_options,
+                mpi_config,
+                msg="Found old temporary file: " + nbm_tmp_nc + " - Removing.....",
             )
-            err_handler.log_warning(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
             except OSError:
-                config_options.errMsg = "Unable to remove file: " + nbm_tmp_nc
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to remove file: " + nbm_tmp_nc,
+                )
     err_handler.check_program_status(config_options, mpi_config)
 
     if forcings_or_precip.grib_vars is not None:
         fields = []
         for force_count, grib_var in enumerate(forcings_or_precip.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Converting NBM Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Converting NBM Variable: " + grib_var,
                 )  # log at debug level
             time_str = (
                 "{}-{} hour acc fcst".format(
@@ -12108,13 +12848,16 @@ def regrid_hourly_nbm(
 
     err_handler.check_program_status(config_options, mpi_config)
 
-    config_options.statusMsg = "Processing NBM Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(config_options, mpi_config, msg="Processing NBM Variables")
 
     for force_count, nc_var in enumerate(forcings_or_precip.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Processing NBM Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing NBM Variable: " + nc_var,
+            )  # log at debug level
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -12142,11 +12885,11 @@ def regrid_hourly_nbm(
         if calc_regrid_flag:
             if is_supp:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Calculating NBM {tag} regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Calculating NBM {tag} regridding weights.",
                     )  # log at debug level
                 calculate_supp_pcp_weights(
                     forcings_or_precip,
@@ -12158,11 +12901,11 @@ def regrid_hourly_nbm(
                 err_handler.check_program_status(config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Calculating NBM {tag} regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Calculating NBM {tag} regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -12176,15 +12919,19 @@ def regrid_hourly_nbm(
 
                 # Regrid the height variable.
                 if config_options.grid_meta is None:
-                    config_options.errMsg = (
-                        "No NBM height file supplied, downscaling will not be available"
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="No NBM height file supplied, downscaling will not be available",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     if not os.path.exists(config_options.grid_meta):
-                        config_options.errMsg = 'NBM height file "{config_options.grid_meta}" does not exist'
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg='NBM height file "{config_options.grid_meta}" does not exist',
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     terrain_tmp = os.path.join(
@@ -12214,19 +12961,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -12237,11 +12985,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12250,11 +12999,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12262,11 +13012,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12286,19 +13037,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -12309,11 +13061,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12322,11 +13075,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12334,11 +13088,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12358,19 +13113,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -12381,11 +13137,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12394,11 +13151,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12406,11 +13164,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12429,17 +13188,20 @@ def regrid_hourly_nbm(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = "Regridding NBM elevation data to the unstructured domain."
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the unstructured domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out_elem = (
@@ -12450,11 +13212,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the unstructured domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the unstructured domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12463,11 +13226,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute element mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute element mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12475,11 +13239,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12489,21 +13254,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -12514,10 +13282,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12527,8 +13296,11 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -12537,11 +13309,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -12575,10 +13348,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12590,21 +13365,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -12615,10 +13393,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12628,8 +13407,11 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -12637,11 +13419,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -12675,10 +13458,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12690,21 +13475,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -12715,10 +13503,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12728,8 +13517,11 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -12737,11 +13529,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -12775,10 +13568,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12790,21 +13585,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -12815,10 +13613,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12830,8 +13629,11 @@ def regrid_hourly_nbm(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -12839,11 +13641,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1_elem = (
@@ -12881,10 +13684,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12902,7 +13707,6 @@ def regrid_hourly_nbm(
                 f"Unable to close NetCDF file: {nbm_tmp_nc} - {e}\n"
                 f"{traceback.format_exc()}"
             )
-            err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(nbm_tmp_nc)
         except Exception as e:
@@ -12910,7 +13714,6 @@ def regrid_hourly_nbm(
                 f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc} - {e}\n"
                 f"{traceback.format_exc()}"
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -12926,12 +13729,15 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No NDFD regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NDFD regridding required for this timestep.",
+            )  # log at debug level
         return
 
-    config_options.statusMsg = "Regrid NDFD"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(config_options, mpi_config, msg="Regrid NDFD")
 
     hour = input_forcings.fcst_hour2
     current_cycle = config_options.current_fcst_cycle
@@ -12957,41 +13763,45 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         # Temp file may exist. If it does, and we don't need it again, remove it.....
         if not reuse_prev_file and mpi_config.rank == 0:
             if os.path.isfile(tmp_file):
-                config_options.statusMsg = f"Deleting old temporary file: {tmp_file}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Deleting old temporary file: {tmp_file}",
                 )  # log at debug level
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
-                    config_options.errMsg = f"Unable to remove file: {tmp_file}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove file: {tmp_file}",
+                    )
         err_handler.check_program_status(config_options, mpi_config)
 
         id_tmp = None
         try:
             if reuse_prev_file:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Cycle unchanged, reusing temporary file: {tmp_file}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Cycle unchanged, reusing temporary file: {tmp_file}",
                     )  # log at debug level
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}",
                     )  # log at debug level
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
                 else:
-                    cmd = (
-                        f"$WGRIB2 -match :d={current_cycle.strftime('%Y%m%d%H')}: -vt {grb_file} | "
-                        f"sort -t = -k 2 | $WGRIB2 -i -netcdf {tmp_file} {grb_file}"
-                    )
+                    cmd = f"$WGRIB2 -match :d={current_cycle.strftime('%Y%m%d%H')}: -vt {grb_file} | sort -t = -k 2 | $WGRIB2 -i -netcdf {tmp_file} {grb_file}"
                 id_tmp = ioMod.open_grib2(
                     grb_file,
                     tmp_file,
@@ -13008,43 +13818,49 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 times = [datetime.utcfromtimestamp(t) for t in id_tmp["time"][:]]
                 if ndfd_var != "qpf":
                     if forecast_time > times[-1] + timedelta(hours=3):
-                        config_options.statusMsg = (
-                            "Forecast time beyond NDFD range, skipping"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Forecast time beyond NDFD range, skipping",
                         )  # log at debug level
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
-                        config_options.statusMsg = f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}",
                         )  # log at debug level
                     else:
                         time_index = min(
                             range(len(times)),
                             key=lambda i: abs(times[i] - forecast_time),
                         )
-                        config_options.statusMsg = f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}",
                         )  # log at debug level
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
-                        config_options.statusMsg = (
-                            "Forecast time beyond NDFD precip range, skipping"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Forecast time beyond NDFD precip range, skipping",
                         )  # log at debug level
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
-                        config_options.statusMsg = f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}",
                         )  # log at debug level
 
             skip_file = mpi_config.broadcast_parameter(
@@ -13071,9 +13887,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 continue
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing NDFD variable: " + ndfd_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing NDFD variable: " + ndfd_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -13088,9 +13906,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating NDFD regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating NDFD regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -13117,11 +13937,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         ][time_index, :, :]
                         var_tmp_elem = var_tmp_elem.filled(config_options.globalNdv)
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} "
-                        f"from: {input_forcings.tmpFile} ({err})"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} from: {input_forcings.tmpFile} ({err})",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -13144,10 +13964,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_in_elem.data[:] = var_sub_tmp_elem
                 # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -13165,10 +13987,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid input NDFD forcing variable using ESMF: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input NDFD forcing variable using ESMF: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and fix missings that were interpolated
@@ -13183,8 +14006,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # input_forcings.esmf_field_out.data[np.where((input_forcings.esmf_field_out.data/config_options.globalNdv) > 0.75)] = \
                 #     config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input NDFD regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input NDFD regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If processing wind speed, calculate final U2 / V2 fields
@@ -13235,8 +14061,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     AttributeError,
                     KeyError,
                 ) as npe:
-                    config_options.errMsg = f"Unable to convert NDFD wind speed/dir to U/V components: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to convert NDFD wind speed/dir to U/V components: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -13258,10 +14087,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NDFD QPF precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NDFD QPF precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -13281,11 +14111,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[i], :
                     ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
         finally:
             # always close the NetCDF handle
@@ -13293,10 +14124,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     id_tmp.close()
                 except OSError as e:
-                    config_options.errMsg = (
-                        f"Unable to close NDFD temp file {tmp_file}: {e}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to close NDFD temp file {tmp_file}: {e}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
 
             # only remove the scratch file if this was a new‐cycle run
             if (
@@ -13341,17 +14173,21 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         mpi_config.comm.barrier()
         id_tmp = config_options.aws_obj
 
-        config_options.statusMsg = "Processing Custom NetCDF Forcing Variables"
-        err_handler.log_msg(config_options, mpi_config, True)
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="Processing Custom NetCDF Forcing Variables",
+        )
 
     with timing_block(f"regrid step 2 | {mpi_config.rank}: loop over variables"):
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Processing Custom NetCDF Forcing Variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
                 )  # log at debug level
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
@@ -13398,31 +14234,32 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -13433,10 +14270,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13446,11 +14285,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -13459,11 +14299,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -13481,11 +14322,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13493,11 +14335,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -13517,31 +14360,32 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -13552,10 +14396,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13565,11 +14411,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -13578,11 +14425,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -13599,11 +14447,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13611,11 +14460,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -13634,31 +14484,32 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -13669,10 +14520,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13684,11 +14537,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -13697,11 +14551,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -13721,11 +14576,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13733,11 +14589,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -13764,21 +14621,21 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     with timing_block(
                         f"regrid step 2.5.1 | {mpi_config.rank}: regrid messages"
                     ):
-                        config_options.statusMsg = (
-                            "Regridding Custom netCDF input variable: " + nc_var
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding Custom netCDF input variable: " + nc_var,
                         )  # log at debug level
                     try:
                         with timing_block(
                             f"regrid step 2.5.2 | {mpi_config.rank}: messages2"
                         ):
-                            config_options.statusMsg = (
-                                f"Using {fill} to replace missing values in input"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Using {fill} to replace missing values in input",
                             )  # log at debug level
                         with timing_block(
                             f"regrid step 2.5.3 | {mpi_config.rank}: fill missing"
@@ -13789,8 +14646,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         with timing_block(
                             f"regrid step 2.5.4 | {mpi_config.rank}: extract error"
                         ):
-                            config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                            )
 
                 with timing_block(
                     f"regrid step 2.5.5 | {mpi_config.rank}: check program status"
@@ -13810,11 +14670,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local array into local ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place local array into local ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13829,11 +14690,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13845,11 +14707,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = fill
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13875,11 +14738,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             AttributeError,
                             KeyError,
                         ) as npe:
-                            config_options.errMsg = (
-                                "Unable to run NDV search on Custom netCDF precipitation: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to run NDV search on Custom netCDF precipitation: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13890,11 +14754,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local ESMF regridded data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place local ESMF regridded data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13939,13 +14804,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
         elif config_options.grid_type == "unstructured":
             try:
@@ -13955,13 +14821,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field node mesh object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
@@ -13969,13 +14836,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field element mesh object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
         elif config_options.grid_type == "hydrofabric":
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
@@ -13984,13 +14852,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field element mesh object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14360,8 +15229,12 @@ def load_weight_file(
         field_out = input_forcings.esmf_field_out_elem
         target_object_attr_name = "regridObj_elem"
 
-    config_options.statusMsg = f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}"
-    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.log_msg(
+        config_options,
+        mpi_config,
+        debug=True,
+        msg=f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}",
+    )  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
     try:
@@ -14372,13 +15245,19 @@ def load_weight_file(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = (
-            f"Unable to load cached ESMF{msg_augment}weight file: " + str(esmf_error)
+        err_handler.log_warning(
+            config_options,
+            mpi_config,
+            msg=f"Unable to load cached ESMF{msg_augment}weight file: "
+            + str(esmf_error),
         )
-        err_handler.log_warning(config_options, mpi_config)
     else:
-        config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds"
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg=f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds",
+        )  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14412,8 +15291,9 @@ def make_regrid(
 
     start_msg = f"RANK: {mpi_config.rank}: Creating{msg_augment}weight object from ESMF. weight_file={weight_file}"
     if mpi_config.rank == 0:
-        config_options.statusMsg = start_msg
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options, mpi_config, debug=True, msg=start_msg
+        )  # log at debug level
 
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[
@@ -14438,17 +15318,22 @@ def make_regrid(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = (
-            f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
-            + str(esmf_error)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
+            + str(esmf_error),
         )
-        err_handler.log_critical(config_options, mpi_config)
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
     else:
         if mpi_config.rank == 0:
-            config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds",
+            )  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14481,14 +15366,20 @@ def execute_regrid(
             input_forcings, target_object_attr_name, regrid_object(field_in, field_out)
         )
     except ValueError as ve:
-        config_options.errMsg = (
-            "Unable to extract regridded data from ESMF regridded field: " + str(ve)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to extract regridded data from ESMF regridded field: "
+            + str(ve),
         )
-        err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
         if weight_file is not None:
-            config_options.statusMsg = f"Deleting if exists: {weight_file}"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Deleting if exists: {weight_file}",
+            )  # log at debug level
             try:
                 os_utils.os_remove_retry(weight_file)
             except FileNotFoundError:
@@ -14527,8 +15418,9 @@ def calculate_weights(
         esmf_grid_retry, mpi_config, config_options, err_handler
     )
 
-    config_options.statusMsg = "Calculate Weights"
-    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.log_msg(
+        config_options, mpi_config, debug=True, msg="Calculate Weights"
+    )  # log at debug level
 
     if mpi_config.rank == 0:
         if config_options.aws:
@@ -14537,54 +15429,58 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[0]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Y shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Y shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object"
+                    + " from aws object",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract X shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract X shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object"
+                    + " from aws object",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         else:
             try:
                 input_forcings.ny_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Y shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Y shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
                     + " from: "
                     + input_forcings.tmpFile
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[2]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract X shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract X shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
                     + " from: "
                     + input_forcings.tmpFile
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # Broadcast the forcing nx/ny values
@@ -14605,14 +15501,15 @@ def calculate_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = (
-            "Unable to create source ESMF grid from temporary file: "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to create source ESMF grid from temporary file: "
             + input_forcings.tmpFile
             + " ("
             + str(esmf_error)
-            + ")"
+            + ")",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -14635,27 +15532,28 @@ def calculate_weights(
             input_forcings.y_upper_bound - input_forcings.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to extract local X/Y boundaries from global grid from temporary "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to extract local X/Y boundaries from global grid from temporary "
             + "file: "
             + input_forcings.tmpFile
             + " ("
             + str(err)
-            + ")"
+            + ")",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if input_forcings.nx_local < 2 or input_forcings.ny_local < 2:
-        config_options.errMsg = (
-            "You have either specified too many cores for: "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="You have either specified too many cores for: "
             + input_forcings.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must "
-            "have x/y dimension size of 2."
+            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # check if we're doing border trimming and set up mask
@@ -14666,13 +15564,13 @@ def calculate_weights(
                 ESMF.GridItem.MASK, ESMF.StaggerLoc.CENTER
             )
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Trimming input forcing `{}` by {} grid cells".format(
-                        input_forcings.product_name, border
-                    )
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Trimming input forcing `{}` by {} grid cells".format(
+                        input_forcings.product_name, border
+                    ),
                 )  # log at debug level
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
@@ -14782,21 +15680,23 @@ def calculate_weights(
     try:
         input_forcings.esmf_lats = input_forcings.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate latitude coordinate object within input ESMF grid: "
-            + str(ge)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to locate latitude coordinate object within input ESMF grid: "
+            + str(ge),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
         input_forcings.esmf_lons = input_forcings.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate longitude coordinate object within input ESMF grid: "
-            + str(ge)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to locate longitude coordinate object within input ESMF grid: "
+            + str(ge),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     input_forcings.esmf_lats[:, :] = var_sub_lat_tmp
@@ -14814,10 +15714,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
     if config_options.grid_type == "unstructured":
@@ -14828,10 +15729,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Create a ESMF field to hold the incoming data.
@@ -14841,10 +15743,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
     elif config_options.grid_type == "hydrofabric":
@@ -14855,10 +15758,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
     # Scatter global grid to processors..
@@ -15098,13 +16002,13 @@ def calculate_supp_pcp_weights(
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if supplemental_precip.nx_local < 2 or supplemental_precip.ny_local < 2:
-        config_options.errMsg = (
-            "You have either specified too many cores for: "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="You have either specified too many cores for: "
             + supplemental_precip.product_name
-            + ", or  your input forcing grid is too small to process. Local grid "
-            "must have x/y dimension size of 2."
+            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     lat_tmp = lon_tmp = None


### PR DESCRIPTION
Edit: these changes were applied in a new PR: https://github.com/NGWPC/ngen-forcing/pull/98.  Closing this one.



This contains a large amount of cosmetic changes to `regrid.py` that go deeper than the initial `ruff` formatting that was done recently.

This is to prepare for a broader refactor of `regrid.py`, via some initial streamlining of repetitive logic and improved string composition.  After these changes are in effect, it will be easier on the eyes to look at diffs between functions that have lots of identical code and begin to consolidate / DRYify / restructure the branches of business logic.

The changes in this PR were made as follows:

### Replacing the double-line pattern of setting `config_options.statusMsg =` (or equivalent) and then calling the logger, preferring direct calls to the logger with new `msg` argument:

1. Set ruff line length to 320 and save, so lines become long again

2. Use VS Code to apply these regex pattern replacements:

```
### Bare

## Find

^(\s+)config_options\.(status|err)Msg = (.+)\n\1err_handler\.log_(error|critical|warning|msg)\(config_options, mpi_config\)

## Replace with

$1err_handler.log_$4(config_options, mpi_config, msg=$3)


### Debug

## Find

^(\s+)config_options\.(status|err)Msg = (.+)\n\1err_handler\.log_(error|critical|warning|msg)\(config_options, mpi_config, True\)

## Replace with

$1err_handler.log_$4(config_options, mpi_config, debug=True, msg=$3)
```

3. Switch ruff line length back to default and save again

### Replacing all string formatting / string composition with single-line f-strings:

1. Run flynt:

```
flynt -tc -ll 9999 ~/ngwpc/ngen-forcing/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
```

2. Use VS Code to remove the `!s` phrases that flynt adds, since those are unnecessary.



## Additions

-

## Removals

-

## Changes

- See description

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

