### PR TITLE
Klarkin netcdf remove retry

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -10104,6 +10104,7 @@ def regrid_mrms_precip_flag(
                 f"Unable to remove NetCDF file: {mrms_tmp_nc} - {e}\n"
                 f"{traceback.format_exc()}"
             )
+            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -13316,6 +13317,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         f"{traceback.format_exc()}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
+            err_handler.check_program_status(config_options, mpi_config)
 
 
 def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -986,13 +986,24 @@ def _regrid_ak_ext_ana_pcp_stage4(
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {stage4_tmp_nc}"
+            except Exception as e:
+                config_options.errMsg = (
+                    f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
-            except OSError:
-                config_options.errMsg = f"Unable to remove NetCDF file: {stage4_tmp_nc}"
+            except FileNotFoundError:
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {stage4_tmp_nc}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                config_options.errMsg = (
+                    f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -1563,13 +1574,24 @@ def _regrid_conus_ext_ana_pcp_stage4(
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {stage4_tmp_nc}"
+            except Exception as e:
+                config_options.errMsg = (
+                    f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
-            except OSError:
-                config_options.errMsg = f"Unable to remove NetCDF file: {stage4_tmp_nc}"
+            except FileNotFoundError:
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {stage4_tmp_nc}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                config_options.errMsg = (
+                    f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
@@ -2550,16 +2572,25 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
+            except Exception as e:
                 config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                # Any other exception is critical
                 config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -3511,19 +3542,28 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
     finally:
         # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0:
+        if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
+            except Exception as e:
                 config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                # Any other exception is critical
                 config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -4690,16 +4730,25 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
+            except Exception as e:
                 config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                # Any other exception is critical
                 config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -7926,9 +7975,10 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
+            except Exception as e:
                 config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
 
@@ -7938,12 +7988,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = f"NetCDF file not found for removal, continuing: {input_forcings.tmpFile}"
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                )
                 err_handler.log_warning(config_options, mpi_config)
-            except OSError as e:
-                # Any other OS error is critical
+            except Exception as e:
+                # Any other exception is critical
                 config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}"
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -8766,16 +8819,25 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
+            except Exception as e:
                 config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                # Any other exception is critical
                 config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10022,16 +10084,26 @@ def regrid_mrms_precip_flag(
     if mpi_config.rank == 0:
         try:
             id_tmp.close()
-        except OSError:
+        except Exception as e:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + supplemental_precip.file_in2
+                f"Unable to close NetCDF file: {mrms_tmp_nc} - {e}\n"
+                f"{traceback.format_exc()}"
             )
             err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(mrms_tmp_nc)
-        except OSError:
-            config_options.errMsg = "Unable to remove NetCDF file: " + mrms_tmp_nc
-            err_handler.log_critical(config_options, mpi_config)
+        except FileNotFoundError:
+            # File doesn't exist
+            config_options.statusMsg = (
+                f"NetCDF file not found, continuing: {mrms_tmp_nc}"
+            )
+            err_handler.log_warning(config_options, mpi_config)
+        except Exception as e:
+            # Any other exception is critical
+            config_options.errMsg = (
+                f"Unable to remove NetCDF file: {mrms_tmp_nc} - {e}\n"
+                f"{traceback.format_exc()}"
+            )
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -10964,19 +11036,28 @@ def regrid_hourly_wrf_arw(
 
     finally:
         # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0:
+        if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
+            except Exception as e:
                 config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                # Any other exception is critical
                 config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
+                    f"{traceback.format_exc()}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
@@ -11487,13 +11568,26 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
         if mpi_config.rank == 0 and id_tmp is not None:
             try:
                 id_tmp.close()
-            except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {arw_tmp_nc}"
+            except Exception as e:
+                config_options.errMsg = (
+                    f"Unable to close NetCDF file: {arw_tmp_nc} - {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(arw_tmp_nc)
-            except OSError:
-                config_options.errMsg = f"Unable to remove NetCDF file: {arw_tmp_nc}"
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = (
+                    f"NetCDF file not found, continuing: {arw_tmp_nc}"
+                )
+                err_handler.log_warning(config_options, mpi_config)
+            except Exception as e:
+                # Any other exception is critical
+                config_options.errMsg = (
+                    f"Unable to remove NetCDF file: {arw_tmp_nc} - {e}\n"
+                    f"{traceback.format_exc()}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12801,16 +12895,18 @@ def regrid_hourly_nbm(
     if mpi_config.rank == 0:
         try:
             id_tmp.close()
-        except OSError:
+        except Exception as e:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + forcings_or_precip.file_in1
+                f"Unable to close NetCDF file: {nbm_tmp_nc} - {e}\n"
+                f"{traceback.format_exc()}"
             )
             err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(nbm_tmp_nc)
-        except OSError:
+        except Exception as e:
             config_options.errMsg = (
-                "Unable to remove temporary NBM NetCDF file: " + nbm_tmp_nc
+                f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc} - {e}\n"
+                f"{traceback.format_exc()}"
             )
             err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
@@ -13208,9 +13304,16 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             ):
                 try:
                     os_utils.os_remove_retry(tmp_file)
-                except OSError as e:
+                except FileNotFoundError:
+                    config_options.statusMsg = (
+                        f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                    )
+                    err_handler.log_warning(config_options, mpi_config)
+
+                except Exception as e:
                     config_options.errMsg = (
-                        f"Unable to remove scratch file {tmp_file}: {e}"
+                        f"Unable to remove scratch file {tmp_file}: {e}\n"
+                        f"{traceback.format_exc()}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -7936,9 +7936,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # benefits of reuse seem unclear
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
+            except FileNotFoundError:
+                # File doesn't exist
+                config_options.statusMsg = f"NetCDF file not found for removal, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(config_options, mpi_config)
+            except OSError as e:
+                # Any other OS error is critical
                 config_options.errMsg = (
-                    "Unable to remove NetCDF file: " + input_forcings.tmpFile
+                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)


### PR DESCRIPTION
Some cases where netcdf temp files are failing to remove may be occurring due to FileNotFound, which should not be fatal or critical. This adds FileNotFound exception handling, and stacktraces during failure, so that we can gather more information if failures continue. 

## Additions

-

## Removals

-

## Changes

- Added FileNotFound handling during os_remove_retry() calls. Added stacktrace messaging.

## Testing

1. Tested on all configurations, but could only do this locally. Further testing on EFS under load is likely required. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

