### PR TITLE
Initial DRYifying of regrid.py

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -111,7 +111,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"{name} file being used: {input_file}",
-            )  # log at debug level
+            )
 
             os.symlink(input_file, tmpFile)
         except:
@@ -159,7 +159,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg="No AK AnA in_2 file found for this timestep.",
-                )  # log at debug level
+                )
             return
 
         # Check to see if the regrid complete flag for this
@@ -172,7 +172,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg="No AK AnA regridding required for this timestep.",
-                )  # log at debug level
+                )
             return
 
         # Only rank‐0 opens the file
@@ -364,7 +364,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}",
-                )  # log at debug level
+                )
                 LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
                     try:
@@ -520,7 +520,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 mpi_config,
                 debug=True,
                 msg="No StageIV regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -564,7 +564,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             if mpi_config.rank == 0:
                 err_handler.log_msg(
                     config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
-                )  # log at debug level
+                )
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -600,7 +600,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     mpi_config,
                     debug=True,
                     msg="Calculating STAGE IV regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -622,7 +622,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -655,7 +655,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -688,7 +688,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -722,7 +722,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1103,7 +1103,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 mpi_config,
                 debug=True,
                 msg="No StageIV regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -1146,7 +1146,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             if mpi_config.rank == 0:
                 err_handler.log_msg(
                     config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
-                )  # log at debug level
+                )
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -1182,7 +1182,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     mpi_config,
                     debug=True,
                     msg="Calculating STAGE IV regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -1204,7 +1204,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1237,7 +1237,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1270,7 +1270,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1304,7 +1304,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1682,7 +1682,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 mpi_config,
                 debug=True,
                 msg="No HRRR in_2 file found for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Check to see if the regrid complete flag for this
@@ -1695,7 +1695,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 mpi_config,
                 debug=True,
                 msg="No HRRR regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -1737,7 +1737,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Converting HRRR Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 if 0 < input_forcings.cycle_freq < 60:
                     time_str = (
                         f"{input_forcings.fcst_min1}-{input_forcings.fcst_min2} min acc fcst"
@@ -1793,7 +1793,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     mpi_config,
                     debug=True,
                     msg=f"Processing HRRR Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -1812,7 +1812,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg="Calculating HRRR regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -1826,7 +1826,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # # Read in the HRRR height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in HRRR elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -1869,7 +1869,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -1944,7 +1944,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2015,7 +2015,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -2092,7 +2092,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             mpi_config,
                             debug=True,
                             msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2156,7 +2156,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2204,7 +2204,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2263,7 +2263,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2311,7 +2311,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2369,7 +2369,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp_elem = id_tmp.variables[
@@ -2417,7 +2417,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -2478,7 +2478,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2526,7 +2526,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2627,7 +2627,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 mpi_config,
                 debug=True,
                 msg="No RAP regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -2670,7 +2670,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Converting CONUS RAP Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
@@ -2716,7 +2716,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     mpi_config,
                     debug=True,
                     msg=f"Processing Conus RAP Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -2735,7 +2735,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg="Calculating RAP regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -2749,7 +2749,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in RAP elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -2791,7 +2791,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2866,7 +2866,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2940,7 +2940,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -3017,7 +3017,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             mpi_config,
                             debug=True,
                             msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -3111,7 +3111,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3217,7 +3217,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3322,7 +3322,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -3431,7 +3431,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3552,7 +3552,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 mpi_config,
                 debug=True,
                 msg="No need to read in new CFSv2 data at this time.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -3595,7 +3595,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         mpi_config,
                         debug=True,
                         msg=f"Converting CFSv2 Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -3636,7 +3636,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     mpi_config,
                     debug=True,
                     msg=f"Processing CFSv2 Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -3655,7 +3655,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         mpi_config,
                         debug=True,
                         msg="Calculate CFSv2 regridding weights.",
-                    )  # log at debug level
+                    )
 
                 calculate_weights(
                     id_tmp,
@@ -3670,7 +3670,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in CFSv2 elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 #
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
@@ -3714,7 +3714,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3790,7 +3790,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3865,7 +3865,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -3943,7 +3943,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -4011,7 +4011,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4158,7 +4158,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4304,7 +4304,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4453,7 +4453,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             mpi_config,
                             debug=True,
                             msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
-                        )  # log at debug level
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -4646,7 +4646,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No NWM NetCDF regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4665,7 +4665,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-            )  # log at debug level
+            )
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4692,7 +4692,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
-            )  # log at debug level
+            )
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
@@ -4703,7 +4703,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4774,7 +4774,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4844,7 +4844,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4915,7 +4915,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -5011,7 +5011,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 mpi_config,
                 debug=True,
                 msg="No NWM NetCDF regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -5046,7 +5046,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 mpi_config,
                 debug=True,
                 msg=f"Processing Custom zarr Forcing Variable: {nc_var}",
-            )  # log at debug level
+            )
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -5082,7 +5082,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5153,7 +5153,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5223,7 +5223,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5294,7 +5294,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     mpi_config,
                     debug=True,
                     msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5410,7 +5410,7 @@ def regrid_custom_hourly_netcdf(
                     mpi_config,
                     debug=True,
                     msg="No Custom Hourly NetCDF regridding required for this timestep.",
-                )  # log at debug level
+                )
             return
 
         # Open the input NetCDF file containing necessary data.
@@ -5442,7 +5442,7 @@ def regrid_custom_hourly_netcdf(
                     mpi_config,
                     debug=True,
                     msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-                )  # log at debug level
+                )
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
                 force_count,
@@ -5501,7 +5501,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5572,7 +5572,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5644,7 +5644,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out_elem = (
                                 esmf_regridobj_call_retry_partial(
@@ -5715,7 +5715,7 @@ def regrid_custom_hourly_netcdf(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5782,14 +5782,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -5897,14 +5897,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -6010,14 +6010,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -6129,14 +6129,14 @@ def regrid_custom_hourly_netcdf(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
                         err_handler.log_critical(
@@ -6274,7 +6274,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No ERA5-Interim regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -6308,7 +6308,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}",
-            )  # log at debug level
+            )
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -6355,14 +6355,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6472,14 +6472,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6588,14 +6588,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.0)[
                         ind, :, :
                     ]
@@ -6712,14 +6712,14 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     err_handler.log_msg(
                         config_options,
                         mpi_config,
                         debug=True,
                         msg="Using -9999. to replace missing values in input",
-                    )  # log at debug level
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6862,7 +6862,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No 13km GFS regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a temporary NetCDF file name to hold converted GRIB2 data.
@@ -6918,7 +6918,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Converting 13km GFS Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
                     # By far the most complicated of output variables. We need to calculate
@@ -6976,7 +6976,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Processing 13km GFS Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -6995,7 +6995,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg="Calculating 13km GFS regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -7009,7 +7009,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # Read in the GFS height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #    config_options.statusMsg = "Reading in 13km GFS elevation data."
-                #    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #    err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #    "\":(HGT):(surface):\" " + \
                 #    " -netcdf " + input_forcings.tmpFileHeight
@@ -7104,7 +7104,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain.",
-                    )  # log at debug level
+                    )
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.esmf_field_out = (
@@ -7461,7 +7461,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -7476,7 +7476,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7526,7 +7526,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -7541,7 +7541,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Node Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7590,7 +7590,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out_elem = (
@@ -7607,7 +7607,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Element Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7657,7 +7657,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -7672,7 +7672,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Element Regridding took {end - begin} seconds",
-                        )  # log at debug level
+                        )
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7769,7 +7769,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             mpi_config,
             debug=True,
             msg="No regridding of NAM nest data necessary for this timestep - already completed.",
-        )  # log at debug level
+        )
         return
 
     # Create a path for a temporary NetCDF file
@@ -7808,7 +7808,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Converting NAM-Nest Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -7852,7 +7852,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     mpi_config,
                     debug=True,
                     msg=f"Processing NAM Nest Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -7871,7 +7871,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg="Calculating NAM nest regridding weights....",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -7885,7 +7885,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in NAM nest elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -7921,7 +7921,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -7990,7 +7990,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -8058,7 +8058,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -8129,7 +8129,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -8195,7 +8195,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8281,7 +8281,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8366,7 +8366,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8454,7 +8454,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -8599,7 +8599,7 @@ def regrid_mrms_hourly(
                 mpi_config,
                 debug=True,
                 msg="No MRMS regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -8749,7 +8749,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg="Calculating MRMS regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config
             )
@@ -8793,7 +8793,7 @@ def regrid_mrms_hourly(
                         mpi_config,
                         debug=True,
                         msg="Regridding MRMS RQI Field.",
-                    )  # log at debug level
+                    )
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -8820,7 +8820,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"{n_masked} masked cells in RQI field, will remove",
-                            )  # log at debug level
+                            )
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
@@ -8869,7 +8869,7 @@ def regrid_mrms_hourly(
                         mpi_config,
                         debug=True,
                         msg="Regridding MRMS RQI Field.",
-                    )  # log at debug level
+                    )
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -8896,7 +8896,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"{n_masked} masked cells in RQI field, will remove",
-                            )  # log at debug level
+                            )
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
@@ -8944,7 +8944,7 @@ def regrid_mrms_hourly(
                         mpi_config,
                         debug=True,
                         msg="Regridding MRMS RQI Field.",
-                    )  # log at debug level
+                    )
                 try:
                     supplemental_precip.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -8971,7 +8971,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"{n_masked} masked cells in RQI field, will remove",
-                            )  # log at debug level
+                            )
 
                     supplemental_precip.esmf_field_out_elem.data[
                         np.where(supplemental_precip.regridded_mask_elem == 0)
@@ -9000,7 +9000,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg="MRMS Will not be filtered using RQI values.",
-                )  # log at debug level
+                )
 
         elif supplemental_precip.rqiMethod == 2:
             # Read in the RQI field from monthly climatological files.
@@ -9036,7 +9036,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9112,7 +9112,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
@@ -9164,7 +9164,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9240,7 +9240,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
@@ -9291,7 +9291,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9372,7 +9372,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = (
                         config_options.globalNdv
                     )
@@ -9423,7 +9423,7 @@ def regrid_mrms_hourly(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9499,7 +9499,7 @@ def regrid_mrms_hourly(
                                 mpi_config,
                                 debug=True,
                                 msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
-                            )  # log at debug level
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
@@ -9868,7 +9868,7 @@ def regrid_hourly_wrf_arw(
             mpi_config,
             debug=True,
             msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed.",
-        )  # log at debug level
+        )
         return
 
     # Create a path for a temporary NetCDF file
@@ -9909,7 +9909,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Converting WRF-ARW Variable: {grib_var}",
-                    )  # log at debug level
+                    )
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
@@ -9958,7 +9958,7 @@ def regrid_hourly_wrf_arw(
                     mpi_config,
                     debug=True,
                     msg=f"Processing WRF-ARW Variable: {grib_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -9977,7 +9977,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg="Calculating WRF-ARW regridding weights....",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -9991,7 +9991,7 @@ def regrid_hourly_wrf_arw(
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in WRF-ARW elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -10027,7 +10027,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -10095,7 +10095,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -10163,7 +10163,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -10234,7 +10234,7 @@ def regrid_hourly_wrf_arw(
                             mpi_config,
                             debug=True,
                             msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
-                        )  # log at debug level
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -10300,7 +10300,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10410,7 +10410,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10519,7 +10519,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10632,7 +10632,7 @@ def regrid_hourly_wrf_arw(
                         mpi_config,
                         debug=True,
                         msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
-                    )  # log at debug level
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
@@ -10787,7 +10787,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 mpi_config,
                 debug=True,
                 msg="No ARW regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -10864,7 +10864,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     mpi_config,
                     debug=True,
                     msg="Calculating WRF ARW regridding weights.",
-                )  # log at debug level
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config
             )
@@ -10880,7 +10880,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -10973,7 +10973,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11065,7 +11065,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11161,7 +11161,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                         mpi_config,
                         debug=True,
                         msg="Regridding WRF ARW APCP Precipitation.",
-                    )  # log at debug level
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11310,7 +11310,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 mpi_config,
                 debug=True,
                 msg="Calculating SBCv2 Liquid Water Fraction regridding weights.",
-            )  # log at debug level
+            )
         calculate_supp_pcp_weights(
             supplemental_forcings,
             id_tmp,
@@ -11412,7 +11412,7 @@ def regrid_sbcv2_liquid_water_fraction(
                     mpi_config,
                     debug=True,
                     msg="Regridding SBCv2 Liquid Water Fraction - unstructured",
-                )  # log at debug level
+                )
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -11492,7 +11492,7 @@ def regrid_sbcv2_liquid_water_fraction(
                     mpi_config,
                     debug=True,
                     msg="Regridding SBCv2 Liquid Water Fraction input variable.",
-                )  # log at debug level
+                )
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_forcings.netcdf_var_names[0]
@@ -11727,7 +11727,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Converting NBM Variable: {grib_var}",
-                )  # log at debug level
+                )
             time_str = (
                 f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
@@ -11769,7 +11769,7 @@ def regrid_hourly_nbm(
                 mpi_config,
                 debug=True,
                 msg=f"Processing NBM Variable: {nc_var}",
-            )  # log at debug level
+            )
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -11802,7 +11802,7 @@ def regrid_hourly_nbm(
                         mpi_config,
                         debug=True,
                         msg=f"Calculating NBM {tag} regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_supp_pcp_weights(
                     forcings_or_precip,
                     id_tmp,
@@ -11818,7 +11818,7 @@ def regrid_hourly_nbm(
                         mpi_config,
                         debug=True,
                         msg=f"Calculating NBM {tag} regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -11886,7 +11886,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -11958,7 +11958,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -12030,7 +12030,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the WRF-Hydro domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -12101,7 +12101,7 @@ def regrid_hourly_nbm(
                                 mpi_config,
                                 debug=True,
                                 msg="Regridding NBM elevation data to the unstructured domain.",
-                            )  # log at debug level
+                            )
                         try:
                             forcings_or_precip.esmf_field_out_elem = (
                                 esmf_regridobj_call_retry_partial(
@@ -12155,7 +12155,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12260,7 +12260,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12364,7 +12364,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12468,7 +12468,7 @@ def regrid_hourly_nbm(
                     mpi_config,
                     debug=True,
                     msg=f"Regridding NBM {nc_var}",
-                )  # log at debug level
+                )
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12608,7 +12608,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 mpi_config,
                 debug=True,
                 msg="No NDFD regridding required for this timestep.",
-            )  # log at debug level
+            )
         return
 
     err_handler.log_msg(config_options, mpi_config, msg="Regrid NDFD")
@@ -12642,7 +12642,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Deleting old temporary file: {tmp_file}",
-                )  # log at debug level
+                )
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
@@ -12662,7 +12662,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"Cycle unchanged, reusing temporary file: {tmp_file}",
-                    )  # log at debug level
+                    )
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
@@ -12671,7 +12671,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}",
-                    )  # log at debug level
+                    )
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
                 else:
@@ -12697,7 +12697,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg="Forecast time beyond NDFD range, skipping",
-                        )  # log at debug level
+                        )
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
@@ -12706,7 +12706,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}",
-                        )  # log at debug level
+                        )
                     else:
                         time_index = min(
                             range(len(times)),
@@ -12717,7 +12717,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}",
-                        )  # log at debug level
+                        )
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
@@ -12726,7 +12726,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg="Forecast time beyond NDFD precip range, skipping",
-                        )  # log at debug level
+                        )
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
@@ -12735,7 +12735,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             mpi_config,
                             debug=True,
                             msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}",
-                        )  # log at debug level
+                        )
 
             skip_file = mpi_config.broadcast_parameter(
                 skip_file, config_options, param_type=np.ubyte
@@ -12766,7 +12766,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     mpi_config,
                     debug=True,
                     msg=f"Processing NDFD variable: {ndfd_var}",
-                )  # log at debug level
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -12785,7 +12785,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         mpi_config,
                         debug=True,
                         msg="Calculating NDFD regridding weights.",
-                    )  # log at debug level
+                    )
                 calculate_weights(
                     id_tmp,
                     i,
@@ -13053,7 +13053,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     mpi_config,
                     debug=True,
                     msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-                )  # log at debug level
+                )
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
             ):
@@ -13104,14 +13104,14 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
                         err_handler.log_critical(
@@ -13219,14 +13219,14 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
                         err_handler.log_critical(
@@ -13332,14 +13332,14 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         mpi_config,
                         debug=True,
                         msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )  # log at debug level
+                    )
                     try:
                         err_handler.log_msg(
                             config_options,
                             mpi_config,
                             debug=True,
                             msg=f"Using {fill} to replace missing values in input",
-                        )  # log at debug level
+                        )
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
                         err_handler.log_critical(
@@ -13458,7 +13458,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             mpi_config,
                             debug=True,
                             msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                        )  # log at debug level
+                        )
                     try:
                         with timing_block(
                             f"regrid step 2.5.2 | {mpi_config.rank}: messages2"
@@ -13468,7 +13468,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                                 mpi_config,
                                 debug=True,
                                 msg=f"Using {fill} to replace missing values in input",
-                            )  # log at debug level
+                            )
                         with timing_block(
                             f"regrid step 2.5.3 | {mpi_config.rank}: fill missing"
                         ):
@@ -14028,7 +14028,7 @@ def load_weight_file(
         mpi_config,
         debug=True,
         msg=f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}",
-    )  # log at debug level
+    )
 
     err_handler.check_program_status(config_options, mpi_config)
     try:
@@ -14050,7 +14050,7 @@ def load_weight_file(
             mpi_config,
             debug=True,
             msg=f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds",
-        )  # log at debug level
+        )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14081,9 +14081,7 @@ def make_regrid(
 
     start_msg = f"RANK: {mpi_config.rank}: Creating{msg_augment}weight object from ESMF. weight_file={weight_file}"
     if mpi_config.rank == 0:
-        err_handler.log_msg(
-            config_options, mpi_config, debug=True, msg=start_msg
-        )  # log at debug level
+        err_handler.log_msg(config_options, mpi_config, debug=True, msg=start_msg)
 
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[
@@ -14122,7 +14120,7 @@ def make_regrid(
                 mpi_config,
                 debug=True,
                 msg=f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds",
-            )  # log at debug level
+            )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14167,7 +14165,7 @@ def execute_regrid(
                 mpi_config,
                 debug=True,
                 msg=f"Deleting if exists: {weight_file}",
-            )  # log at debug level
+            )
             try:
                 os_utils.os_remove_retry(weight_file)
             except FileNotFoundError:
@@ -14205,9 +14203,7 @@ def calculate_weights(
         esmf_grid_retry, mpi_config, config_options, err_handler
     )
 
-    err_handler.log_msg(
-        config_options, mpi_config, debug=True, msg="Calculate Weights"
-    )  # log at debug level
+    err_handler.log_msg(config_options, mpi_config, debug=True, msg="Calculate Weights")
 
     if mpi_config.rank == 0:
         if config_options.aws:
@@ -14329,7 +14325,7 @@ def calculate_weights(
                     mpi_config,
                     debug=True,
                     msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells",
-                )  # log at debug level
+                )
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
             gmask[:+border, :] = 0.0  # top edge

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -233,10 +233,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds = Dataset(input_forcings.file_in2, "r")
             except Exception as e:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})",
+                log_crit(
+                    msg=f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})"
                 )
 
             # turn off automatic masking but keep scaling
@@ -267,10 +265,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         coord_sys=ESMF.CoordSys.SPH_DEG,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    log_crit(
+                        msg=f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -302,10 +298,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.y_upper_bound - input_forcings.y_lower_bound
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})",
+                    log_crit(
+                        msg=f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
@@ -319,10 +313,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    log_crit(
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -340,10 +332,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in_elem.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    log_crit(
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -353,10 +343,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    log_crit(
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -368,10 +356,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    log_crit(
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -420,10 +406,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        log_crit(
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
                         )
                 elif config_options.grid_type == "unstructured":
                     try:
@@ -433,10 +417,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp_elem = ds.variables[nc_var][0, :]
                         var_tmp_elem = np.float32(var_tmp_elem)
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        log_crit(
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
                         )
                 elif config_options.grid_type == "hydrofabric":
                     try:
@@ -444,10 +426,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        log_crit(
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
                         )
 
             err_handler.check_program_status(config_options, mpi_config)
@@ -462,10 +442,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -485,10 +463,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds_elem]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -510,10 +486,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -654,10 +628,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -684,10 +656,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -714,10 +684,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -745,10 +713,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -761,10 +727,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -775,10 +739,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -788,10 +750,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -810,10 +770,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -829,10 +787,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -843,10 +799,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -856,10 +810,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -878,10 +830,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -896,10 +846,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -912,10 +860,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -925,10 +871,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -948,10 +892,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -967,10 +909,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -981,10 +921,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -994,10 +932,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1016,10 +952,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1190,10 +1124,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1220,10 +1152,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1250,10 +1180,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp_elem,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1281,10 +1209,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1297,10 +1223,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1311,10 +1235,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1324,10 +1246,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1346,10 +1266,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1365,10 +1283,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1379,10 +1295,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1392,10 +1306,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1414,10 +1326,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1432,10 +1342,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1448,10 +1356,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1461,10 +1367,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1484,10 +1388,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1503,10 +1405,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1517,10 +1417,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1530,10 +1428,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1557,10 +1453,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 del ind_valid
                 del invalid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
@@ -1776,10 +1670,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1796,10 +1688,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1809,20 +1699,16 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        log_crit(
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1848,10 +1734,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1868,10 +1752,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1881,20 +1763,16 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        log_crit(
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1916,10 +1794,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1936,10 +1812,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1949,10 +1823,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1961,10 +1833,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        log_crit(
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1990,10 +1860,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2010,10 +1878,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2023,20 +1889,16 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        log_crit(
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2081,10 +1943,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2096,10 +1956,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2114,11 +1972,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid input HRRR forcing data: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2127,10 +1981,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2139,10 +1991,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2182,10 +2032,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2197,10 +2045,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2215,11 +2061,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid input HRRR forcing data: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2228,10 +2070,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2240,10 +2080,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2282,10 +2120,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2297,10 +2133,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2317,11 +2151,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid input HRRR forcing data: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2330,10 +2160,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2342,10 +2170,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2385,10 +2211,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2400,10 +2224,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2418,11 +2240,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid input HRRR forcing data: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2431,10 +2249,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2443,10 +2259,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2606,10 +2420,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2621,10 +2433,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2641,10 +2451,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2654,20 +2462,16 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2678,10 +2482,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2693,10 +2495,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2713,10 +2513,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2726,20 +2524,16 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2749,10 +2543,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2764,10 +2556,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2784,10 +2574,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2797,10 +2585,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2809,10 +2595,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2823,10 +2607,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2838,10 +2620,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2858,10 +2638,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2871,20 +2649,16 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2914,10 +2688,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2929,10 +2701,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local RAP array into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local RAP array into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2947,10 +2717,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    log_crit(
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2960,10 +2728,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2973,10 +2739,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF data into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF data into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3017,10 +2781,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3032,10 +2794,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local RAP array into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local RAP array into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3050,10 +2810,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    log_crit(
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3063,10 +2821,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3076,10 +2832,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF data into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF data into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3119,10 +2873,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp_elem /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3134,10 +2886,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local RAP array into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local RAP array into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3154,10 +2904,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    log_crit(
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3167,10 +2915,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3180,10 +2926,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF element data into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF element data into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3225,10 +2969,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3240,10 +2982,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local RAP array into ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local RAP array into ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3258,10 +2998,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    log_crit(
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3271,10 +3009,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3284,10 +3020,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place RAP ESMF data into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place RAP ESMF data into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3464,10 +3198,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3479,10 +3211,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3500,10 +3230,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3513,20 +3241,16 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3537,10 +3261,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3552,10 +3274,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3573,10 +3293,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3586,20 +3304,16 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3609,10 +3323,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3624,10 +3336,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3645,10 +3355,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3658,10 +3366,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3670,10 +3376,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3684,10 +3388,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3699,10 +3401,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3720,10 +3420,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3733,20 +3431,16 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3780,10 +3474,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3845,10 +3537,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3861,10 +3551,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3874,10 +3562,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3886,10 +3572,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3924,10 +3608,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3989,10 +3671,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4005,10 +3685,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4018,10 +3696,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4030,10 +3706,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4067,10 +3741,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4134,10 +3806,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4150,10 +3820,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4163,10 +3831,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4175,10 +3841,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4213,10 +3877,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4278,10 +3940,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4294,10 +3954,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        log_crit(
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4307,10 +3965,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        log_crit(
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4319,10 +3975,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4437,10 +4091,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4452,10 +4104,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4466,10 +4116,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4478,10 +4126,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4503,10 +4149,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4518,10 +4162,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4532,10 +4174,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4544,10 +4184,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4568,10 +4206,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4583,10 +4219,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4597,10 +4231,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4609,10 +4241,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4634,10 +4264,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4649,10 +4277,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4663,10 +4289,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4675,10 +4299,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4787,10 +4409,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4802,10 +4422,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4816,10 +4434,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4828,10 +4444,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4853,10 +4467,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4868,10 +4480,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4882,10 +4492,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4894,10 +4502,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4918,10 +4524,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4933,10 +4537,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4947,10 +4549,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4959,10 +4559,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4984,10 +4582,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5003,10 +4599,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5017,10 +4611,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5029,10 +4621,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5167,10 +4757,8 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5187,10 +4775,8 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5200,10 +4786,8 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5212,10 +4796,8 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5235,10 +4817,8 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5255,10 +4835,8 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5268,10 +4846,8 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5280,10 +4856,8 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5304,10 +4878,8 @@ def regrid_custom_hourly_netcdf(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5324,10 +4896,8 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5337,10 +4907,8 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5349,10 +4917,8 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5372,10 +4938,8 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5392,10 +4956,8 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5405,10 +4967,8 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5417,10 +4977,8 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5449,10 +5007,8 @@ def regrid_custom_hourly_netcdf(
                         )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5464,10 +5020,8 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5478,10 +5032,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5491,10 +5043,8 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5513,10 +5063,8 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5525,10 +5073,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5556,10 +5102,8 @@ def regrid_custom_hourly_netcdf(
                         )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5571,10 +5115,8 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5585,10 +5127,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5598,10 +5138,8 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5619,10 +5157,8 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5631,10 +5167,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5661,10 +5195,8 @@ def regrid_custom_hourly_netcdf(
                         )
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5676,10 +5208,8 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5692,10 +5222,8 @@ def regrid_custom_hourly_netcdf(
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5705,10 +5233,8 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5729,10 +5255,8 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5741,10 +5265,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5772,10 +5294,8 @@ def regrid_custom_hourly_netcdf(
                         )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5786,10 +5306,8 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5800,10 +5318,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5813,10 +5329,8 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5839,10 +5353,8 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5851,10 +5363,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5990,10 +5500,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6005,10 +5513,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6019,10 +5525,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6032,10 +5536,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
+                log_crit(
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6048,10 +5550,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6060,10 +5560,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6097,10 +5595,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6112,10 +5608,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6126,10 +5620,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6139,10 +5631,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
+                log_crit(
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6155,10 +5645,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6167,10 +5655,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6207,10 +5693,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6222,10 +5706,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6236,10 +5718,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6249,10 +5729,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask_elem == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                log_crit(
+                    msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6267,10 +5745,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6280,10 +5756,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ] = input_forcings.esmf_field_out_elem.data
 
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6317,10 +5791,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6332,10 +5804,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6346,10 +5816,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6359,10 +5827,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
+                log_crit(
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6375,10 +5841,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6387,10 +5851,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6575,10 +6037,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6592,10 +6052,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6609,10 +6067,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6626,10 +6082,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            log_crit(
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6641,10 +6095,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local GFS array into an ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local GFS array into an ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6662,11 +6114,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid GFS elevation data: {ve}",
-                        )
+                        log_crit(msg=f"Unable to regrid GFS elevation data: {ve}")
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -6675,10 +6123,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6692,20 +6138,16 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place local GFS array into an ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place local GFS array into an ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6718,10 +6160,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6731,10 +6171,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6744,10 +6182,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
@@ -6760,11 +6196,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid GFS elevation data: {ve}",
-                        )
+                        log_crit(msg=f"Unable to regrid GFS elevation data: {ve}")
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -6773,10 +6205,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6784,20 +6214,16 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6806,10 +6232,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}",
+                        log_crit(
+                            msg=f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6817,10 +6241,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6848,10 +6270,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
@@ -6862,10 +6282,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6876,10 +6294,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -6890,10 +6306,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6965,39 +6379,31 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    log_crit(
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    log_crit(
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    log_crit(
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    log_crit(
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7017,10 +6423,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     if mpi_config.rank == 0:
                         log_debug(msg=f"Regridding took {end - begin} seconds")
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    log_crit(
+                        msg=f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7030,10 +6434,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7042,10 +6444,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
+                    log_crit(
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7074,10 +6474,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     if mpi_config.rank == 0:
                         log_debug(msg=f"Node Regridding took {end - begin} seconds")
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    log_crit(
+                        msg=f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7087,10 +6485,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7099,10 +6495,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
+                    log_crit(
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7132,10 +6526,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     if mpi_config.rank == 0:
                         log_debug(msg=f"Element Regridding took {end - begin} seconds")
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    log_crit(
+                        msg=f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7145,10 +6537,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7157,10 +6547,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
+                    log_crit(
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7189,10 +6577,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     if mpi_config.rank == 0:
                         log_debug(msg=f"Element Regridding took {end - begin} seconds")
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    log_crit(
+                        msg=f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7202,10 +6588,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    log_crit(
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7214,10 +6598,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
+                    log_crit(
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7385,10 +6767,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7405,10 +6785,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7418,20 +6796,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7451,10 +6825,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7471,10 +6843,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7484,20 +6854,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7516,10 +6882,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7536,10 +6900,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7549,10 +6911,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7561,10 +6921,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7584,10 +6942,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7604,10 +6960,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7617,20 +6971,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7663,10 +7013,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7678,10 +7026,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7692,10 +7038,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7705,10 +7049,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7717,10 +7059,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7746,10 +7086,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7761,10 +7099,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7775,10 +7111,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7788,10 +7122,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7800,10 +7132,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7828,10 +7158,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7843,10 +7171,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7859,10 +7185,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7872,10 +7196,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7884,10 +7206,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7913,10 +7233,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7928,10 +7246,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7942,10 +7258,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7955,10 +7269,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7967,10 +7279,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8198,10 +7508,8 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8213,10 +7521,8 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8231,11 +7537,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid MRMS RQI field: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid MRMS RQI field: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8251,10 +7553,8 @@ def regrid_mrms_hourly(
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
+                    log_crit(
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8266,10 +7566,8 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8281,10 +7579,8 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8299,11 +7595,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid MRMS RQI field: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid MRMS RQI field: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8319,10 +7611,8 @@ def regrid_mrms_hourly(
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
+                    log_crit(
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8333,10 +7623,8 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8348,10 +7636,8 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8366,11 +7652,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid MRMS RQI field: {ve}",
-                    )
+                    log_crit(msg=f"Unable to regrid MRMS RQI field: {ve}")
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8386,10 +7668,8 @@ def regrid_mrms_hourly(
                         np.where(supplemental_precip.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
+                    log_crit(
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8441,10 +7721,8 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8463,11 +7741,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid MRMS precipitation: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid MRMS precipitation: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8484,10 +7758,8 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8514,11 +7786,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
-                    )
+                    log_crit(msg=f"Unable to run MRMS RQI threshold search: {npe}")
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -8533,10 +7801,8 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                    log_crit(
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8561,10 +7827,8 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8583,11 +7847,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid MRMS precipitation: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid MRMS precipitation: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8604,10 +7864,8 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8634,11 +7892,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
-                    )
+                    log_crit(msg=f"Unable to run MRMS RQI threshold search: {npe}")
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -8653,10 +7907,8 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                    log_crit(
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8680,10 +7932,8 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8704,11 +7954,7 @@ def regrid_mrms_hourly(
                     )
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid MRMS precipitation: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid MRMS precipitation: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8728,10 +7974,8 @@ def regrid_mrms_hourly(
                     # err_handler.log_warning(config_options, mpi_config)
 
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8758,11 +8002,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
-                    )
+                    log_crit(msg=f"Unable to run MRMS RQI threshold search: {npe}")
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -8776,10 +8016,8 @@ def regrid_mrms_hourly(
                 )
                 del ind_valid_elem
             except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                log_crit(
+                    msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8804,10 +8042,8 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8826,11 +8062,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid MRMS precipitation: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid MRMS precipitation: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8847,10 +8079,8 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8877,11 +8107,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
-                    )
+                    log_crit(msg=f"Unable to run MRMS RQI threshold search: {npe}")
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -8896,10 +8122,8 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                    log_crit(
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9016,10 +8240,8 @@ def regrid_mrms_precip_flag(
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
+            log_crit(
+                msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})"
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9034,11 +8256,7 @@ def regrid_mrms_precip_flag(
 
         supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
     except (ValueError, KeyError, AttributeError) as err:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
-        )
+        log_crit(msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}")
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -9048,11 +8266,7 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_out,
         )
     except ValueError as ve:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
-        )
+        log_crit(msg=f"Unable to regrid MRMS PrecipFlag: {ve}")
     err_handler.check_program_status(config_options, mpi_config)
 
     # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -9064,11 +8278,7 @@ def regrid_mrms_precip_flag(
             np.where(supplemental_precip.esmf_field_out.data < 0)
         ] = 1.0
     except (ValueError, ArithmeticError) as npe:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
-        )
+        log_crit(msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}")
     err_handler.check_program_status(config_options, mpi_config)
 
     supplemental_precip.regridded_precip2[:] = supplemental_precip.esmf_field_out.data
@@ -9093,10 +8303,8 @@ def regrid_mrms_precip_flag(
                     supplemental_precip.netcdf_var_names[0]
                 ][0, :, :]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
+                log_crit(
+                    msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})"
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -9115,10 +8323,8 @@ def regrid_mrms_precip_flag(
 
             supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
         except (ValueError, KeyError, AttributeError) as err:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
+            log_crit(
+                msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -9129,11 +8335,7 @@ def regrid_mrms_precip_flag(
                 supplemental_precip.esmf_field_out_elem,
             )
         except ValueError as ve:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
-            )
+            log_crit(msg=f"Unable to regrid MRMS PrecipFlag: {ve}")
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -9145,11 +8347,7 @@ def regrid_mrms_precip_flag(
                 np.where(supplemental_precip.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
-            )
+            log_crit(msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}")
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_precip.regridded_precip2_elem[:] = (
@@ -9329,10 +8527,8 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9349,10 +8545,8 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9362,20 +8556,16 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -9394,10 +8584,8 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9414,10 +8602,8 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9427,20 +8613,16 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9459,10 +8641,8 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9479,10 +8659,8 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9492,10 +8670,8 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9504,10 +8680,8 @@ def regrid_hourly_wrf_arw(
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9527,10 +8701,8 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        log_crit(
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9547,10 +8719,8 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9560,20 +8730,16 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
+                        log_crit(
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        log_crit(
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9606,10 +8772,8 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9621,10 +8785,8 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9635,10 +8797,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9648,10 +8808,8 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9672,10 +8830,8 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9684,10 +8840,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9713,10 +8867,8 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9728,10 +8880,8 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9742,10 +8892,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9755,10 +8903,8 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9779,10 +8925,8 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9791,10 +8935,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9819,10 +8961,8 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9834,10 +8974,8 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9850,10 +8988,8 @@ def regrid_hourly_wrf_arw(
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9863,10 +8999,8 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9888,10 +9022,8 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9900,10 +9032,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9929,10 +9059,8 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9944,10 +9072,8 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9958,10 +9084,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9971,10 +9095,8 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9995,10 +9117,8 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10007,10 +9127,8 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10155,10 +9273,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10170,10 +9286,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10184,10 +9298,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10197,10 +9309,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10219,10 +9329,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10243,10 +9351,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10258,10 +9364,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10272,10 +9376,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10285,10 +9387,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10307,10 +9407,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10330,10 +9428,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10345,10 +9441,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10361,10 +9455,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     )
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10374,10 +9466,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10397,10 +9487,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid_elem
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10421,10 +9509,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10436,10 +9522,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10450,10 +9534,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10463,10 +9545,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10485,10 +9565,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10578,10 +9656,8 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                log_crit(
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10595,10 +9671,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            log_crit(
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10609,11 +9683,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
-            )
+            log_crit(msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}")
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10625,10 +9695,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
+            log_crit(
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10654,10 +9722,8 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                log_crit(
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10671,10 +9737,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            log_crit(
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10685,11 +9749,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
-            )
+            log_crit(msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}")
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10701,10 +9761,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
+            log_crit(
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10731,10 +9789,8 @@ def regrid_sbcv2_liquid_water_fraction(
                     supplemental_forcings.netcdf_var_names[0]
                 ][:]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                log_crit(
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10748,10 +9804,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp_elem / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            log_crit(
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10764,11 +9818,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 )
             )
         except ValueError as ve:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
-            )
+            log_crit(msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}")
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10780,10 +9830,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
+            log_crit(
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10809,10 +9857,8 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                log_crit(
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10826,10 +9872,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            log_crit(
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10840,11 +9884,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
-            )
+            log_crit(msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}")
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10856,10 +9896,8 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
+            log_crit(
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10941,11 +9979,7 @@ def regrid_hourly_nbm(
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
             except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove file: {nbm_tmp_nc}",
-                )
+                log_crit(msg=f"Unable to remove file: {nbm_tmp_nc}")
     err_handler.check_program_status(config_options, mpi_config)
 
     if forcings_or_precip.grib_vars is not None:
@@ -11049,10 +10083,8 @@ def regrid_hourly_nbm(
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     if not os.path.exists(config_options.grid_meta):
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg='NBM height file "{config_options.grid_meta}" does not exist',
+                        log_crit(
+                            msg='NBM height file "{config_options.grid_meta}" does not exist'
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11083,10 +10115,8 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11103,10 +10133,8 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11116,10 +10144,8 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11128,10 +10154,8 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11152,10 +10176,8 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11172,10 +10194,8 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11185,10 +10205,8 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11197,10 +10215,8 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11221,10 +10237,8 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11241,10 +10255,8 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11254,10 +10266,8 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11266,10 +10276,8 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11289,10 +10297,8 @@ def regrid_hourly_nbm(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            log_crit(
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11309,10 +10315,8 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}",
+                            log_crit(
+                                msg=f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11322,10 +10326,8 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to compute element mask on NBM elevation data: {npe}",
+                            log_crit(
+                                msg=f"Unable to compute element mask on NBM elevation data: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11334,10 +10336,8 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            log_crit(
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11351,10 +10351,8 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11366,11 +10364,7 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
-                )
+                log_crit(msg=f"Unable to place NBM {tag} into local ESMF field: {err}")
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11380,11 +10374,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid NBM {tag}: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11393,10 +10383,8 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11431,10 +10419,8 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11451,10 +10437,8 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11466,11 +10450,7 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
-                )
+                log_crit(msg=f"Unable to place NBM {tag} into local ESMF field: {err}")
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11480,11 +10460,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid NBM {tag}: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -11492,10 +10468,8 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11530,10 +10504,8 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11550,10 +10522,8 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11565,11 +10535,7 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
-                )
+                log_crit(msg=f"Unable to place NBM {tag} into local ESMF field: {err}")
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11579,11 +10545,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid NBM {tag}: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -11591,10 +10553,8 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11629,10 +10589,8 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11649,10 +10607,8 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11664,11 +10620,7 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
-                )
+                log_crit(msg=f"Unable to place NBM {tag} into local ESMF field: {err}")
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11680,11 +10632,7 @@ def regrid_hourly_nbm(
                     )
                 )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: {ve}",
-                )
+                log_crit(msg=f"Unable to regrid NBM {tag}: {ve}")
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -11692,10 +10640,8 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                log_crit(
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11734,10 +10680,8 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11810,11 +10754,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to remove file: {tmp_file}",
-                    )
+                    log_crit(msg=f"Unable to remove file: {tmp_file}")
         err_handler.check_program_status(config_options, mpi_config)
 
         id_tmp = None
@@ -11942,10 +10882,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         ][time_index, :, :]
                         var_tmp_elem = var_tmp_elem.filled(config_options.globalNdv)
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} from: {input_forcings.tmpFile} ({err})",
+                    log_crit(
+                        msg=f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} from: {input_forcings.tmpFile} ({err})"
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11969,10 +10907,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_in_elem.data[:] = var_sub_tmp_elem
                 # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local array into local ESMF field: {err}",
+                log_crit(
+                    msg=f"Unable to place local array into local ESMF field: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11991,10 +10927,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     )
             except ValueError as ve:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to regrid input NDFD forcing variable using ESMF: {ve}",
+                log_crit(
+                    msg=f"Unable to regrid input NDFD forcing variable using ESMF: {ve}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12010,10 +10944,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # input_forcings.esmf_field_out.data[np.where((input_forcings.esmf_field_out.data/config_options.globalNdv) > 0.75)] = \
                 #     config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to calculate mask from input NDFD regridded forcings: {npe}",
+                log_crit(
+                    msg=f"Unable to calculate mask from input NDFD regridded forcings: {npe}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12065,10 +10997,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     AttributeError,
                     KeyError,
                 ) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to convert NDFD wind speed/dir to U/V components: {npe}",
+                    log_crit(
+                        msg=f"Unable to convert NDFD wind speed/dir to U/V components: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12091,10 +11021,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to run NDV search on NDFD QPF precipitation: {npe}",
+                    log_crit(
+                        msg=f"Unable to run NDV search on NDFD QPF precipitation: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12115,10 +11043,8 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[i], :
                     ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                log_crit(
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}"
                 )
             err_handler.check_program_status(config_options, mpi_config)
         finally:
@@ -12134,11 +11060,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError as e:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to remove scratch file {tmp_file}: {e}",
-                    )
+                    log_crit(msg=f"Unable to remove scratch file {tmp_file}: {e}")
 
 
 def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
@@ -12231,10 +11153,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12246,10 +11166,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12260,10 +11178,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12273,10 +11189,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12295,10 +11209,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12307,10 +11219,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12338,10 +11248,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12353,10 +11261,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12367,10 +11273,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12380,10 +11284,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12401,10 +11303,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12413,10 +11313,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12443,10 +11341,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        log_crit(
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12458,10 +11354,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local array into local ESMF field: {err}",
+                    log_crit(
+                        msg=f"Unable to place local array into local ESMF field: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12474,10 +11368,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    log_crit(
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12487,10 +11379,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    log_crit(
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12511,10 +11401,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        log_crit(
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12523,10 +11411,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    log_crit(
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}"
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -12573,10 +11459,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         with timing_block(
                             f"regrid step 2.5.4 | {mpi_config.rank}: extract error"
                         ):
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                            log_crit(
+                                msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})"
                             )
 
                 with timing_block(
@@ -12597,10 +11481,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place local array into local ESMF field: {err}",
+                        log_crit(
+                            msg=f"Unable to place local array into local ESMF field: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12616,10 +11498,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                        log_crit(
+                            msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12632,10 +11512,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = fill
                     except (ValueError, ArithmeticError) as npe:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                        log_crit(
+                            msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12662,10 +11540,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             AttributeError,
                             KeyError,
                         ) as npe:
-                            err_handler.log_critical(
-                                config_options,
-                                mpi_config,
-                                msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                            log_crit(
+                                msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12677,10 +11553,8 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                        log_crit(
+                            msg=f"Unable to place local ESMF regridded data into local array: {err}"
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12738,10 +11612,8 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}",
+                log_crit(
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}"
                 )
 
         elif config_options.grid_type == "unstructured":
@@ -12752,10 +11624,8 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}",
+                log_crit(
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}"
                 )
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
@@ -12764,10 +11634,8 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
+                log_crit(
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}"
                 )
         elif config_options.grid_type == "hydrofabric":
             try:
@@ -12777,10 +11645,8 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
+                log_crit(
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}"
                 )
 
     err_handler.check_program_status(config_options, mpi_config)
@@ -13340,20 +12206,16 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[0]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
+                log_crit(
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object"
                 )
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
+                log_crit(
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object"
                 )
         else:
             try:
@@ -13361,20 +12223,16 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                log_crit(
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                 )
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[2]
             except (ValueError, KeyError, AttributeError) as err:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                log_crit(
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                 )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13396,10 +12254,8 @@ def calculate_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})",
+        log_crit(
+            msg=f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})"
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13423,20 +12279,16 @@ def calculate_weights(
             input_forcings.y_upper_bound - input_forcings.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})",
+        log_crit(
+            msg=f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})"
         )
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if input_forcings.nx_local < 2 or input_forcings.ny_local < 2:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+        log_crit(
+            msg=f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2."
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13559,20 +12411,16 @@ def calculate_weights(
     try:
         input_forcings.esmf_lats = input_forcings.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to locate latitude coordinate object within input ESMF grid: {ge}",
+        log_crit(
+            msg=f"Unable to locate latitude coordinate object within input ESMF grid: {ge}"
         )
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
         input_forcings.esmf_lons = input_forcings.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"Unable to locate longitude coordinate object within input ESMF grid: {ge}",
+        log_crit(
+            msg=f"Unable to locate longitude coordinate object within input ESMF grid: {ge}"
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13591,11 +12439,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to create ESMF field object: {esmf_error}",
-            )
+            log_crit(msg=f"Unable to create ESMF field object: {esmf_error}")
         err_handler.check_program_status(config_options, mpi_config)
 
     if config_options.grid_type == "unstructured":
@@ -13606,11 +12450,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to create ESMF field object: {esmf_error}",
-            )
+            log_crit(msg=f"Unable to create ESMF field object: {esmf_error}")
         err_handler.check_program_status(config_options, mpi_config)
 
         # Create a ESMF field to hold the incoming data.
@@ -13620,11 +12460,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to create ESMF field object: {esmf_error}",
-            )
+            log_crit(msg=f"Unable to create ESMF field object: {esmf_error}")
         err_handler.check_program_status(config_options, mpi_config)
 
     elif config_options.grid_type == "hydrofabric":
@@ -13635,11 +12471,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to create ESMF field object: {esmf_error}",
-            )
+            log_crit(msg=f"Unable to create ESMF field object: {esmf_error}")
         err_handler.check_program_status(config_options, mpi_config)
 
     # Scatter global grid to processors..
@@ -13849,10 +12681,8 @@ def calculate_supp_pcp_weights(
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if supplemental_precip.nx_local < 2 or supplemental_precip.ny_local < 2:
-        err_handler.log_critical(
-            config_options,
-            mpi_config,
-            msg=f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+        log_crit(
+            msg=f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2."
         )
     err_handler.check_program_status(config_options, mpi_config)
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -110,7 +110,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
                 config_options,
                 mpi_config,
                 debug=True,
-                msg=name + " file being used: " + input_file,
+                msg=f"{name} file being used: {input_file}",
             )  # log at debug level
 
             os.symlink(input_file, tmpFile)
@@ -118,7 +118,7 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create link: " + input_file + " to: " + tmpFile,
+                msg=f"Unable to create link: {input_file} to: {tmpFile}",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -417,8 +417,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract ExtAnA forcing data from the AK AnA field: "
-                        + str(err),
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -441,8 +440,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err),
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -467,8 +465,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err),
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -546,9 +543,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + stage4_tmp_nc
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
@@ -642,11 +637,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -679,11 +670,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -716,11 +703,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -754,11 +737,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -774,8 +753,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -789,8 +767,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -803,8 +780,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -826,8 +802,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -846,8 +821,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -861,8 +835,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -875,8 +848,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -898,8 +870,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -917,8 +888,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -934,8 +904,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -948,8 +917,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -972,8 +940,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -992,8 +959,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1007,8 +973,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1021,8 +986,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1044,8 +1008,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1162,9 +1125,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + stage4_tmp_nc
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
@@ -1258,11 +1219,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1295,11 +1252,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1332,11 +1285,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1370,11 +1319,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1390,8 +1335,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1405,8 +1349,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1419,8 +1362,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1442,8 +1384,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1462,8 +1403,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1477,8 +1417,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1491,8 +1430,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1514,8 +1452,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1533,8 +1470,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1550,8 +1486,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1564,8 +1499,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1588,8 +1522,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1608,8 +1541,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1623,8 +1555,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid STAGE IV supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1637,8 +1568,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1665,8 +1595,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
@@ -1824,13 +1753,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         else f"{input_forcings.fcst_hour2} hour fcst"
                     )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
@@ -1839,7 +1762,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 pattern = "|".join(fields)
                 cmd = f'$WGRIB2 -match "({pattern})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -1869,7 +1792,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing HRRR Variable: " + grib_var,
+                    msg=f"Processing HRRR Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -1921,12 +1844,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1941,8 +1859,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1965,8 +1882,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1979,8 +1895,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1990,8 +1905,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2005,12 +1919,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2025,8 +1934,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2049,8 +1957,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2063,8 +1970,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2074,8 +1980,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2085,12 +1990,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2105,8 +2005,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2129,8 +2028,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2143,8 +2041,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2156,8 +2053,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2171,12 +2067,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2191,8 +2082,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2215,8 +2105,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2229,8 +2118,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform HRRR mask search on elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2240,8 +2128,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err),
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2268,8 +2155,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2293,13 +2179,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2314,8 +2194,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2324,8 +2203,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2337,7 +2215,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2350,8 +2228,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2363,8 +2240,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2386,8 +2262,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2411,13 +2286,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2432,8 +2301,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2442,8 +2310,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2455,7 +2322,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2468,8 +2335,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2481,8 +2347,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2503,8 +2368,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2528,13 +2392,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2549,8 +2407,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2559,8 +2416,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -2574,7 +2430,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2587,8 +2443,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2600,8 +2455,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2623,8 +2477,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2648,13 +2501,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2669,8 +2516,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place input HRRR data into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2679,8 +2525,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2692,7 +2537,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2705,8 +2550,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe),
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2718,8 +2562,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err),
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2807,9 +2650,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -2817,7 +2658,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to remove file: " + input_forcings.tmpFile,
+                            msg=f"Unable to remove file: {input_forcings.tmpFile}",
                         )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -2828,38 +2669,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting CONUS RAP Variable: " + grib_var,
+                        msg=f"Converting CONUS RAP Variable: {grib_var}",
                     )  # log at debug level
                 time_str = (
-                    "{}-{} hour acc fcst".format(
-                        input_forcings.fcst_hour1, input_forcings.fcst_hour2
-                    )
+                    f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
-                    else str(input_forcings.fcst_hour2) + " hour fcst"
+                    else f"{input_forcings.fcst_hour2} hour fcst"
                 )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -2889,7 +2715,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing Conus RAP Variable: " + grib_var,
+                    msg=f"Processing Conus RAP Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -2940,11 +2766,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2959,8 +2781,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2983,8 +2804,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2997,8 +2817,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3008,8 +2827,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3023,11 +2841,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3042,8 +2856,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3066,8 +2879,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3080,8 +2892,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3091,8 +2902,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3105,11 +2915,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3124,8 +2930,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3148,8 +2953,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3162,8 +2966,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3175,8 +2978,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3190,11 +2992,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3209,8 +3007,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3233,8 +3030,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid RAP elevation data using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3247,8 +3043,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on RAP elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3258,8 +3053,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF elevation field into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3292,13 +3086,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3313,8 +3101,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3323,8 +3110,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3336,9 +3122,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3351,11 +3135,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3368,8 +3148,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3413,13 +3192,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3434,8 +3207,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3444,8 +3216,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3457,9 +3228,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3472,11 +3241,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3489,8 +3254,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3533,13 +3297,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3554,8 +3312,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3564,8 +3321,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -3579,9 +3335,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3594,11 +3348,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3611,8 +3361,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF element data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF element data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3657,13 +3406,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3678,8 +3421,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local RAP array into ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3688,8 +3430,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3701,9 +3442,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve),
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3716,11 +3455,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3733,8 +3468,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place RAP ESMF data into local array: "
-                            + str(err),
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3841,9 +3575,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -3851,9 +3583,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to remove previous temporary file: "
-                            + input_forcings.tmpFile
-                            + str(err),
+                            msg=f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err}",
                         )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -3864,31 +3594,18 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting CFSv2 Variable: " + grib_var,
+                        msg=f"Converting CFSv2 Variable: {grib_var}",
                     )  # log at debug level
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + str(input_forcings.fcst_hour2)
-                    + " hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -3918,7 +3635,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing CFSv2 Variable: " + grib_var,
+                    msg=f"Processing CFSv2 Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -3972,11 +3689,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3991,8 +3704,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4016,8 +3728,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4030,8 +3741,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4041,8 +3751,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4056,11 +3765,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4075,8 +3780,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4100,8 +3804,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4114,8 +3817,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4125,8 +3827,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4139,11 +3840,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4158,8 +3855,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4183,8 +3879,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4197,8 +3892,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4210,8 +3904,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4225,11 +3918,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4244,8 +3933,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4269,8 +3957,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve),
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4283,8 +3970,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe),
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4294,8 +3980,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4325,8 +4010,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -4336,13 +4020,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4383,13 +4061,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4413,8 +4085,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4430,11 +4101,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4447,11 +4114,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4463,8 +4126,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4495,8 +4157,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -4506,13 +4167,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4553,13 +4208,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4583,8 +4232,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4600,11 +4248,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4617,11 +4261,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4633,8 +4273,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4664,8 +4303,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -4675,13 +4313,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4724,13 +4356,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count})
 
@@ -4754,8 +4380,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4771,11 +4396,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4788,11 +4409,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4804,8 +4421,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4836,8 +4452,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count],
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -4847,13 +4462,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4894,13 +4503,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4924,8 +4527,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4941,11 +4543,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")",
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4958,11 +4556,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")",
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4974,8 +4568,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF field data for CFSv2: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5071,7 +4664,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+                msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
             )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
@@ -5109,7 +4702,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
@@ -5117,13 +4710,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5138,8 +4725,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5153,8 +4739,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5166,8 +4751,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5189,7 +4773,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
@@ -5197,13 +4781,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5218,8 +4796,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5233,8 +4810,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5246,8 +4822,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5268,7 +4843,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
@@ -5276,13 +4851,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5297,8 +4866,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5312,8 +4880,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5325,8 +4892,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5348,7 +4914,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom netCDF input variable: " + nc_var,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
@@ -5356,13 +4922,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5377,8 +4937,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5392,8 +4951,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5405,8 +4963,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5425,7 +4982,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -5488,7 +5045,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing Custom zarr Forcing Variable: " + nc_var,
+                msg=f"Processing Custom zarr Forcing Variable: {nc_var}",
             )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
@@ -5524,7 +5081,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
@@ -5532,13 +5089,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5553,8 +5104,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5568,8 +5118,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5581,8 +5130,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5604,7 +5152,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
@@ -5612,13 +5160,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5633,8 +5175,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5648,8 +5189,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5661,8 +5201,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5683,7 +5222,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
@@ -5691,13 +5230,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5712,8 +5245,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5727,8 +5259,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5740,8 +5271,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5763,7 +5293,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding Custom zarr input variable: " + nc_var,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
@@ -5771,13 +5301,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5796,8 +5320,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5811,8 +5334,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5824,8 +5346,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5844,7 +5365,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -5920,7 +5441,7 @@ def regrid_custom_hourly_netcdf(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
                 )  # log at debug level
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -5970,8 +5491,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5994,8 +5514,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6008,8 +5527,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6021,8 +5539,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6045,8 +5562,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6069,8 +5585,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6083,8 +5598,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6096,8 +5610,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6121,8 +5634,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6145,8 +5657,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6159,8 +5670,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6172,8 +5682,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6196,8 +5705,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6220,8 +5728,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6234,8 +5741,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6247,8 +5753,7 @@ def regrid_custom_hourly_netcdf(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -6276,7 +5781,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6290,13 +5795,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6311,8 +5810,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6326,8 +5824,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6340,8 +5837,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6363,8 +5859,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6376,8 +5871,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6402,7 +5896,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6416,13 +5910,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6437,8 +5925,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6452,8 +5939,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6466,8 +5952,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6488,8 +5973,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6501,8 +5985,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6526,7 +6009,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6540,13 +6023,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6561,8 +6038,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6578,8 +6054,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6592,8 +6067,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6617,8 +6091,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6630,8 +6103,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6656,7 +6128,7 @@ def regrid_custom_hourly_netcdf(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -6670,13 +6142,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6690,8 +6156,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6705,8 +6170,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6719,8 +6183,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6746,8 +6209,7 @@ def regrid_custom_hourly_netcdf(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6759,8 +6221,7 @@ def regrid_custom_hourly_netcdf(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6779,7 +6240,7 @@ def regrid_custom_hourly_netcdf(
                 id_tmp.close()
             except OSError:
                 config_options.errMsg = (
-                    "Unable to close NetCDF file: " + input_forcings.tmpFile
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
                 )
                 err_handler.err_out(config_options)
 
@@ -6846,7 +6307,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing ERA-5 Interim Forcing Variable: " + nc_var,
+                msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}",
             )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
@@ -6893,7 +6354,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -6918,13 +6379,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6939,8 +6394,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6954,8 +6408,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6968,8 +6421,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6985,8 +6437,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6998,8 +6449,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7021,7 +6471,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -7046,13 +6496,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7067,8 +6511,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7082,8 +6525,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7096,8 +6538,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7113,8 +6554,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7126,8 +6566,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7148,7 +6587,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -7177,13 +6616,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7198,8 +6631,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7213,8 +6645,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7227,8 +6658,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7246,8 +6676,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7260,8 +6689,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7283,7 +6711,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding ERA5-Interim input variable: " + nc_var,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
                 )  # log at debug level
                 try:
                     err_handler.log_msg(
@@ -7308,13 +6736,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7329,8 +6751,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7344,8 +6765,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve),
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7358,8 +6778,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe),
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7375,8 +6794,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7388,8 +6806,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7409,7 +6826,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -7481,9 +6898,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_warning(
                     config_options,
                     mpi_config,
-                    msg="Found old temporary file: "
-                    + input_forcings.tmpFile
-                    + " - Removing.....",
+                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                 )
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -7491,7 +6906,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to remove file: " + input_forcings.tmpFile,
+                        msg=f"Unable to remove file: {input_forcings.tmpFile}",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7502,7 +6917,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting 13km GFS Variable: " + grib_var,
+                        msg=f"Converting 13km GFS Variable: {grib_var}",
                     )  # log at debug level
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
@@ -7518,40 +6933,19 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         tmp_hr_previous = input_forcings.fcst_hour1
 
                     fields.append(
-                        ":"
-                        + grib_var
-                        + ":"
-                        + input_forcings.grib_levels[force_count]
-                        + ":"
-                        + str(tmp_hr_previous)
-                        + "-"
-                        + str(input_forcings.fcst_hour2)
-                        + " hour ave fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{tmp_hr_previous}-{input_forcings.fcst_hour2} hour ave fcst:"
                     )
                 else:
                     fields.append(
-                        ":"
-                        + grib_var
-                        + ":"
-                        + input_forcings.grib_levels[force_count]
-                        + ":"
-                        + str(input_forcings.fcst_hour2)
-                        + " hour fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                     )
 
             # if calc_regrid_flag:
             fields.append(":(HGT):(surface):")
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -7581,7 +6975,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing 13km GFS Variable: " + grib_var,
+                    msg=f"Processing 13km GFS Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -7634,11 +7028,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7655,11 +7045,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7676,11 +7062,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7697,11 +7079,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")",
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
                             )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7716,8 +7094,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local GFS array into an ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local GFS array into an ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7741,7 +7118,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data: " + str(ve),
+                            msg=f"Unable to regrid GFS elevation data: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7754,8 +7131,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7772,8 +7148,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data with ESMF mesh nodes: "
-                            + str(ve),
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7783,8 +7158,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place local GFS array into an ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place local GFS array into an ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7800,8 +7174,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data with ESMF mesh elements: "
-                            + str(ve),
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7814,8 +7187,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7828,8 +7200,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
@@ -7845,7 +7216,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid GFS elevation data: " + str(ve),
+                            msg=f"Unable to regrid GFS elevation data: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7858,8 +7229,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to perform mask search on GFS elevation data: "
-                            + str(npe),
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7870,8 +7240,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -7881,8 +7250,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7894,8 +7262,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field with mesh elements: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7906,8 +7273,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract GFS elevation array from ESMF field: "
-                            + str(err),
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7938,13 +7304,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
@@ -7958,13 +7318,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7978,13 +7332,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -7998,13 +7346,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8079,8 +7421,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
@@ -8090,8 +7431,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
@@ -8100,8 +7440,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -8111,8 +7450,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place GFS local array into ESMF element field object: "
-                        + str(err),
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8122,8 +7460,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8138,17 +7475,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding took {} seconds".format(end - begin),
+                            msg=f"Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8161,11 +7494,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8177,8 +7506,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8197,8 +7525,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field for Mesh nodes: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8213,17 +7540,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Node Regridding took {} seconds".format(end - begin),
+                            msg=f"Node Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable for Mesh Nodes: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8236,11 +7559,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8252,8 +7571,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8271,8 +7589,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field for Mesh elements: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8289,19 +7606,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Element Regridding took {} seconds".format(
-                                end - begin
-                            ),
+                            msg=f"Element Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8314,11 +7625,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8330,8 +7637,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8350,8 +7656,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Input 13km GFS Field for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -8366,19 +7671,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Element Regridding took {} seconds".format(
-                                end - begin
-                            ),
+                            msg=f"Element Regridding took {end - begin} seconds",
                         )  # log at debug level
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid GFS variable for Mesh Element: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")",
+                        msg=f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8391,11 +7690,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")",
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8407,8 +7702,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract GFS ESMF field data to local array: "
-                        + str(err),
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8441,7 +7735,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to remove NetCDF file: " + input_forcings.tmpFile,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -8498,9 +7792,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -8515,31 +7807,18 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting NAM-Nest Variable: " + grib_var,
+                        msg=f"Converting NAM-Nest Variable: {grib_var}",
                     )  # log at debug level
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + str(input_forcings.fcst_hour2)
-                    + " hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -8572,7 +7851,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing NAM Nest Variable: " + grib_var,
+                    msg=f"Processing NAM Nest Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -8632,8 +7911,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8656,8 +7934,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8670,8 +7947,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8681,8 +7957,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8705,8 +7980,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8729,8 +8003,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8743,8 +8016,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8754,8 +8026,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8777,8 +8048,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8801,8 +8071,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8815,8 +8084,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8828,8 +8096,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8852,8 +8119,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8876,8 +8142,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8890,8 +8155,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on NAM nest elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8901,8 +8165,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8931,8 +8194,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -8942,13 +8204,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8963,8 +8219,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8978,8 +8233,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8992,8 +8246,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9005,8 +8258,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9028,8 +8280,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -9039,13 +8290,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9060,8 +8305,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9075,8 +8319,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9089,8 +8332,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9102,8 +8344,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9124,8 +8365,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -9135,13 +8375,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9156,8 +8390,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9173,8 +8406,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9187,8 +8419,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9200,8 +8431,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9223,8 +8453,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -9234,13 +8463,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9255,8 +8478,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9270,8 +8492,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9284,8 +8505,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9297,8 +8517,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9460,7 +8679,7 @@ def regrid_mrms_hourly(
 
             # Perform a GRIB dump to NetCDF for the MRMS precip and RQI data.
             if WGRIB2_env:
-                cmd1 = "$WGRIB2 " + mrms_tmp_grib2 + " -netcdf " + mrms_tmp_nc
+                cmd1 = f"$WGRIB2 {mrms_tmp_grib2} -netcdf {mrms_tmp_nc}"
             else:
                 cmd1 = mrms_tmp_grib2
 
@@ -9477,9 +8696,7 @@ def regrid_mrms_hourly(
 
             if supplemental_precip.rqiMethod == 1:
                 if WGRIB2_env:
-                    cmd2 = (
-                        "$WGRIB2 " + mrms_tmp_rqi_grib2 + " -netcdf " + mrms_tmp_rqi_nc
-                    )
+                    cmd2 = f"$WGRIB2 {mrms_tmp_rqi_grib2} -netcdf {mrms_tmp_rqi_nc}"
                 else:
                     cmd2 = mrms_tmp_rqi_grib2
 
@@ -9551,13 +8768,7 @@ def regrid_mrms_hourly(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9572,8 +8783,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place MRMS data into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9596,7 +8806,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid MRMS RQI field: " + str(ve),
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9619,8 +8829,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation for MRMS RQI data: "
-                        + str(npe),
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9635,13 +8844,7 @@ def regrid_mrms_hourly(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9656,8 +8859,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place MRMS data into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9680,7 +8882,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid MRMS RQI field: " + str(ve),
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9703,8 +8905,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation for MRMS RQI data: "
-                        + str(npe),
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9718,13 +8919,7 @@ def regrid_mrms_hourly(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9739,8 +8934,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place MRMS data into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9763,7 +8957,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid MRMS RQI field: " + str(ve),
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9786,8 +8980,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run mask calculation for MRMS RQI data: "
-                        + str(npe),
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9842,7 +9035,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
@@ -9852,13 +9045,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9880,7 +9067,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9901,8 +9088,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9935,7 +9121,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9954,8 +9140,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe),
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9978,7 +9163,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
@@ -9988,13 +9173,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10016,7 +9195,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10037,8 +9216,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10071,7 +9249,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10090,8 +9268,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe),
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10113,7 +9290,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_mrms.variables[
@@ -10123,13 +9300,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10153,7 +9324,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10177,8 +9348,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10211,7 +9381,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10229,8 +9399,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run global NDV search on MRMS regridded precip: "
-                    + str(npe),
+                    msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10253,7 +9422,7 @@ def regrid_mrms_hourly(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
@@ -10263,13 +9432,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10291,7 +9454,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid MRMS precipitation: " + str(ve),
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10312,8 +9475,7 @@ def regrid_mrms_hourly(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on MRMS supplemental precip: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10346,7 +9508,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10365,8 +9527,7 @@ def regrid_mrms_hourly(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe),
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10459,7 +9620,7 @@ def regrid_mrms_precip_flag(
     err_handler.check_program_status(config_options, mpi_config)
 
     # Perform a GRIB dump to NetCDF for the MRMS precip and RQI data.
-    cmd1 = "$WGRIB2 " + mrms_tmp_grib2 + " -netcdf " + mrms_tmp_nc
+    cmd1 = f"$WGRIB2 {mrms_tmp_grib2} -netcdf {mrms_tmp_nc}"
     id_tmp = ioMod.open_grib2(
         mrms_tmp_grib2,
         mrms_tmp_nc,
@@ -10505,11 +9666,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to extract PrecipFlag from file: "
-                + supplemental_precip.file_in2
-                + " ("
-                + str(err)
-                + ")",
+                msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10527,7 +9684,7 @@ def regrid_mrms_precip_flag(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to place MRMS PrecipFlag into local ESMF field: " + str(err),
+            msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10541,7 +9698,7 @@ def regrid_mrms_precip_flag(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+            msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10557,7 +9714,7 @@ def regrid_mrms_precip_flag(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
+            msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10590,11 +9747,7 @@ def regrid_mrms_precip_flag(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract PrecipFlag from file: "
-                    + supplemental_precip.file_in2
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10616,8 +9769,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place MRMS PrecipFlag into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10631,7 +9783,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+                msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10647,7 +9799,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
+                msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10672,7 +9824,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to close NetCDF file: " + supplemental_precip.file_in2,
+                msg=f"Unable to close NetCDF file: {supplemental_precip.file_in2}",
             )
         try:
             os_utils.os_remove_retry(mrms_tmp_nc)
@@ -10680,7 +9832,7 @@ def regrid_mrms_precip_flag(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to remove NetCDF file: " + mrms_tmp_nc,
+                msg=f"Unable to remove NetCDF file: {mrms_tmp_nc}",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10741,9 +9893,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -10758,38 +9908,23 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Converting WRF-ARW Variable: " + grib_var,
+                        msg=f"Converting WRF-ARW Variable: {grib_var}",
                     )  # log at debug level
                 time_str = (
-                    "{}-{} hour acc fcst".format(
-                        input_forcings.fcst_hour1, input_forcings.fcst_hour2
-                    )
+                    f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
-                    else str(input_forcings.fcst_hour2) + " hour fcst"
+                    else f"{input_forcings.fcst_hour2} hour fcst"
                 )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -10822,7 +9957,7 @@ def regrid_hourly_wrf_arw(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing WRF-ARW Variable: " + grib_var,
+                    msg=f"Processing WRF-ARW Variable: {grib_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -10882,8 +10017,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10906,8 +10040,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10920,8 +10053,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10931,8 +10063,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -10954,8 +10085,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10978,8 +10108,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10992,8 +10121,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11003,8 +10131,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11026,8 +10153,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11050,8 +10176,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11064,8 +10189,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11077,8 +10201,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11101,8 +10224,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err),
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11125,8 +10247,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11139,8 +10260,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe),
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11150,8 +10270,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
-                            + str(err),
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11180,8 +10299,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -11191,13 +10309,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11212,8 +10324,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11227,8 +10338,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11241,8 +10351,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11266,8 +10375,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11279,8 +10387,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11302,8 +10409,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -11313,13 +10419,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11334,8 +10434,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11349,8 +10448,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11363,8 +10461,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11388,8 +10485,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11401,8 +10497,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11423,8 +10518,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -11434,13 +10528,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11455,8 +10543,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11472,8 +10559,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11486,8 +10572,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11512,8 +10597,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11525,8 +10609,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11548,8 +10631,7 @@ def regrid_hourly_wrf_arw(
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count],
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
@@ -11559,13 +10641,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11580,8 +10656,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11595,8 +10670,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11609,8 +10683,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11634,8 +10707,7 @@ def regrid_hourly_wrf_arw(
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11647,8 +10719,7 @@ def regrid_hourly_wrf_arw(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11736,9 +10807,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_warning(
                         config_options,
                         mpi_config,
-                        msg="Found old temporary file: "
-                        + arw_tmp_nc
-                        + " - Removing.....",
+                        msg=f"Found old temporary file: {arw_tmp_nc} - Removing.....",
                     )
                     try:
                         os_utils.os_remove_retry(arw_tmp_nc)
@@ -11758,26 +10827,9 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    "$WGRIB2 "
-                    + supplemental_precip.file_in1
-                    + ' -match ":('
-                    + "APCP):(surface):("
-                    + str(supplemental_precip.fcst_hour1 - 1)
-                    + "-"
-                    + str(supplemental_precip.fcst_hour1)
-                    + ' hour acc fcst):"'
-                    + " -netcdf "
-                    + arw_tmp_nc
-                )
+                cmd = f'$WGRIB2 {supplemental_precip.file_in1} -match ":(APCP):(surface):({supplemental_precip.fcst_hour1 - 1}-{supplemental_precip.fcst_hour1} hour acc fcst):" -netcdf {arw_tmp_nc}'
             else:
-                cmd = (
-                    "(APCP):(surface):("
-                    + str(supplemental_precip.fcst_hour1 - 1)
-                    + "-"
-                    + str(supplemental_precip.fcst_hour1)
-                    + " hour acc fcst)"
-                )
+                cmd = f"(APCP):(surface):({supplemental_precip.fcst_hour1 - 1}-{supplemental_precip.fcst_hour1} hour acc fcst)"
 
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in1,
@@ -11835,11 +10887,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11854,8 +10902,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11869,8 +10916,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11883,8 +10929,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11906,8 +10951,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11936,11 +10980,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11955,8 +10995,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11970,8 +11009,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11984,8 +11022,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12007,8 +11044,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12036,11 +11072,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12055,8 +11087,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12072,8 +11103,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12086,8 +11116,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12110,8 +11139,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12140,11 +11168,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12159,8 +11183,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12174,8 +11197,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to regrid WRF ARW supplemental precipitation: "
-                    + str(ve),
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12188,8 +11210,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12211,8 +11232,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12318,11 +11338,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12339,8 +11355,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12354,7 +11369,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12370,8 +11385,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12405,11 +11419,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12426,8 +11436,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12441,7 +11450,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12457,8 +11466,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12493,11 +11501,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12514,8 +11518,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12531,7 +11534,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12547,8 +11550,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12581,11 +11583,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
                 )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12602,8 +11600,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err),
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12617,7 +11614,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12633,8 +11630,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
-                + str(npe),
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12659,7 +11655,7 @@ def regrid_sbcv2_liquid_water_fraction(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to close NetCDF file: " + supplemental_forcings.file_in1,
+                msg=f"Unable to close NetCDF file: {supplemental_forcings.file_in1}",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12710,7 +11706,7 @@ def regrid_hourly_nbm(
             err_handler.log_warning(
                 config_options,
                 mpi_config,
-                msg="Found old temporary file: " + nbm_tmp_nc + " - Removing.....",
+                msg=f"Found old temporary file: {nbm_tmp_nc} - Removing.....",
             )
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
@@ -12718,7 +11714,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to remove file: " + nbm_tmp_nc,
+                    msg=f"Unable to remove file: {nbm_tmp_nc}",
                 )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12730,57 +11726,27 @@ def regrid_hourly_nbm(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Converting NBM Variable: " + grib_var,
+                    msg=f"Converting NBM Variable: {grib_var}",
                 )  # log at debug level
             time_str = (
-                "{}-{} hour acc fcst".format(
-                    forcings_or_precip.fcst_hour1, forcings_or_precip.fcst_hour2
-                )
+                f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
-                else str(forcings_or_precip.fcst_hour2) + " hour fcst"
+                else f"{forcings_or_precip.fcst_hour2} hour fcst"
             )
             fields.append(
-                ":"
-                + grib_var
-                + ":"
-                + forcings_or_precip.grib_levels[force_count]
-                + ":"
-                + time_str
-                + ":"
+                f":{grib_var}:{forcings_or_precip.grib_levels[force_count]}:{time_str}:"
             )
         # fields.append(":(HGT):(surface):")
         # Create a temporary NetCDF file from the GRIB2 file.
-        cmd = (
-            '$WGRIB2 -match "('
-            + "|".join(fields)
-            + ')" -not "prob" -not "ens" '
-            + forcings_or_precip.file_in1
-            + " -netcdf "
-            + nbm_tmp_nc
-        )
+        cmd = f'$WGRIB2 -match "({"|".join(fields)})" -not "prob" -not "ens" {forcings_or_precip.file_in1} -netcdf {nbm_tmp_nc}'
     else:
         # Perform a GRIB dump to NetCDF for the precip data.
         fieldnbm_match1 = '":APCP:"'
         fieldnbm_match2 = (
-            '"'
-            + str(forcings_or_precip.fcst_hour1)
-            + "-"
-            + str(forcings_or_precip.fcst_hour2)
-            + '"'
+            f'"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2}"'
         )
         fieldnbm_notmatch1 = '"prob"'  # We don't want the probabilistic QPF layers
-        cmd = (
-            "$WGRIB2 "
-            + forcings_or_precip.file_in1
-            + " -match "
-            + fieldnbm_match1
-            + " -match "
-            + fieldnbm_match2
-            + " -not "
-            + fieldnbm_notmatch1
-            + " -netcdf "
-            + nbm_tmp_nc
-        )
+        cmd = f"$WGRIB2 {forcings_or_precip.file_in1} -match {fieldnbm_match1} -match {fieldnbm_match2} -not {fieldnbm_notmatch1} -netcdf {nbm_tmp_nc}"
 
     id_tmp = ioMod.open_grib2(
         forcings_or_precip.file_in1,
@@ -12802,7 +11768,7 @@ def regrid_hourly_nbm(
                 config_options,
                 mpi_config,
                 debug=True,
-                msg="Processing NBM Variable: " + nc_var,
+                msg=f"Processing NBM Variable: {nc_var}",
             )  # log at debug level
 
         # Check to see if we need to calculate regridding weights.
@@ -12910,8 +11876,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12934,8 +11899,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12948,8 +11912,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12961,8 +11924,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12986,8 +11948,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13010,8 +11971,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13024,8 +11984,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13037,8 +11996,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13062,8 +12020,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13086,8 +12043,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13100,8 +12056,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13113,8 +12068,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13137,8 +12091,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err),
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13161,8 +12114,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to regrid NBM elevation data to the unstructured domain using ESMF: "
-                                + str(ve),
+                                msg=f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13175,8 +12127,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to compute element mask on NBM elevation data: "
-                                + str(npe),
+                                msg=f"Unable to compute element mask on NBM elevation data: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13188,8 +12139,7 @@ def regrid_hourly_nbm(
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
-                                + str(err),
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13212,11 +12162,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13231,7 +12177,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13245,7 +12191,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13258,8 +12204,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13297,8 +12242,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13323,11 +12267,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13342,7 +12282,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13356,7 +12296,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -13368,8 +12308,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13407,8 +12346,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13433,11 +12371,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13452,7 +12386,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13466,7 +12400,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -13478,8 +12412,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13517,8 +12450,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13543,11 +12475,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")",
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
                     )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13562,7 +12490,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13578,7 +12506,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                    msg=f"Unable to regrid NBM {tag}: {ve}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -13590,8 +12518,7 @@ def regrid_hourly_nbm(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe),
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -13633,8 +12560,7 @@ def regrid_hourly_nbm(
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to run NDV search on NBM precipitation: "
-                        + str(npe),
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13652,7 +12578,7 @@ def regrid_hourly_nbm(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to close NetCDF file: " + forcings_or_precip.file_in1,
+                msg=f"Unable to close NetCDF file: {forcings_or_precip.file_in1}",
             )
         try:
             os_utils.os_remove_retry(nbm_tmp_nc)
@@ -13660,7 +12586,7 @@ def regrid_hourly_nbm(
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to remove temporary NBM NetCDF file: " + nbm_tmp_nc,
+                msg=f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc}",
             )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13839,7 +12765,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing NDFD variable: " + ndfd_var,
+                    msg=f"Processing NDFD variable: {ndfd_var}",
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -13915,8 +12841,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local array into local ESMF field: "
-                    + str(err),
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -14062,8 +12987,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to place local ESMF regridded data into local array: "
-                    + str(err),
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
             err_handler.check_program_status(config_options, mpi_config)
         finally:
@@ -14128,7 +13052,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
                 )  # log at debug level
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
@@ -14179,7 +13103,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -14193,13 +13117,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14214,8 +13132,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14229,8 +13146,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14243,8 +13159,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14266,8 +13181,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14279,8 +13193,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14305,7 +13218,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -14319,13 +13232,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14340,8 +13247,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14355,8 +13261,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14369,8 +13274,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14391,8 +13295,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14404,8 +13307,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14429,7 +13331,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options,
                         mpi_config,
                         debug=True,
-                        msg="Regridding Custom netCDF input variable: " + nc_var,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
                     )  # log at debug level
                     try:
                         err_handler.log_msg(
@@ -14443,13 +13345,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")",
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
                         )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14464,8 +13360,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local array into local ESMF field: "
-                        + str(err),
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14481,8 +13376,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve),
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14495,8 +13389,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe),
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14520,8 +13413,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe),
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14533,8 +13425,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.log_critical(
                         config_options,
                         mpi_config,
-                        msg="Unable to place local ESMF regridded data into local array: "
-                        + str(err),
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
                     )
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -14566,7 +13457,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             config_options,
                             mpi_config,
                             debug=True,
-                            msg="Regridding Custom netCDF input variable: " + nc_var,
+                            msg=f"Regridding Custom netCDF input variable: {nc_var}",
                         )  # log at debug level
                     try:
                         with timing_block(
@@ -14614,8 +13505,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place local array into local ESMF field: "
-                            + str(err),
+                            msg=f"Unable to place local array into local ESMF field: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14634,8 +13524,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                            + str(ve),
+                            msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14651,8 +13540,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
-                            + str(npe),
+                            msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14682,8 +13570,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             err_handler.log_critical(
                                 config_options,
                                 mpi_config,
-                                msg="Unable to run NDV search on Custom netCDF precipitation: "
-                                + str(npe),
+                                msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -14698,8 +13585,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         err_handler.log_critical(
                             config_options,
                             mpi_config,
-                            msg="Unable to place local ESMF regridded data into local array: "
-                            + str(err),
+                            msg=f"Unable to place local ESMF regridded data into local array: {err}",
                         )
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14742,16 +13628,13 @@ def check_regrid_status(
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}",
                 )
 
         elif config_options.grid_type == "unstructured":
@@ -14759,47 +13642,38 @@ def check_regrid_status(
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.NODE,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field node mesh object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}",
                 )
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field element mesh object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
                 )
         elif config_options.grid_type == "hydrofabric":
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field element mesh object: "
-                    + str(esmf_error),
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
                 )
 
     err_handler.check_program_status(config_options, mpi_config)
@@ -14911,45 +13785,30 @@ def check_supp_pcp_regrid_status(
             try:
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF field object: {esmf_error}"
                 err_handler.err_out(config_options)
         elif config_options.grid_type == "unstructured":
             try:
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.NODE,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF node field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF node field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
             try:
                 supplemental_precip.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF element field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
         elif config_options.grid_type == "hydrofabric":
@@ -14957,15 +13816,10 @@ def check_supp_pcp_regrid_status(
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF element field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
     # Determine if we need to calculate a regridding object. The following situations warrant the calculation of
@@ -15188,8 +14042,7 @@ def load_weight_file(
         err_handler.log_warning(
             config_options,
             mpi_config,
-            msg=f"Unable to load cached ESMF{msg_augment}weight file: "
-            + str(esmf_error),
+            msg=f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error}",
         )
     else:
         err_handler.log_msg(
@@ -15258,8 +14111,7 @@ def make_regrid(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
-            + str(esmf_error),
+            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error}",
         )
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
@@ -15306,8 +14158,7 @@ def execute_regrid(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to extract regridded data from ESMF regridded field: "
-            + str(ve),
+            msg=f"Unable to extract regridded data from ESMF regridded field: {ve}",
         )
         # delete bad cached file if it exists
         if weight_file is not None:
@@ -15368,9 +14219,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Y shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object",
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
                 )
             try:
                 input_forcings.nx_global = id_tmp.variables[
@@ -15380,9 +14229,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract X shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object",
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
                 )
         else:
             try:
@@ -15393,13 +14240,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract Y shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from: "
-                    + input_forcings.tmpFile
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                 )
             try:
                 input_forcings.nx_global = id_tmp.variables[
@@ -15409,13 +14250,7 @@ def calculate_weights(
                 err_handler.log_critical(
                     config_options,
                     mpi_config,
-                    msg="Unable to extract X shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from: "
-                    + input_forcings.tmpFile
-                    + " ("
-                    + str(err)
-                    + ")",
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
                 )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15440,11 +14275,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to create source ESMF grid from temporary file: "
-            + input_forcings.tmpFile
-            + " ("
-            + str(esmf_error)
-            + ")",
+            msg=f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15471,12 +14302,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to extract local X/Y boundaries from global grid from temporary "
-            + "file: "
-            + input_forcings.tmpFile
-            + " ("
-            + str(err)
-            + ")",
+            msg=f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15486,9 +14312,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="You have either specified too many cores for: "
-            + input_forcings.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+            msg=f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15504,9 +14328,7 @@ def calculate_weights(
                     config_options,
                     mpi_config,
                     debug=True,
-                    msg="Trimming input forcing `{}` by {} grid cells".format(
-                        input_forcings.product_name, border
-                    ),
+                    msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells",
                 )  # log at debug level
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
@@ -15619,8 +14441,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to locate latitude coordinate object within input ESMF grid: "
-            + str(ge),
+            msg=f"Unable to locate latitude coordinate object within input ESMF grid: {ge}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15630,8 +14451,7 @@ def calculate_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="Unable to locate longitude coordinate object within input ESMF grid: "
-            + str(ge),
+            msg=f"Unable to locate longitude coordinate object within input ESMF grid: {ge}",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15647,13 +14467,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15662,13 +14482,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15676,13 +14496,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in_elem = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE_ELEMENT",
+                name=f"{input_forcings.product_name}_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15691,13 +14511,13 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
             err_handler.log_critical(
                 config_options,
                 mpi_config,
-                msg="Unable to create ESMF field object: " + str(esmf_error),
+                msg=f"Unable to create ESMF field object: {esmf_error}",
             )
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -15836,7 +14656,7 @@ def calculate_supp_pcp_weights(
         else:
             latdim = londim = -1
             config_options.errMsg = (
-                "Unable to determine lat/lon grid size from " + tmp_file
+                f"Unable to determine lat/lon grid size from {tmp_file}"
             )
             err_handler.err_out(config_options)
 
@@ -15845,34 +14665,14 @@ def calculate_supp_pcp_weights(
                 supplemental_precip.netcdf_var_names[0]
             ].shape[latdim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = (
-                "Unable to extract Y shape size from: "
-                + supplemental_precip.netcdf_var_names[0]
-                + " from: "
-                + tmp_file
-                + " ("
-                + str(err)
-                + ", "
-                + type(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract Y shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err}, {type(err)})"
             err_handler.err_out(config_options)
         try:
             supplemental_precip.nx_global = id_tmp.variables[
                 supplemental_precip.netcdf_var_names[0]
             ].shape[londim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = (
-                "Unable to extract X shape size from: "
-                + supplemental_precip.netcdf_var_names[0]
-                + " from: "
-                + tmp_file
-                + " ("
-                + str(err)
-                + ", "
-                + type(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract X shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err}, {type(err)})"
             err_handler.err_out(config_options)
 
     # mpi_config.comm.barrier()
@@ -15894,13 +14694,7 @@ def calculate_supp_pcp_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = (
-            "Unable to create source ESMF grid from temporary file: "
-            + tmp_file
-            + " ("
-            + str(esmf_error)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {tmp_file} ({esmf_error})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -15924,14 +14718,7 @@ def calculate_supp_pcp_weights(
             supplemental_precip.y_upper_bound - supplemental_precip.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to extract local X/Y boundaries from global grid from temporary "
-            + "file: "
-            + tmp_file
-            + " ("
-            + str(err)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {tmp_file} ({err})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -15941,9 +14728,7 @@ def calculate_supp_pcp_weights(
         err_handler.log_critical(
             config_options,
             mpi_config,
-            msg="You have either specified too many cores for: "
-            + supplemental_precip.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+            msg=f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15993,20 +14778,14 @@ def calculate_supp_pcp_weights(
     try:
         supplemental_precip.esmf_lats = supplemental_precip.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate latitude coordinate object within supplemental precip ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate latitude coordinate object within supplemental precip ESMF grid: {ge}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
     try:
         supplemental_precip.esmf_lons = supplemental_precip.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate longitude coordinate object within supplemental precip ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate longitude coordinate object within supplemental precip ESMF grid: {ge}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -16021,7 +14800,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -16076,7 +14855,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -16139,7 +14918,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in_elem = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -16196,7 +14975,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -1672,6 +1672,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -1712,21 +1715,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
-            if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                err_handler.log_warning(
-                    config_options,
-                    mpi_config,
-                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing...",
-                )
-                try:
-                    os_utils.os_remove_retry(input_forcings.tmpFile)
-                except OSError:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to remove temporary file: {input_forcings.tmpFile}",
-                    )
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             # Build GRIB2 to NetCDF conversion
             fields = []

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -9203,10 +9203,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             # These files shouldn't exist. If they do, remove them.
             if mpi_config.rank == 0:
                 if os.path.isfile(arw_tmp_nc):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {arw_tmp_nc} - Removing.....",
+                    log_warn(
+                        msg=f"Found old temporary file: {arw_tmp_nc} - Removing....."
                     )
                     try:
                         os_utils.os_remove_retry(arw_tmp_nc)
@@ -9971,11 +9969,7 @@ def regrid_hourly_nbm(
 
     if mpi_config.rank == 0:
         if os.path.isfile(nbm_tmp_nc):
-            err_handler.log_warning(
-                config_options,
-                mpi_config,
-                msg=f"Found old temporary file: {nbm_tmp_nc} - Removing.....",
-            )
+            log_warn(msg=f"Found old temporary file: {nbm_tmp_nc} - Removing.....")
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
             except OSError:
@@ -10075,10 +10069,8 @@ def regrid_hourly_nbm(
 
                 # Regrid the height variable.
                 if config_options.grid_meta is None:
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg="No NBM height file supplied, downscaling will not be available",
+                    log_warn(
+                        msg="No NBM height file supplied, downscaling will not be available"
                     )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -146,6 +146,9 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     esmf_mesh_retry_partial = functools.partial(
         esmf_mesh_retry, mpi_config, config_options, err_handler
     )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
 
     ds = None
 
@@ -477,15 +480,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ]
     finally:
-        if mpi_config.rank == 0 and ds is not None:
-            try:
-                ds.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close input NetCDF file: {input_forcings.file_in2}",
-                )
+        close_rank_0_partial(ds)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -8365,6 +8360,12 @@ def regrid_mrms_hourly(
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    close_partial = functools.partial(
+        os_utils.close, mpi_config, config_options, err_handler
+    )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # Do we want to use MRMS data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
@@ -9340,37 +9341,12 @@ def regrid_mrms_hourly(
 
     finally:
         # Close whichever file handles got opened
-        if id_mrms is not None:
-            try:
-                id_mrms.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {mrms_tmp_nc}",
-                )
-
-        if id_mrms_rqi is not None:
-            try:
-                id_mrms_rqi.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}",
-                )
-
-        if mpi_config.rank == 0:
-            for f in (mrms_tmp_grib2, mrms_tmp_nc, mrms_tmp_rqi_grib2, mrms_tmp_rqi_nc):
-                if os.path.isfile(f):
-                    try:
-                        os_utils.os_remove_retry(f)
-                    except OSError:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to remove scratch file: {f}",
-                        )
+        close_partial(id_mrms)
+        close_partial(id_mrms_rqi)
+        os_remove_rank_0_partial(mrms_tmp_grib2)
+        os_remove_rank_0_partial(mrms_tmp_nc)
+        os_remove_rank_0_partial(mrms_tmp_rqi_grib2)
+        os_remove_rank_0_partial(mrms_tmp_rqi_nc)
         mpi_config.comm.barrier()
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11684,8 +11660,8 @@ def regrid_hourly_nbm(
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
-                        if mpi_config.rank == 0:
-                            hgt_tmp.close()
+                        close_rank_0_partial(hgt_tmp)
+
                     elif config_options.grid_type == "hydrofabric":
                         if mpi_config.rank == 0:
                             var_tmp = hgt_tmp.variables["DIST_surface"][0, :, :]
@@ -11756,8 +11732,8 @@ def regrid_hourly_nbm(
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
-                        if mpi_config.rank == 0:
-                            hgt_tmp.close()
+                        close_rank_0_partial(hgt_tmp)
+
                     elif config_options.grid_type == "unstructured":
                         if mpi_config.rank == 0:
                             var_tmp = hgt_tmp.variables["DIST_surface"][0, :, :]
@@ -11899,8 +11875,7 @@ def regrid_hourly_nbm(
                             )
                         err_handler.check_program_status(config_options, mpi_config)
 
-                        if mpi_config.rank == 0:
-                            hgt_tmp.close()
+                        close_rank_0_partial(hgt_tmp)
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
@@ -12338,6 +12313,9 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    close_partial = functools.partial(
+        os_utils.close, mpi_config, config_options, err_handler
+    )
 
     # Check to see if the regrid complete flag for this
     # output time step is true. This entails the necessary
@@ -12733,15 +12711,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             err_handler.check_program_status(config_options, mpi_config)
         finally:
             # always close the NetCDF handle
-            if id_tmp is not None:
-                try:
-                    id_tmp.close()
-                except OSError as e:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to close NDFD temp file {tmp_file}: {e}",
-                    )
+            close_partial(id_tmp)
 
             # only remove the scratch file if this was a new‐cycle run
             if (

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -106,15 +106,20 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
     """Create a symbolic link to the input file for processing."""
     if mpi_config.rank == 0:
         try:
-            config_options.statusMsg = name + " file being used: " + input_file
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=name + " file being used: " + input_file,
+            )  # log at debug level
 
             os.symlink(input_file, tmpFile)
         except:
-            config_options.errMsg = (
-                "Unable to create link: " + input_file + " to: " + tmpFile
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create link: " + input_file + " to: " + tmpFile,
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -149,11 +154,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # exit out of this routine as the regridded fields have already been set to NDV.
         if not os.path.isfile(input_forcings.file_in2):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No AK AnA in_2 file found for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No AK AnA in_2 file found for this timestep.",
                 )  # log at debug level
             return
 
@@ -162,11 +167,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No AK AnA regridding required for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No AK AnA regridding required for this timestep.",
                 )  # log at debug level
             return
 
@@ -177,10 +182,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds = Dataset(input_forcings.file_in2, "r")
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
             # turn off automatic masking but keep scaling
             ds.set_auto_scale(True)
@@ -210,8 +216,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         coord_sys=ESMF.CoordSys.SPH_DEG,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -242,8 +251,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.y_upper_bound - input_forcings.y_lower_bound
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
                 try:
@@ -256,8 +268,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -274,8 +289,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in_elem.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
@@ -284,8 +302,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -296,8 +317,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Create out regridded numpy arrays to hold the regridded data.
@@ -335,9 +359,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             var_tmp = None
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}",
                 )  # log at debug level
                 LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
@@ -346,8 +372,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
                 elif config_options.grid_type == "unstructured":
                     try:
                         var_tmp = ds.variables[nc_var][0, :]
@@ -356,16 +385,22 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp_elem = ds.variables[nc_var][0, :]
                         var_tmp_elem = np.float32(var_tmp_elem)
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
                 elif config_options.grid_type == "hydrofabric":
                     try:
                         var_tmp = ds.variables[nc_var][0, :]
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
 
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -379,11 +414,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract ExtAnA forcing data from the AK AnA field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -402,11 +438,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds_elem]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -427,11 +464,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -446,10 +484,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close input NetCDF file: {input_forcings.file_in2}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close input NetCDF file: {input_forcings.file_in2}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -479,10 +518,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No StageIV regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No StageIV regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -502,19 +543,21 @@ def _regrid_ak_ext_ana_pcp_stage4(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + stage4_tmp_nc
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove temporary file: {stage4_tmp_nc}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Create a temporary NetCDF file from the GRIB2 file.
@@ -524,9 +567,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-6 hour acc fcst"
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"WGRIB2 command: {cmd}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
                 )  # log at debug level
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
@@ -558,9 +600,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating STAGE IV regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating STAGE IV regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip,
@@ -578,9 +622,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -593,14 +639,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -612,9 +659,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -627,14 +676,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -646,9 +696,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[
@@ -661,14 +713,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -681,9 +734,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -696,14 +751,15 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -715,11 +771,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -729,10 +786,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -741,11 +800,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -763,11 +823,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -782,11 +843,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -796,10 +858,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -808,11 +872,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -830,11 +895,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -848,11 +914,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -864,10 +931,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -876,11 +945,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -899,11 +969,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -918,11 +989,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -932,10 +1004,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -944,11 +1018,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -966,11 +1041,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -987,13 +1063,19 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {stage4_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}",
+                )
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
             except OSError:
-                config_options.errMsg = f"Unable to remove NetCDF file: {stage4_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -1053,10 +1135,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No StageIV regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No StageIV regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -1075,19 +1159,21 @@ def _regrid_conus_ext_ana_pcp_stage4(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + stage4_tmp_nc
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove temporary file: {stage4_tmp_nc}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Create a temporary NetCDF file from the GRIB2 file.
@@ -1097,9 +1183,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-1 hour acc fcst"
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"WGRIB2 command: {cmd}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
                 )  # log at debug level
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
@@ -1131,9 +1216,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating STAGE IV regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating STAGE IV regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip,
@@ -1151,9 +1238,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -1166,14 +1255,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1185,9 +1275,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -1200,14 +1292,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1219,9 +1312,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[
@@ -1234,14 +1329,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp_elem,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -1254,9 +1350,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[
@@ -1269,14 +1367,15 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from STAGE IV file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1288,11 +1387,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1302,10 +1402,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1314,11 +1416,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -1336,11 +1439,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1355,11 +1459,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1369,10 +1474,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1381,11 +1488,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -1403,11 +1511,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1421,11 +1530,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1437,10 +1547,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1449,11 +1561,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -1472,11 +1585,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1491,11 +1605,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place STAGE IV precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1505,10 +1620,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid STAGE IV supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1517,11 +1634,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -1544,11 +1662,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 del ind_valid
                 del invalid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on STAGE IV supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
             # the latest as there are no states for time 0.
@@ -1564,13 +1683,19 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {stage4_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}",
+                )
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
             except OSError:
-                config_options.errMsg = f"Unable to remove NetCDF file: {stage4_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}",
+                )
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1623,8 +1748,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # exit out of this routine as the regridded fields have already been set to NDV.
     if not os.path.isfile(input_forcings.file_in2):
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No HRRR in_2 file found for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No HRRR in_2 file found for this timestep.",
+            )  # log at debug level
         return
 
     # Check to see if the regrid complete flag for this
@@ -1632,8 +1761,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No HRRR regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No HRRR regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -1645,33 +1778,36 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CONUS HRRR"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS HRRR")
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = (
-                    f"Found old temporary file: {input_forcings.tmpFile} - Removing..."
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing...",
                 )
-                err_handler.log_warning(config_options, mpi_config)
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
-                    config_options.errMsg = (
-                        f"Unable to remove temporary file: {input_forcings.tmpFile}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove temporary file: {input_forcings.tmpFile}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Build GRIB2 to NetCDF conversion
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Converting HRRR Variable: {grib_var}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting HRRR Variable: {grib_var}",
                     )  # log at debug level
                 if 0 < input_forcings.cycle_freq < 60:
                     time_str = (
@@ -1729,9 +1865,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing HRRR Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing HRRR Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -1746,9 +1884,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating HRRR regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating HRRR regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -1798,17 +1938,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -1819,11 +1962,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1832,21 +1976,23 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -1876,17 +2022,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -1897,11 +2046,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1910,21 +2060,23 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -1950,17 +2102,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -1971,11 +2126,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1984,11 +2140,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -1996,11 +2153,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -2030,17 +2188,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place input NetCDF HRRR data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -2051,11 +2212,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid HRRR surface elevation using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2064,21 +2226,23 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform HRRR mask search on elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract regridded HRRR elevation data from ESMF: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -2100,12 +2264,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2126,16 +2290,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2146,19 +2311,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2167,10 +2334,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2179,11 +2347,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2191,11 +2360,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2212,12 +2382,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2238,16 +2408,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2258,19 +2429,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2279,10 +2452,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2291,11 +2465,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2303,11 +2478,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2323,12 +2499,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2349,16 +2525,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2369,19 +2546,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -2392,10 +2571,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2404,11 +2584,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2416,11 +2597,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2437,12 +2619,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Processing input HRRR variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2463,16 +2645,17 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2483,19 +2666,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place input HRRR data into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input HRRR Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2504,10 +2689,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input HRRR forcing data: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2516,11 +2702,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to perform mask test on regridded HRRR forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2528,11 +2715,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract regridded HRRR forcing data from the ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2551,17 +2739,19 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -2589,8 +2779,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No RAP regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No RAP regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -2604,36 +2798,37 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CONUS RAP"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS RAP")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
-                        config_options.errMsg = (
-                            "Unable to remove file: " + input_forcings.tmpFile
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to remove file: " + input_forcings.tmpFile,
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting CONUS RAP Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting CONUS RAP Variable: " + grib_var,
                     )  # log at debug level
                 time_str = (
                     "{}-{} hour acc fcst".format(
@@ -2690,9 +2885,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing Conus RAP Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing Conus RAP Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -2707,9 +2904,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating RAP regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating RAP regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -2738,14 +2937,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2756,17 +2956,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -2777,10 +2980,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2789,21 +2994,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -2813,14 +3020,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2831,17 +3039,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -2852,10 +3063,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2864,21 +3077,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -2887,14 +3102,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2905,17 +3121,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -2926,10 +3145,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2938,11 +3159,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -2950,11 +3172,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -2964,14 +3187,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from : "
                                 + id_tmp
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2982,17 +3206,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place temporary RAP elevation variable into ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -3003,10 +3230,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid RAP elevation data using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3015,21 +3244,23 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on RAP elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF elevation field into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -3058,16 +3289,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3078,19 +3310,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3099,12 +3333,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3113,14 +3348,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3129,11 +3365,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3173,16 +3410,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3193,19 +3431,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3214,12 +3454,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3228,14 +3469,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3244,11 +3486,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3287,16 +3530,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp_elem /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -3307,19 +3551,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -3330,12 +3576,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3344,14 +3591,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3360,11 +3608,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF element data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF element data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3405,16 +3654,17 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3425,19 +3675,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local RAP array into ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input RAP Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3446,12 +3698,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3460,14 +3713,15 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation on RAP variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3476,11 +3730,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place RAP ESMF data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3515,17 +3770,19 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -3556,8 +3813,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         # correction on incoming CFSv2 data. Because of the nature, we
         # need to regrid bias-corrected data every hour.
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No need to read in new CFSv2 data at this time."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No need to read in new CFSv2 data at this time.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -3571,36 +3832,39 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CFSv2"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CFSv2")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError as err:
-                        config_options.errMsg = (
-                            "Unable to remove previous temporary file: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to remove previous temporary file: "
                             + input_forcings.tmpFile
-                            + str(err)
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Converting CFSv2 Variable: " + grib_var
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting CFSv2 Variable: " + grib_var,
                     )  # log at debug level
                 fields.append(
                     ":"
@@ -3650,9 +3914,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing CFSv2 Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing CFSv2 Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -3667,9 +3933,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculate CFSv2 regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculate CFSv2 regridding weights.",
                     )  # log at debug level
 
                 calculate_weights(
@@ -3701,14 +3969,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3719,19 +3988,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3743,11 +4013,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3756,21 +4027,23 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -3780,14 +4053,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3798,19 +4072,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3822,11 +4097,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3835,21 +4111,23 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -3858,14 +4136,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -3876,19 +4155,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3900,11 +4180,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3913,11 +4194,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3925,11 +4207,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -3939,14 +4222,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract HGT_surface from file: "
                                 + input_forcings.file_in2
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3957,19 +4241,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
 
                     try:
@@ -3981,11 +4266,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3994,21 +4280,23 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract CFSv2 regridded elevation data from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -4033,28 +4321,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4121,11 +4410,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4137,14 +4427,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4153,14 +4444,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4168,10 +4460,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4197,28 +4491,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4285,11 +4580,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4301,14 +4597,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4317,14 +4614,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4332,10 +4630,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4360,28 +4660,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4450,11 +4751,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4466,14 +4768,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4482,14 +4785,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4497,10 +4801,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4526,28 +4832,29 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 variable: "
+                            + input_forcings.netcdf_var_names[force_count],
                         )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from file: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4614,11 +4921,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place CFSv2 forcing data into temporary ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4630,14 +4938,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(ve)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4646,14 +4955,15 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run mask calculation on CFSv2 variable: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " ("
                             + str(npe)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4661,10 +4971,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF field data for CFSv2: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4691,17 +5003,19 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -4734,10 +5048,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No NWM NetCDF regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NWM NetCDF regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4745,15 +5061,18 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         input_forcings.file_in2, config_options, mpi_config, open_on_all_procs=True
     )
 
-    config_options.statusMsg = "Regrid NWM Custom NetCDF Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid NWM Custom NetCDF Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Processing Custom NetCDF Forcing Variable: " + nc_var
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
+            )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4775,35 +5094,37 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                f"Downscaling will not be available."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
+            )  # log at debug level
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4814,10 +5135,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4827,11 +5150,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4839,11 +5163,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4860,25 +5185,26 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4889,10 +5215,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4902,11 +5230,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4914,11 +5243,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4934,25 +5264,26 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -4963,10 +5294,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4976,11 +5309,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4988,11 +5322,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5009,25 +5344,26 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom netCDF input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5038,10 +5374,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5051,11 +5389,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5063,11 +5402,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5109,10 +5449,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No NWM NetCDF regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NWM NetCDF regridding required for this timestep.",
+            )  # log at debug level
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -5136,15 +5478,18 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 longitude=(["y", "x"], lon_coords), latitude=(["y", "x"], lat_coords)
             )
 
-    config_options.statusMsg = "Regrid NWM Custom zarr Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid NWM Custom zarr Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Processing Custom zarr Forcing Variable: " + nc_var
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing Custom zarr Forcing Variable: " + nc_var,
+            )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -5165,35 +5510,36 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                f"Downscaling will not be available."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
             )
-            err_handler.log_msg(config_options, mpi_config)
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5204,10 +5550,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5217,11 +5565,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5229,11 +5578,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5250,25 +5600,26 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5279,10 +5630,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5292,11 +5645,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5304,11 +5658,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5324,25 +5679,26 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -5353,10 +5709,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5366,11 +5724,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5378,11 +5737,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5399,25 +5759,26 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding Custom zarr input variable: " + nc_var,
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # convert to array for NWM
@@ -5432,10 +5793,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5445,11 +5808,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input Custom zarr forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5457,11 +5821,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5519,11 +5884,11 @@ def regrid_custom_hourly_netcdf(
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No Custom Hourly NetCDF regridding required for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No Custom Hourly NetCDF regridding required for this timestep.",
                 )  # log at debug level
             return
 
@@ -5543,16 +5908,19 @@ def regrid_custom_hourly_netcdf(
             "DLWRF": 310.0,
         }
 
-        config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            msg="Regrid Custom Hourly NetCDF Forcing Variables",
+        )
 
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Processing Custom NetCDF Forcing Variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
                 )  # log at debug level
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -5599,19 +5967,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out = (
@@ -5622,11 +5991,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5635,10 +6005,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5646,11 +6018,12 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                     elif config_options.grid_type == "unstructured":
@@ -5669,19 +6042,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out = (
@@ -5692,11 +6066,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5705,10 +6080,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5716,11 +6093,12 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Regrid the height variable.
@@ -5740,19 +6118,20 @@ def regrid_custom_hourly_netcdf(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out_elem = (
@@ -5763,11 +6142,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5776,10 +6156,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5787,11 +6169,12 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                     elif config_options.grid_type == "hydrofabric":
@@ -5810,19 +6193,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NetCDF elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             input_forcings.esmf_field_out = (
@@ -5833,11 +6217,12 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5846,10 +6231,12 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5857,21 +6244,22 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                 else:
                     input_forcings.height = None
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                            f"Downscaling will not be available."
+                        err_handler.log_msg(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
                         )
-                        err_handler.log_msg(config_options, mpi_config)
 
                 # close netCDF file on non-root ranks
                 if mpi_config.rank != 0:
@@ -5884,31 +6272,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -5919,10 +6308,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5932,11 +6323,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -5945,11 +6337,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -5967,11 +6360,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5979,11 +6373,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6003,31 +6398,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -6038,10 +6434,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6051,11 +6449,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6064,11 +6463,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -6085,11 +6485,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6097,11 +6498,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6120,31 +6522,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -6155,10 +6558,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6170,11 +6575,12 @@ def regrid_custom_hourly_netcdf(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6183,11 +6589,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -6207,11 +6614,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6219,11 +6627,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6243,31 +6652,32 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -6277,10 +6687,12 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6290,11 +6702,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6303,11 +6716,12 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if nc_var == "DSWRF_surface":
@@ -6329,11 +6743,12 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6341,11 +6756,12 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -6392,10 +6808,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No ERA5-Interim regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No ERA5-Interim regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -6418,15 +6836,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     )
     ind = np.where(seconds_index == np.min(seconds_index))[0][0]
 
-    config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid Custom Hourly NetCDF Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Processing ERA-5 Interim Forcing Variable: " + nc_var
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing ERA-5 Interim Forcing Variable: " + nc_var,
+            )  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -6453,11 +6874,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             else:
                 input_forcings.height = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Unable to locate Geopoential height in: {input_forcings.file_in2}. "
-                        f"Downscaling will not be available."
+                    err_handler.log_msg(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to locate Geopoential height in: {input_forcings.file_in2}. Downscaling will not be available.",
                     )
-                    err_handler.log_msg(config_options, mpi_config)
 
             # close netCDF file on non-root ranks
             if mpi_config.rank != 0:
@@ -6468,18 +6889,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
@@ -6494,16 +6915,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6514,10 +6936,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6527,11 +6951,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6540,11 +6965,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6556,11 +6982,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6568,11 +6995,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6589,18 +7017,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
@@ -6615,16 +7043,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6635,10 +7064,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6648,11 +7079,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6661,11 +7093,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6677,11 +7110,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6689,11 +7123,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6709,18 +7144,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.0)[
                         ind, :, :
@@ -6739,16 +7174,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -6759,10 +7195,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6772,11 +7210,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6785,11 +7224,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask_elem == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6803,11 +7243,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6816,11 +7257,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ] = input_forcings.esmf_field_out_elem.data
 
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6837,18 +7279,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding ERA5-Interim input variable: " + nc_var,
                 )  # log at debug level
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
                     )  # log at debug level
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
@@ -6863,16 +7305,17 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract "
                         + nc_var
                         + " from: "
                         + input_forcings.file_in2
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6883,10 +7326,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6896,11 +7341,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid input ERA5-Interim forcing variables using ESMF: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6909,11 +7355,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to calculate mask from input ERA5-Interim regridded forcings: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6925,11 +7372,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on ERA5-Interim precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6937,11 +7385,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6991,10 +7440,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No 13km GFS regridding required for this timestep."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No 13km GFS regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a temporary NetCDF file name to hold converted GRIB2 data.
@@ -7019,36 +7470,39 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regridding 13km GFS Variables."
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(
+            config_options, mpi_config, msg="Regridding 13km GFS Variables."
+        )
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = (
-                    "Found old temporary file: "
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg="Found old temporary file: "
                     + input_forcings.tmpFile
-                    + " - Removing....."
+                    + " - Removing.....",
                 )
-                err_handler.log_warning(config_options, mpi_config)
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
-                    config_options.errMsg = (
-                        "Unable to remove file: " + input_forcings.tmpFile
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to remove file: " + input_forcings.tmpFile,
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting 13km GFS Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting 13km GFS Variable: " + grib_var,
                     )  # log at debug level
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
@@ -7123,9 +7577,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing 13km GFS Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing 13km GFS Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -7140,11 +7596,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating 13km GFS regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating 13km GFS regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -7175,14 +7631,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -7195,14 +7652,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -7215,14 +7673,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -7235,14 +7694,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract GFS elevation from: "
                                 + input_forcings.tmpFile
                                 + " ("
                                 + str(err)
-                                + ")"
+                                + ")",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -7253,17 +7713,20 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local GFS array into an ESMF field: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local GFS array into an ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding 13km GFS surface elevation data to the WRF-Hydro domain."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain.",
                     )  # log at debug level
                 if config_options.grid_type == "gridded":
                     try:
@@ -7275,10 +7738,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data: " + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7287,11 +7751,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -7304,21 +7769,23 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data with ESMF mesh nodes: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data with ESMF mesh nodes: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local GFS array into an ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place local GFS array into an ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -7330,11 +7797,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data with ESMF mesh elements: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data with ESMF mesh elements: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7343,11 +7811,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7356,11 +7825,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
                     try:
@@ -7372,10 +7842,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid GFS elevation data: " + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7384,32 +7855,35 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to perform mask search on GFS elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -7417,22 +7891,24 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field with mesh elements: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field with mesh elements: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract GFS elevation array from ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -7459,16 +7935,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
                 var_tmp = None
@@ -7478,16 +7955,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_tmp_elem = None
@@ -7497,16 +7975,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 var_tmp = None
@@ -7516,16 +7995,17 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are regridding GFS data, and this is precipitation, we need to run calculations
@@ -7596,50 +8076,54 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place GFS local array into ESMF element field object: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if config_options.grid_type == "gridded":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7650,21 +8134,22 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding took {} seconds".format(
-                            end - begin
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding took {} seconds".format(end - begin),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7673,14 +8158,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7688,11 +8174,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7706,12 +8193,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "unstructured":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh nodes: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field for Mesh nodes: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7722,21 +8209,22 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Node Regridding took {} seconds".format(end - begin)
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Node Regridding took {} seconds".format(end - begin),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Nodes: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable for Mesh Nodes: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7745,14 +8233,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7760,11 +8249,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7777,12 +8267,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field for Mesh elements: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7795,21 +8285,24 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Element Regridding took {} seconds".format(end - begin)
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Element Regridding took {} seconds".format(
+                                end - begin
+                            ),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Elements: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable for Mesh Elements: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7818,14 +8311,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7833,11 +8327,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7851,12 +8346,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "hydrofabric":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Input 13km GFS Field for Mesh Elements: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                 try:
                     begin = monotonic()
@@ -7867,21 +8362,24 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Element Regridding took {} seconds".format(end - begin)
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Element Regridding took {} seconds".format(
+                                end - begin
+                            ),
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Element: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid GFS variable for Mesh Element: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(ve)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7890,14 +8388,15 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask search on GFS variable: "
                         + input_forcings.netcdf_var_names[force_count]
                         + " ("
                         + str(npe)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7905,11 +8404,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract GFS ESMF field data to local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -7927,20 +8427,22 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
             # reinstituting removal - overwriting can cause issues on some file systems
             # benefits of reuse seem unclear
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except OSError:
-                config_options.errMsg = (
-                    "Unable to remove NetCDF file: " + input_forcings.tmpFile
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to remove NetCDF file: " + input_forcings.tmpFile,
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -7968,8 +8470,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        config_options.statusMsg = "No regridding of NAM nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="No regridding of NAM nest data necessary for this timestep - already completed.",
+        )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -7983,19 +8489,19 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regridding NAM nest data"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regridding NAM nest data")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
@@ -8005,11 +8511,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting NAM-Nest Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting NAM-Nest Variable: " + grib_var,
                     )  # log at debug level
                 fields.append(
                     ":"
@@ -8062,9 +8568,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing NAM Nest Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing NAM Nest Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -8079,11 +8587,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating NAM nest regridding weights...."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating NAM nest regridding weights....",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -8121,17 +8629,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -8142,11 +8653,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8155,21 +8667,23 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -8188,17 +8702,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -8209,11 +8726,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8222,21 +8740,23 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -8254,17 +8774,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -8275,11 +8798,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8288,11 +8812,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -8300,11 +8825,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -8323,17 +8849,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -8344,11 +8873,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8357,21 +8887,23 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on NAM nest elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded NAM nest elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -8395,28 +8927,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -8427,10 +8960,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8440,11 +8975,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8453,11 +8989,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8465,11 +9002,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8486,28 +9024,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -8518,10 +9057,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8531,11 +9072,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8544,11 +9086,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8556,11 +9099,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8576,28 +9120,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -8608,10 +9153,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8623,11 +9170,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8636,11 +9184,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8648,11 +9197,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8669,28 +9219,29 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding NAM nest input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -8701,10 +9252,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8714,11 +9267,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input NAM nest forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -8727,11 +9281,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input NAM nest regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -8739,11 +9294,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -8762,17 +9318,19 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -8796,8 +9354,11 @@ def regrid_mrms_hourly(
     # Do we want to use MRMS data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Exceeded max hours for MRMS precipitation"
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Exceeded max hours for MRMS precipitation",
+            )
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -8814,8 +9375,12 @@ def regrid_mrms_hourly(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No MRMS regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No MRMS regridding required for this timestep.",
+            )  # log at debug level
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -8847,11 +9412,11 @@ def regrid_mrms_hourly(
     # alert the user, and set the final output grids to be the global NDV and return.
     if not supplemental_precip.file_in1 or not supplemental_precip.file_in2:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No MRMS Precipitation available. Supplemental precipitation will "
-                "not be used."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="No MRMS Precipitation available. Supplemental precipitation will not be used.",
             )
-            err_handler.log_msg(config_options, mpi_config)
         supplemental_precip.regridded_precip2 = None
         supplemental_precip.regridded_precip1 = None
         if config_options.grid_type == "unstructured":
@@ -8875,8 +9440,7 @@ def regrid_mrms_hourly(
     id_mrms = None
     id_mrms_rqi = None
     try:
-        config_options.statusMsg = "Rrgrid MRMS"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Rrgrid MRMS")
 
         if supplemental_precip.file_type != NETCDF:
             # Unzip MRMS files to temporary locations.
@@ -8963,9 +9527,11 @@ def regrid_mrms_hourly(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating MRMS regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating MRMS regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config
@@ -8982,16 +9548,17 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + supplemental_precip.rqi_netcdf_var_names[0]
                             + " from: "
                             + mrms_tmp_rqi_grib2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9002,16 +9569,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place MRMS data into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
                     )  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out = (
@@ -9022,10 +9593,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid MRMS RQI field: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9033,21 +9605,23 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
                             )  # log at debug level
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation for MRMS RQI data: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             elif config_options.grid_type == "unstructured":
@@ -9058,16 +9632,17 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + supplemental_precip.rqi_netcdf_var_names[0]
                             + " from: "
                             + mrms_tmp_rqi_grib2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9078,16 +9653,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place MRMS data into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
                     )  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out = (
@@ -9098,10 +9677,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid MRMS RQI field: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9109,21 +9689,23 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
                             )  # log at debug level
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation for MRMS RQI data: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_tmp_elem = None
@@ -9133,16 +9715,17 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract: "
                             + supplemental_precip.rqi_netcdf_var_names[0]
                             + " from: "
                             + mrms_tmp_rqi_grib2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9153,16 +9736,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place MRMS data into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
                     )  # log at debug level
                 try:
                     supplemental_precip.esmf_field_out_elem = (
@@ -9173,10 +9760,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid MRMS RQI field: " + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9184,21 +9772,23 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask_elem == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
                             )  # log at debug level
 
                     supplemental_precip.esmf_field_out_elem.data[
                         np.where(supplemental_precip.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run mask calculation for MRMS RQI data: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
         if not supplemental_precip.rqiMethod:
@@ -9212,9 +9802,11 @@ def regrid_mrms_hourly(
                 supplemental_precip.regridded_rqi2[:] = 1.0
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = "MRMS Will not be filtered using RQI values."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="MRMS Will not be filtered using RQI values.",
                 )  # log at debug level
 
         elif supplemental_precip.rqiMethod == 2:
@@ -9246,27 +9838,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9284,10 +9877,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9304,10 +9898,12 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -9325,19 +9921,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -9352,11 +9951,12 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run global NDV search on MRMS regridded precip: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9374,27 +9974,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9412,10 +10013,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9432,10 +10034,12 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -9453,19 +10057,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -9480,11 +10087,12 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run global NDV search on MRMS regridded precip: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9501,27 +10109,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9541,10 +10150,11 @@ def regrid_mrms_hourly(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9564,10 +10174,12 @@ def regrid_mrms_hourly(
                     # err_handler.log_warning(config_options, mpi_config)
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -9585,19 +10197,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter_elem) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = (
                         config_options.globalNdv
                     )
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -9611,11 +10226,12 @@ def regrid_mrms_hourly(
                 )
                 del ind_valid_elem
             except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run global NDV search on MRMS regridded precip: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run global NDV search on MRMS regridded precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9633,27 +10249,28 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding: " + supplemental_precip.netcdf_var_names[0],
                 )  # log at debug level
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract: "
                         + supplemental_precip.netcdf_var_names[0]
                         + " from: "
                         + mrms_tmp_nc
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9671,10 +10288,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid MRMS precipitation: " + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -9691,10 +10309,12 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on MRMS supplemental precip: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -9712,19 +10332,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
                             )  # log at debug level
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run MRMS RQI threshold search: " + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -9739,11 +10362,12 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run global NDV search on MRMS regridded precip: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9763,17 +10387,21 @@ def regrid_mrms_hourly(
             try:
                 id_mrms.close()
             except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {mrms_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {mrms_tmp_nc}",
+                )
 
         if id_mrms_rqi is not None:
             try:
                 id_mrms_rqi.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
         if mpi_config.rank == 0:
             for f in (mrms_tmp_grib2, mrms_tmp_nc, mrms_tmp_rqi_grib2, mrms_tmp_rqi_nc):
@@ -9781,8 +10409,11 @@ def regrid_mrms_hourly(
                     try:
                         os_utils.os_remove_retry(f)
                     except OSError:
-                        config_options.errMsg = f"Unable to remove scratch file: {f}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove scratch file: {f}",
+                        )
         mpi_config.comm.barrier()
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -9847,8 +10478,11 @@ def regrid_mrms_precip_flag(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Calculating MRMS PrecipFlag regridding weights."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Calculating MRMS PrecipFlag regridding weights.",
+            )
         calculate_supp_pcp_weights(
             supplemental_precip,
             id_tmp,
@@ -9862,19 +10496,21 @@ def regrid_mrms_precip_flag(
     var_tmp = None
     if mpi_config.rank == 0:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Regridding MRMS PrecipFlag Fraction."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options, mpi_config, msg="Regridding MRMS PrecipFlag Fraction."
+            )
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to extract PrecipFlag from file: "
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to extract PrecipFlag from file: "
                 + supplemental_precip.file_in2
                 + " ("
                 + str(err)
-                + ")"
+                + ")",
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     var_sub_tmp = mpi_config.scatter_array(supplemental_precip, var_tmp, config_options)
@@ -9888,10 +10524,11 @@ def regrid_mrms_precip_flag(
 
         supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to place MRMS PrecipFlag into local ESMF field: " + str(err)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to place MRMS PrecipFlag into local ESMF field: " + str(err),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -9901,8 +10538,11 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_out,
         )
     except ValueError as ve:
-        config_options.errMsg = "Unable to regrid MRMS PrecipFlag: " + str(ve)
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -9914,10 +10554,11 @@ def regrid_mrms_precip_flag(
             np.where(supplemental_precip.esmf_field_out.data < 0)
         ] = 1.0
     except (ValueError, ArithmeticError) as npe:
-        config_options.errMsg = "Unable to run mask search on MRMS PrecipFlag: " + str(
-            npe
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     supplemental_precip.regridded_precip2[:] = supplemental_precip.esmf_field_out.data
@@ -9936,21 +10577,25 @@ def regrid_mrms_precip_flag(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding MRMS PrecipFlag Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding MRMS PrecipFlag Fraction.",
+                )
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_precip.netcdf_var_names[0]
                 ][0, :, :]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract PrecipFlag from file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract PrecipFlag from file: "
                     + supplemental_precip.file_in2
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9968,10 +10613,12 @@ def regrid_mrms_precip_flag(
 
             supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place MRMS PrecipFlag into local ESMF field: " + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place MRMS PrecipFlag into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -9981,8 +10628,11 @@ def regrid_mrms_precip_flag(
                 supplemental_precip.esmf_field_out_elem,
             )
         except ValueError as ve:
-            config_options.errMsg = "Unable to regrid MRMS PrecipFlag: " + str(ve)
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid MRMS PrecipFlag: " + str(ve),
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -9994,10 +10644,11 @@ def regrid_mrms_precip_flag(
                 np.where(supplemental_precip.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on MRMS PrecipFlag: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on MRMS PrecipFlag: " + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_precip.regridded_precip2_elem[:] = (
@@ -10018,15 +10669,19 @@ def regrid_mrms_precip_flag(
         try:
             id_tmp.close()
         except OSError:
-            config_options.errMsg = (
-                "Unable to close NetCDF file: " + supplemental_precip.file_in2
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to close NetCDF file: " + supplemental_precip.file_in2,
             )
-            err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(mrms_tmp_nc)
         except OSError:
-            config_options.errMsg = "Unable to remove NetCDF file: " + mrms_tmp_nc
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to remove NetCDF file: " + mrms_tmp_nc,
+            )
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -10056,8 +10711,12 @@ def regrid_hourly_wrf_arw(
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        config_options.statusMsg = "No regridding of WRF-ARW nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed.",
+        )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF file
@@ -10072,20 +10731,20 @@ def regrid_hourly_wrf_arw(
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid WRF-ARW nest data"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid WRF-ARW nest data")
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
                         + input_forcings.tmpFile
-                        + " - Removing....."
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
@@ -10095,11 +10754,11 @@ def regrid_hourly_wrf_arw(
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Converting WRF-ARW Variable: " + grib_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Converting WRF-ARW Variable: " + grib_var,
                     )  # log at debug level
                 time_str = (
                     "{}-{} hour acc fcst".format(
@@ -10159,9 +10818,11 @@ def regrid_hourly_wrf_arw(
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing WRF-ARW Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing WRF-ARW Variable: " + grib_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -10176,11 +10837,11 @@ def regrid_hourly_wrf_arw(
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating WRF-ARW regridding weights...."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating WRF-ARW regridding weights....",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -10218,19 +10879,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -10241,11 +10903,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10254,21 +10917,23 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     # Regrid the height variable.
@@ -10286,19 +10951,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -10309,11 +10975,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10322,21 +10989,23 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -10354,19 +11023,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -10377,11 +11047,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10390,11 +11061,12 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -10402,11 +11074,12 @@ def regrid_hourly_wrf_arw(
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -10425,19 +11098,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
                         )  # log at debug level
                     try:
                         input_forcings.esmf_field_out = (
@@ -10448,11 +11122,12 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -10461,21 +11136,23 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to compute mask on WRF-ARW elevation data: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract ESMF regridded WRF-ARW elevation data to a local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -10499,28 +11176,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -10531,10 +11209,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10544,11 +11224,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10557,11 +11238,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10581,11 +11263,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10593,11 +11276,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10614,28 +11298,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -10646,10 +11331,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10659,11 +11346,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10672,11 +11360,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10696,11 +11385,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10708,11 +11398,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10728,28 +11419,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -10760,10 +11452,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10775,11 +11469,12 @@ def regrid_hourly_wrf_arw(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10788,11 +11483,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10813,11 +11509,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10825,11 +11522,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10846,28 +11544,29 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF-ARW input variable: "
+                        + input_forcings.netcdf_var_names[force_count],
                     )  # log at debug level
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + input_forcings.netcdf_var_names[force_count]
                             + " from: "
                             + input_forcings.tmpFile
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -10878,10 +11577,12 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10891,11 +11592,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input WRF-ARW forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -10904,11 +11606,12 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input WRF-ARW regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -10928,11 +11631,12 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on WRF ARW precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -10940,11 +11644,12 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -10963,17 +11668,19 @@ def regrid_hourly_wrf_arw(
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11004,8 +11711,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No ARW regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No ARW regridding required for this timestep.",
+            )  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -11016,17 +11727,19 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid ARW"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid ARW")
 
         if supplemental_precip.file_type != NETCDF:
             # These files shouldn't exist. If they do, remove them.
             if mpi_config.rank == 0:
                 if os.path.isfile(arw_tmp_nc):
-                    config_options.statusMsg = (
-                        "Found old temporary file: " + arw_tmp_nc + " - Removing....."
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="Found old temporary file: "
+                        + arw_tmp_nc
+                        + " - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(arw_tmp_nc)
                     except IOError:
@@ -11094,9 +11807,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating WRF ARW regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating WRF ARW regridding weights.",
                 )  # log at debug level
             calculate_supp_pcp_weights(
                 supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config
@@ -11108,21 +11823,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11133,11 +11851,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11147,10 +11866,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11159,11 +11880,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -11181,11 +11903,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11201,21 +11924,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11226,11 +11952,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11240,10 +11967,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11252,11 +11981,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -11274,11 +12004,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11293,21 +12024,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -11318,11 +12052,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11334,10 +12069,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11346,11 +12083,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -11369,11 +12107,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid_elem
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11389,21 +12128,24 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
                     )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract precipitation from WRF ARW file: "
                         + supplemental_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11414,11 +12156,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place WRF ARW precipitation into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11428,10 +12171,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to regrid WRF ARW supplemental precipitation: "
+                    + str(ve),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11440,11 +12185,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -11462,11 +12208,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run NDV search on WRF ARW supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11483,13 +12230,19 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 id_tmp.close()
             except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {arw_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {arw_tmp_nc}",
+                )
             try:
                 os_utils.os_remove_retry(arw_tmp_nc)
             except OSError:
-                config_options.errMsg = f"Unable to remove NetCDF file: {arw_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {arw_tmp_nc}",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -11532,10 +12285,12 @@ def regrid_sbcv2_liquid_water_fraction(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Calculating SBCv2 Liquid Water Fraction regridding weights."
-            )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Calculating SBCv2 Liquid Water Fraction regridding weights.",
+            )  # log at debug level
         calculate_supp_pcp_weights(
             supplemental_forcings,
             id_tmp,
@@ -11552,19 +12307,23 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding SBCv2 Liquid Water Fraction.",
+                )
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -11577,11 +12336,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11591,10 +12351,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11606,10 +12367,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -11630,23 +12393,24 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction - unstructured"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding SBCv2 Liquid Water Fraction - unstructured",
                 )  # log at debug level
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -11659,11 +12423,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11673,10 +12438,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11688,10 +12454,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -11711,25 +12479,26 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction input variable."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding SBCv2 Liquid Water Fraction input variable.",
                 )  # log at debug level
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_forcings.netcdf_var_names[0]
                 ][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp_elem = mpi_config.scatter_array(
@@ -11742,11 +12511,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp_elem / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11758,10 +12528,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 )
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11773,10 +12544,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2_elem[:] = (
@@ -11797,21 +12570,23 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction - hydrofabric"
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding SBCv2 Liquid Water Fraction - hydrofabric",
                 )
-                err_handler.log_msg(config_options, mpi_config)
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Liquid Water Fraction from SBCv2 file: "
                     + supplemental_forcings.file_in1
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -11824,11 +12599,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
+                + str(err),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -11838,10 +12614,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -11853,10 +12630,12 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to run mask search on SBCv2 Liquid Water Fraction: "
+                + str(npe),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -11877,10 +12656,11 @@ def regrid_sbcv2_liquid_water_fraction(
         try:
             id_tmp.close()
         except OSError:
-            config_options.errMsg = (
-                "Unable to close NetCDF file: " + supplemental_forcings.file_in1
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to close NetCDF file: " + supplemental_forcings.file_in1,
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -11903,10 +12683,11 @@ def regrid_hourly_nbm(
     # Do we want to use NBM data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Exceeded max hours for NBM data, will not use NBM in final layering."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Exceeded max hours for NBM data, will not use NBM in final layering.",
             )
-            err_handler.log_msg(config_options, mpi_config)
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -11926,24 +12707,30 @@ def regrid_hourly_nbm(
 
     if mpi_config.rank == 0:
         if os.path.isfile(nbm_tmp_nc):
-            config_options.statusMsg = (
-                "Found old temporary file: " + nbm_tmp_nc + " - Removing....."
+            err_handler.log_warning(
+                config_options,
+                mpi_config,
+                msg="Found old temporary file: " + nbm_tmp_nc + " - Removing.....",
             )
-            err_handler.log_warning(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
             except OSError:
-                config_options.errMsg = "Unable to remove file: " + nbm_tmp_nc
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to remove file: " + nbm_tmp_nc,
+                )
     err_handler.check_program_status(config_options, mpi_config)
 
     if forcings_or_precip.grib_vars is not None:
         fields = []
         for force_count, grib_var in enumerate(forcings_or_precip.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Converting NBM Variable: " + grib_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Converting NBM Variable: " + grib_var,
                 )  # log at debug level
             time_str = (
                 "{}-{} hour acc fcst".format(
@@ -12007,13 +12794,16 @@ def regrid_hourly_nbm(
 
     err_handler.check_program_status(config_options, mpi_config)
 
-    config_options.statusMsg = "Processing NBM Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(config_options, mpi_config, msg="Processing NBM Variables")
 
     for force_count, nc_var in enumerate(forcings_or_precip.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Processing NBM Variable: " + nc_var
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Processing NBM Variable: " + nc_var,
+            )  # log at debug level
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -12041,11 +12831,11 @@ def regrid_hourly_nbm(
         if calc_regrid_flag:
             if is_supp:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Calculating NBM {tag} regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Calculating NBM {tag} regridding weights.",
                     )  # log at debug level
                 calculate_supp_pcp_weights(
                     forcings_or_precip,
@@ -12057,11 +12847,11 @@ def regrid_hourly_nbm(
                 err_handler.check_program_status(config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Calculating NBM {tag} regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Calculating NBM {tag} regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -12075,15 +12865,19 @@ def regrid_hourly_nbm(
 
                 # Regrid the height variable.
                 if config_options.grid_meta is None:
-                    config_options.errMsg = (
-                        "No NBM height file supplied, downscaling will not be available"
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="No NBM height file supplied, downscaling will not be available",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     if not os.path.exists(config_options.grid_meta):
-                        config_options.errMsg = 'NBM height file "{config_options.grid_meta}" does not exist'
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg='NBM height file "{config_options.grid_meta}" does not exist',
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     terrain_tmp = os.path.join(
@@ -12113,19 +12907,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -12136,11 +12931,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12149,11 +12945,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12161,11 +12958,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12185,19 +12983,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -12208,11 +13007,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12221,11 +13021,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12233,11 +13034,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12257,19 +13059,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -12280,11 +13083,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12293,11 +13097,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12305,11 +13110,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12328,17 +13134,20 @@ def regrid_hourly_nbm(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to place NBM elevation data into the ESMF field object: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = "Regridding NBM elevation data to the unstructured domain."
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the unstructured domain.",
                             )  # log at debug level
                         try:
                             forcings_or_precip.esmf_field_out_elem = (
@@ -12349,11 +13158,12 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the unstructured domain "
-                                "using ESMF: " + str(ve)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to regrid NBM elevation data to the unstructured domain using ESMF: "
+                                + str(ve),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -12362,11 +13172,12 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute element mask on NBM elevation data: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to compute element mask on NBM elevation data: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -12374,11 +13185,12 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to extract ESMF regridded NBM elevation data to a local array: "
+                                + str(err),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -12388,21 +13200,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -12413,10 +13228,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12426,8 +13242,11 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -12436,11 +13255,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -12474,10 +13294,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12489,21 +13311,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -12514,10 +13339,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12527,8 +13353,11 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -12536,11 +13365,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -12574,10 +13404,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12589,21 +13421,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -12614,10 +13449,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12627,8 +13463,11 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -12636,11 +13475,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -12674,10 +13514,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12689,21 +13531,24 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
                 )  # log at debug level
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to extract data from NBM file: "
                         + forcings_or_precip.file_in1
                         + " ("
                         + str(err)
-                        + ")"
+                        + ")",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -12714,10 +13559,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: " + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -12729,8 +13575,11 @@ def regrid_hourly_nbm(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid NBM {tag}: " + str(ve),
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -12738,11 +13587,12 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to run mask search on NBM supplemental precipitation: "
+                    + str(npe),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1_elem = (
@@ -12780,10 +13630,12 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to run NDV search on NBM precipitation: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -12797,17 +13649,19 @@ def regrid_hourly_nbm(
         try:
             id_tmp.close()
         except OSError:
-            config_options.errMsg = (
-                "Unable to close NetCDF file: " + forcings_or_precip.file_in1
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to close NetCDF file: " + forcings_or_precip.file_in1,
             )
-            err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(nbm_tmp_nc)
         except OSError:
-            config_options.errMsg = (
-                "Unable to remove temporary NBM NetCDF file: " + nbm_tmp_nc
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to remove temporary NBM NetCDF file: " + nbm_tmp_nc,
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -12823,12 +13677,15 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No NDFD regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NDFD regridding required for this timestep.",
+            )  # log at debug level
         return
 
-    config_options.statusMsg = "Regrid NDFD"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(config_options, mpi_config, msg="Regrid NDFD")
 
     hour = input_forcings.fcst_hour2
     current_cycle = config_options.current_fcst_cycle
@@ -12854,41 +13711,45 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         # Temp file may exist. If it does, and we don't need it again, remove it.....
         if not reuse_prev_file and mpi_config.rank == 0:
             if os.path.isfile(tmp_file):
-                config_options.statusMsg = f"Deleting old temporary file: {tmp_file}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Deleting old temporary file: {tmp_file}",
                 )  # log at debug level
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
-                    config_options.errMsg = f"Unable to remove file: {tmp_file}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove file: {tmp_file}",
+                    )
         err_handler.check_program_status(config_options, mpi_config)
 
         id_tmp = None
         try:
             if reuse_prev_file:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Cycle unchanged, reusing temporary file: {tmp_file}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Cycle unchanged, reusing temporary file: {tmp_file}",
                     )  # log at debug level
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}",
                     )  # log at debug level
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
                 else:
-                    cmd = (
-                        f"$WGRIB2 -match :d={current_cycle.strftime('%Y%m%d%H')}: -vt {grb_file} | "
-                        f"sort -t = -k 2 | $WGRIB2 -i -netcdf {tmp_file} {grb_file}"
-                    )
+                    cmd = f"$WGRIB2 -match :d={current_cycle.strftime('%Y%m%d%H')}: -vt {grb_file} | sort -t = -k 2 | $WGRIB2 -i -netcdf {tmp_file} {grb_file}"
                 id_tmp = ioMod.open_grib2(
                     grb_file,
                     tmp_file,
@@ -12905,43 +13766,49 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 times = [datetime.utcfromtimestamp(t) for t in id_tmp["time"][:]]
                 if ndfd_var != "qpf":
                     if forecast_time > times[-1] + timedelta(hours=3):
-                        config_options.statusMsg = (
-                            "Forecast time beyond NDFD range, skipping"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Forecast time beyond NDFD range, skipping",
                         )  # log at debug level
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
-                        config_options.statusMsg = f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}",
                         )  # log at debug level
                     else:
                         time_index = min(
                             range(len(times)),
                             key=lambda i: abs(times[i] - forecast_time),
                         )
-                        config_options.statusMsg = f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}",
                         )  # log at debug level
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
-                        config_options.statusMsg = (
-                            "Forecast time beyond NDFD precip range, skipping"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Forecast time beyond NDFD precip range, skipping",
                         )  # log at debug level
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
-                        config_options.statusMsg = f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}",
                         )  # log at debug level
 
             skip_file = mpi_config.broadcast_parameter(
@@ -12968,9 +13835,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 continue
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing NDFD variable: " + ndfd_var
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing NDFD variable: " + ndfd_var,
                 )  # log at debug level
 
             calc_regrid_flag = check_regrid_status(
@@ -12985,9 +13854,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating NDFD regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating NDFD regridding weights.",
                     )  # log at debug level
                 calculate_weights(
                     id_tmp,
@@ -13014,11 +13885,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         ][time_index, :, :]
                         var_tmp_elem = var_tmp_elem.filled(config_options.globalNdv)
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} "
-                        f"from: {input_forcings.tmpFile} ({err})"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} from: {input_forcings.tmpFile} ({err})",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -13041,10 +13912,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_in_elem.data[:] = var_sub_tmp_elem
                 # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local array into local ESMF field: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -13062,10 +13935,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid input NDFD forcing variable using ESMF: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input NDFD forcing variable using ESMF: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and fix missings that were interpolated
@@ -13080,8 +13954,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # input_forcings.esmf_field_out.data[np.where((input_forcings.esmf_field_out.data/config_options.globalNdv) > 0.75)] = \
                 #     config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input NDFD regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input NDFD regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If processing wind speed, calculate final U2 / V2 fields
@@ -13132,8 +14009,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     AttributeError,
                     KeyError,
                 ) as npe:
-                    config_options.errMsg = f"Unable to convert NDFD wind speed/dir to U/V components: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to convert NDFD wind speed/dir to U/V components: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -13155,10 +14035,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NDFD QPF precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NDFD QPF precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -13178,11 +14059,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[i], :
                     ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to place local ESMF regridded data into local array: "
+                    + str(err),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
         finally:
             # always close the NetCDF handle
@@ -13190,10 +14072,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     id_tmp.close()
                 except OSError as e:
-                    config_options.errMsg = (
-                        f"Unable to close NDFD temp file {tmp_file}: {e}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to close NDFD temp file {tmp_file}: {e}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
 
             # only remove the scratch file if this was a new‐cycle run
             if (
@@ -13204,10 +14087,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError as e:
-                    config_options.errMsg = (
-                        f"Unable to remove scratch file {tmp_file}: {e}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove scratch file {tmp_file}: {e}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
 
 
 def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
@@ -13230,17 +14114,21 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         mpi_config.comm.barrier()
         id_tmp = config_options.aws_obj
 
-        config_options.statusMsg = "Processing Custom NetCDF Forcing Variables"
-        err_handler.log_msg(config_options, mpi_config, True)
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="Processing Custom NetCDF Forcing Variables",
+        )
 
     with timing_block(f"regrid step 2 | {mpi_config.rank}: loop over variables"):
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Processing Custom NetCDF Forcing Variable: " + nc_var
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Processing Custom NetCDF Forcing Variable: " + nc_var,
                 )  # log at debug level
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
@@ -13287,31 +14175,32 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -13322,10 +14211,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13335,11 +14226,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -13348,11 +14240,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -13370,11 +14263,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13382,11 +14276,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -13406,31 +14301,32 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -13441,10 +14337,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13454,11 +14352,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -13467,11 +14366,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -13488,11 +14388,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13500,11 +14401,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -13523,31 +14425,32 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding Custom netCDF input variable: " + nc_var,
                     )  # log at debug level
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
                         )  # log at debug level
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to extract "
                             + nc_var
                             + " from: "
                             + input_forcings.file_in2
                             + " ("
                             + str(err)
-                            + ")"
+                            + ")",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -13558,10 +14461,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local array into local ESMF field: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13573,11 +14478,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                        + str(ve),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -13586,11 +14492,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                        + str(npe),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -13610,11 +14517,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to run NDV search on Custom netCDF precipitation: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -13622,11 +14530,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg="Unable to place local ESMF regridded data into local array: "
+                        + str(err),
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -13653,21 +14562,21 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     with timing_block(
                         f"regrid step 2.5.1 | {mpi_config.rank}: regrid messages"
                     ):
-                        config_options.statusMsg = (
-                            "Regridding Custom netCDF input variable: " + nc_var
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding Custom netCDF input variable: " + nc_var,
                         )  # log at debug level
                     try:
                         with timing_block(
                             f"regrid step 2.5.2 | {mpi_config.rank}: messages2"
                         ):
-                            config_options.statusMsg = (
-                                f"Using {fill} to replace missing values in input"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Using {fill} to replace missing values in input",
                             )  # log at debug level
                         with timing_block(
                             f"regrid step 2.5.3 | {mpi_config.rank}: fill missing"
@@ -13678,8 +14587,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         with timing_block(
                             f"regrid step 2.5.4 | {mpi_config.rank}: extract error"
                         ):
-                            config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                            )
 
                 with timing_block(
                     f"regrid step 2.5.5 | {mpi_config.rank}: check program status"
@@ -13699,11 +14611,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local array into local ESMF field: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place local array into local ESMF field: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13718,11 +14631,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                            + str(ve)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to regrid input Custom netCDF forcing variables using ESMF: "
+                            + str(ve),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13734,11 +14648,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = fill
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                            + str(npe)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to calculate mask from input Custom netCDF regridded forcings: "
+                            + str(npe),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13764,11 +14679,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             AttributeError,
                             KeyError,
                         ) as npe:
-                            config_options.errMsg = (
-                                "Unable to run NDV search on Custom netCDF precipitation: "
-                                + str(npe)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg="Unable to run NDV search on Custom netCDF precipitation: "
+                                + str(npe),
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13779,11 +14695,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local ESMF regridded data into local array: "
-                            + str(err)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg="Unable to place local ESMF regridded data into local array: "
+                            + str(err),
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -13828,13 +14745,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
         elif config_options.grid_type == "unstructured":
             try:
@@ -13844,13 +14762,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field node mesh object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
@@ -13858,13 +14777,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field element mesh object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
         elif config_options.grid_type == "hydrofabric":
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
@@ -13873,13 +14793,14 @@ def check_regrid_status(
                     name=input_forcings.product_name + "FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to create "
                     + input_forcings.product_name
                     + " destination ESMF field element mesh object: "
-                    + str(esmf_error)
+                    + str(esmf_error),
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14248,8 +15169,12 @@ def load_weight_file(
         field_out = input_forcings.esmf_field_out_elem
         target_object_attr_name = "regridObj_elem"
 
-    config_options.statusMsg = f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}"
-    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.log_msg(
+        config_options,
+        mpi_config,
+        debug=True,
+        msg=f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}",
+    )  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
     try:
@@ -14260,13 +15185,19 @@ def load_weight_file(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = (
-            f"Unable to load cached ESMF{msg_augment}weight file: " + str(esmf_error)
+        err_handler.log_warning(
+            config_options,
+            mpi_config,
+            msg=f"Unable to load cached ESMF{msg_augment}weight file: "
+            + str(esmf_error),
         )
-        err_handler.log_warning(config_options, mpi_config)
     else:
-        config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds"
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg=f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds",
+        )  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14297,8 +15228,9 @@ def make_regrid(
 
     start_msg = f"RANK: {mpi_config.rank}: Creating{msg_augment}weight object from ESMF. weight_file={weight_file}"
     if mpi_config.rank == 0:
-        config_options.statusMsg = start_msg
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options, mpi_config, debug=True, msg=start_msg
+        )  # log at debug level
 
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[
@@ -14323,17 +15255,22 @@ def make_regrid(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = (
-            f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
-            + str(esmf_error)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
+            + str(esmf_error),
         )
-        err_handler.log_critical(config_options, mpi_config)
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
     else:
         if mpi_config.rank == 0:
-            config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds",
+            )  # log at debug level
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14366,14 +15303,20 @@ def execute_regrid(
             input_forcings, target_object_attr_name, regrid_object(field_in, field_out)
         )
     except ValueError as ve:
-        config_options.errMsg = (
-            "Unable to extract regridded data from ESMF regridded field: " + str(ve)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to extract regridded data from ESMF regridded field: "
+            + str(ve),
         )
-        err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
         if weight_file is not None:
-            config_options.statusMsg = f"Deleting if exists: {weight_file}"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Deleting if exists: {weight_file}",
+            )  # log at debug level
             try:
                 os_utils.os_remove_retry(weight_file)
             except FileNotFoundError:
@@ -14411,8 +15354,9 @@ def calculate_weights(
         esmf_grid_retry, mpi_config, config_options, err_handler
     )
 
-    config_options.statusMsg = "Calculate Weights"
-    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.log_msg(
+        config_options, mpi_config, debug=True, msg="Calculate Weights"
+    )  # log at debug level
 
     if mpi_config.rank == 0:
         if config_options.aws:
@@ -14421,54 +15365,58 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[0]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Y shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Y shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object"
+                    + " from aws object",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract X shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract X shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object"
+                    + " from aws object",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         else:
             try:
                 input_forcings.ny_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Y shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract Y shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
                     + " from: "
                     + input_forcings.tmpFile
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[2]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract X shape size from: "
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg="Unable to extract X shape size from: "
                     + input_forcings.netcdf_var_names[force_count]
                     + " from: "
                     + input_forcings.tmpFile
                     + " ("
                     + str(err)
-                    + ")"
+                    + ")",
                 )
-                err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # Broadcast the forcing nx/ny values
@@ -14489,14 +15437,15 @@ def calculate_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = (
-            "Unable to create source ESMF grid from temporary file: "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to create source ESMF grid from temporary file: "
             + input_forcings.tmpFile
             + " ("
             + str(esmf_error)
-            + ")"
+            + ")",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -14519,27 +15468,28 @@ def calculate_weights(
             input_forcings.y_upper_bound - input_forcings.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to extract local X/Y boundaries from global grid from temporary "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to extract local X/Y boundaries from global grid from temporary "
             + "file: "
             + input_forcings.tmpFile
             + " ("
             + str(err)
-            + ")"
+            + ")",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if input_forcings.nx_local < 2 or input_forcings.ny_local < 2:
-        config_options.errMsg = (
-            "You have either specified too many cores for: "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="You have either specified too many cores for: "
             + input_forcings.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must "
-            "have x/y dimension size of 2."
+            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # check if we're doing border trimming and set up mask
@@ -14550,13 +15500,13 @@ def calculate_weights(
                 ESMF.GridItem.MASK, ESMF.StaggerLoc.CENTER
             )
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Trimming input forcing `{}` by {} grid cells".format(
-                        input_forcings.product_name, border
-                    )
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Trimming input forcing `{}` by {} grid cells".format(
+                        input_forcings.product_name, border
+                    ),
                 )  # log at debug level
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
@@ -14666,21 +15616,23 @@ def calculate_weights(
     try:
         input_forcings.esmf_lats = input_forcings.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate latitude coordinate object within input ESMF grid: "
-            + str(ge)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to locate latitude coordinate object within input ESMF grid: "
+            + str(ge),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
         input_forcings.esmf_lons = input_forcings.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate longitude coordinate object within input ESMF grid: "
-            + str(ge)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="Unable to locate longitude coordinate object within input ESMF grid: "
+            + str(ge),
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     input_forcings.esmf_lats[:, :] = var_sub_lat_tmp
@@ -14698,10 +15650,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
     if config_options.grid_type == "unstructured":
@@ -14712,10 +15665,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Create a ESMF field to hold the incoming data.
@@ -14725,10 +15679,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
     elif config_options.grid_type == "hydrofabric":
@@ -14739,10 +15694,11 @@ def calculate_weights(
                 name=input_forcings.product_name + "_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg="Unable to create ESMF field object: " + str(esmf_error),
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
     # Scatter global grid to processors..
@@ -14982,13 +15938,13 @@ def calculate_supp_pcp_weights(
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if supplemental_precip.nx_local < 2 or supplemental_precip.ny_local < 2:
-        config_options.errMsg = (
-            "You have either specified too many cores for: "
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg="You have either specified too many cores for: "
             + supplemental_precip.product_name
-            + ", or  your input forcing grid is too small to process. Local grid "
-            "must have x/y dimension size of 2."
+            + ", or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     lat_tmp = lon_tmp = None

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -504,6 +504,9 @@ def _regrid_ak_ext_ana_pcp_stage4(
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
     )
@@ -1007,25 +1010,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}",
-                )
-            try:
-                os_utils.os_remove_retry(stage4_tmp_nc)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}",
-                )
-        err_handler.check_program_status(config_options, mpi_config)
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(stage4_tmp_nc)
 
 
 def regrid_ak_ext_ana_pcp(
@@ -1072,6 +1058,9 @@ def _regrid_conus_ext_ana_pcp_stage4(
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -1579,24 +1568,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}",
-                )
-            try:
-                os_utils.os_remove_retry(stage4_tmp_nc)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(stage4_tmp_nc)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1643,6 +1616,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -2536,24 +2512,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # mpi_config.comm.barrier()
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
-                )
-            try:
-                os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(input_forcings.tmpFile)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -2569,6 +2529,9 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -3444,24 +3407,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
-                )
-            try:
-                os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(input_forcings.tmpFile)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -3477,6 +3424,9 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -4522,24 +4472,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     ] = config_options.globalNdv
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
-                )
-            try:
-                os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(input_forcings.tmpFile)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -4555,6 +4489,9 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
 
     ## Flag to jump to different regridding module for AWS NWM Forcing data
@@ -4907,15 +4844,8 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ]
             err_handler.check_program_status(config_options, mpi_config)
-    # Close the NetCDF file
-    if mpi_config.rank == 0:
-        try:
-            id_tmp.close()
-        except OSError:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
-            )
-            err_handler.err_out(config_options)
+
+    close_rank_0_partial(id_tmp)
 
 
 def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
@@ -4930,6 +4860,9 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
 
     # Check to see if the regrid complete flag for this
@@ -5290,15 +5223,8 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ]
             err_handler.check_program_status(config_options, mpi_config)
-    # Close the NetCDF file
-    if mpi_config.rank == 0:
-        try:
-            id_tmp.close()
-        except OSError:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
-            )
-            err_handler.err_out(config_options)
+
+    close_rank_0_partial(id_tmp)
 
 
 def regrid_custom_hourly_netcdf(
@@ -5315,6 +5241,9 @@ def regrid_custom_hourly_netcdf(
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
 
     with timing_block("Regrid AORC AWS"):
@@ -6165,15 +6094,8 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ]
                 err_handler.check_program_status(config_options, mpi_config)
-        # Close the NetCDF file
-        if mpi_config.rank == 0:
-            try:
-                id_tmp.close()
-            except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
-                )
-                err_handler.err_out(config_options)
+
+        close_rank_0_partial(id_tmp)
 
 
 def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
@@ -6188,6 +6110,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -6751,15 +6676,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ]
             err_handler.check_program_status(config_options, mpi_config)
 
-    # Close the NetCDF file
-    if mpi_config.rank == 0:
-        try:
-            id_tmp.close()
-        except OSError:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
-            )
-            err_handler.err_out(config_options)
+    close_rank_0_partial(id_tmp)
 
 
 @static_vars(last_file=None)
@@ -6776,6 +6693,9 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -7634,27 +7554,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
-                )
-
-            # reinstituting removal - overwriting can cause issues on some file systems
-            # benefits of reuse seem unclear
-            try:
-                os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(input_forcings.tmpFile)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -7671,6 +7572,9 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -8440,24 +8344,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
-                )
-            try:
-                os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(input_forcings.tmpFile)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -9502,6 +9390,12 @@ def regrid_mrms_precip_flag(
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -9724,24 +9618,9 @@ def regrid_mrms_precip_flag(
             )
         err_handler.check_program_status(config_options, mpi_config)
 
-    # Close the NetCDF file
-    if mpi_config.rank == 0:
-        try:
-            id_tmp.close()
-        except OSError:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to close NetCDF file: {supplemental_precip.file_in2}",
-            )
-        try:
-            os_utils.os_remove_retry(mrms_tmp_nc)
-        except OSError:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to remove NetCDF file: {mrms_tmp_nc}",
-            )
+    close_rank_0_partial(id_tmp)
+    # os_remove_rank_0_partial(supplemental_precip.file_in2)  # TODO revisit, is this needed?  Original code was closing id_tmp with a msg about forcings_or_precip.file_in2
+    os_remove_rank_0_partial(mrms_tmp_nc)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -9760,6 +9639,9 @@ def regrid_hourly_wrf_arw(
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
     )
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
@@ -10632,26 +10514,9 @@ def regrid_hourly_wrf_arw(
                 err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile}",
-                )
-            try:
-                os_utils.os_remove_retry(input_forcings.tmpFile)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile}",
-                )
-    # noinspection PyUnreachableCode
-    err_handler.check_program_status(config_options, mpi_config)
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(input_forcings.tmpFile)
+        err_handler.check_program_status(config_options, mpi_config)
 
 
 def regrid_hourly_wrf_arw_hi_res_pcp(
@@ -10668,6 +10533,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
     )
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -11143,24 +11014,8 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             err_handler.check_program_status(config_options, mpi_config)
 
     finally:
-        # Close the temporary NetCDF file and remove it.
-        if mpi_config.rank == 0 and id_tmp is not None:
-            try:
-                id_tmp.close()
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to close NetCDF file: {arw_tmp_nc}",
-                )
-            try:
-                os_utils.os_remove_retry(arw_tmp_nc)
-            except OSError:
-                err_handler.log_critical(
-                    config_options,
-                    mpi_config,
-                    msg=f"Unable to remove NetCDF file: {arw_tmp_nc}",
-                )
+        close_rank_0_partial(id_tmp)
+        os_remove_rank_0_partial(arw_tmp_nc)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -11178,6 +11033,12 @@ def regrid_sbcv2_liquid_water_fraction(
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
     )
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -11545,16 +11406,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         err_handler.check_program_status(config_options, mpi_config)
 
-    # Close the NetCDF file
-    if mpi_config.rank == 0:
-        try:
-            id_tmp.close()
-        except OSError:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to close NetCDF file: {supplemental_forcings.file_in1}",
-            )
+    close_rank_0_partial(id_tmp)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -11572,6 +11424,12 @@ def regrid_hourly_nbm(
     """
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
     )
 
     # Do we want to use NBM data at this timestep? If not, log and continue
@@ -12468,24 +12326,9 @@ def regrid_hourly_nbm(
                 destination1_elem[:] = destination2_elem[:]
             err_handler.check_program_status(config_options, mpi_config)
 
-    # Close the temporary NetCDF file and remove it.
-    if mpi_config.rank == 0:
-        try:
-            id_tmp.close()
-        except OSError:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to close NetCDF file: {forcings_or_precip.file_in1}",
-            )
-        try:
-            os_utils.os_remove_retry(nbm_tmp_nc)
-        except OSError:
-            err_handler.log_critical(
-                config_options,
-                mpi_config,
-                msg=f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc}",
-            )
+    close_rank_0_partial(id_tmp)
+    # os_remove_rank_0_partial(forcings_or_precip.file_in1)  # TODO revisit, is this needed?  Original code was closing id_tmp with a msg about forcings_or_precip.file_in1
+    os_remove_rank_0_partial(nbm_tmp_nc)
     err_handler.check_program_status(config_options, mpi_config)
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -69,6 +69,44 @@ GRIB2 = "GRIB2"
 next_file_number = 0
 
 
+def get_partials(mpi_config: MpiConfig, config_options: ConfigOptions):
+    """Return a tuple of various partials for keeping things DRY"""
+    esmf_regridobj_call_retry_partial = functools.partial(
+        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
+    )
+    esmf_field_retry_partial = functools.partial(
+        esmf_field_retry, mpi_config, config_options, err_handler
+    )
+    esmf_grid_retry_partial = functools.partial(
+        esmf_grid_retry, mpi_config, config_options, err_handler
+    )
+    esmf_regrid_retry_partial = functools.partial(
+        esmf_regrid_retry, mpi_config, config_options, err_handler
+    )
+    esmf_mesh_retry_partial = functools.partial(
+        esmf_mesh_retry, mpi_config, config_options, err_handler
+    )
+    close_rank_0_partial = functools.partial(
+        os_utils.close_rank_0, mpi_config, config_options, err_handler
+    )
+    close_anyrank_partial = functools.partial(
+        os_utils.close, mpi_config, config_options, err_handler
+    )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
+    return (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    )
+
+
 @contextmanager
 def timing_block(step_str: str):
     """Context manager for timing code execution.
@@ -140,15 +178,16 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     :param mpi_config:
     :return:
     """
-    esmf_grid_retry_partial = functools.partial(
-        esmf_grid_retry, mpi_config, config_options, err_handler
-    )
-    esmf_mesh_retry_partial = functools.partial(
-        esmf_mesh_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     ds = None
 
@@ -496,15 +535,16 @@ def _regrid_ak_ext_ana_pcp_stage4(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -1051,15 +1091,16 @@ def _regrid_conus_ext_ana_pcp_stage4(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -1609,15 +1650,16 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -2522,15 +2564,16 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -3417,15 +3460,16 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -4482,12 +4526,16 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     ## Flag to jump to different regridding module for AWS NWM Forcing data
     if config_options.aws:
@@ -4853,12 +4901,16 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # Check to see if the regrid complete flag for this
     # output time step is true. This entails the necessary
@@ -5234,12 +5286,16 @@ def regrid_custom_hourly_netcdf(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     with timing_block("Regrid AORC AWS"):
         # Flag to jump to different regridding function soley for AORC AWS data
@@ -6103,12 +6159,16 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -6686,15 +6746,16 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -7565,15 +7626,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     :param config_options:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -8357,15 +8419,16 @@ def regrid_mrms_hourly(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_partial = functools.partial(
-        os_utils.close, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # Do we want to use MRMS data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
@@ -9341,8 +9404,8 @@ def regrid_mrms_hourly(
 
     finally:
         # Close whichever file handles got opened
-        close_partial(id_mrms)
-        close_partial(id_mrms_rqi)
+        close_anyrank_partial(id_mrms)
+        close_anyrank_partial(id_mrms_rqi)
         os_remove_rank_0_partial(mrms_tmp_grib2)
         os_remove_rank_0_partial(mrms_tmp_nc)
         os_remove_rank_0_partial(mrms_tmp_rqi_grib2)
@@ -9363,15 +9426,16 @@ def regrid_mrms_precip_flag(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -9613,15 +9677,16 @@ def regrid_hourly_wrf_arw(
     :param config_options:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -10507,15 +10572,16 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -11007,15 +11073,16 @@ def regrid_sbcv2_liquid_water_fraction(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -11398,15 +11465,16 @@ def regrid_hourly_nbm(
     :param mpi_config:
     :return:
     """
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_rank_0_partial = functools.partial(
-        os_utils.close_rank_0, mpi_config, config_options, err_handler
-    )
-    os_remove_rank_0_partial = functools.partial(
-        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # Do we want to use NBM data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
@@ -12310,12 +12378,16 @@ def regrid_hourly_nbm(
 @static_vars(last_file=None)
 def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     """Regrid NDFD forcing data to the WRF-Hydro domain."""
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
-    close_partial = functools.partial(
-        os_utils.close, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # Check to see if the regrid complete flag for this
     # output time step is true. This entails the necessary
@@ -12711,7 +12783,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             err_handler.check_program_status(config_options, mpi_config)
         finally:
             # always close the NetCDF handle
-            close_partial(id_tmp)
+            close_anyrank_partial(id_tmp)
 
             # only remove the scratch file if this was a new‐cycle run
             if (
@@ -12731,9 +12803,16 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
 def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     """Regrid AORC AWS forcing data to the WRF-Hydro domain."""
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     fill_values = {
         "TMP": 288.0,
@@ -13329,9 +13408,16 @@ def check_regrid_status(
     :param mpi_config:
     :return:
     """
-    esmf_field_retry_partial = functools.partial(
-        esmf_field_retry, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the destination ESMF field hasn't been created, create it here.
     if not input_forcings.esmf_field_out:
@@ -13486,9 +13572,16 @@ def check_supp_pcp_regrid_status(
     :param mpi_config:
     :return:
     """
-    esmf_field_retry_partial = functools.partial(
-        esmf_field_retry, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     # If the destination ESMF field hasn't been created, create it here.
     if not supplemental_precip.esmf_field_out:
@@ -13907,12 +14000,16 @@ def calculate_weights(
     :param force_count:
     :return:
     """
-    esmf_field_retry_partial = functools.partial(
-        esmf_field_retry, mpi_config, config_options, err_handler
-    )
-    esmf_grid_retry_partial = functools.partial(
-        esmf_grid_retry, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     err_handler.log_msg(config_options, mpi_config, debug=True, msg="Calculate Weights")
 
@@ -14337,18 +14434,16 @@ def calculate_supp_pcp_weights(
     :param config_options:
     :return:
     """
-    esmf_field_retry_partial = functools.partial(
-        esmf_field_retry, mpi_config, config_options, err_handler
-    )
-    esmf_grid_retry_partial = functools.partial(
-        esmf_grid_retry, mpi_config, config_options, err_handler
-    )
-    esmf_regrid_retry_partial = functools.partial(
-        esmf_regrid_retry, mpi_config, config_options, err_handler
-    )
-    esmf_regridobj_call_retry_partial = functools.partial(
-        esmf_regridobj_call_retry, mpi_config, config_options, err_handler
-    )
+    (
+        esmf_regridobj_call_retry_partial,
+        esmf_field_retry_partial,
+        esmf_grid_retry_partial,
+        esmf_regrid_retry_partial,
+        esmf_mesh_retry_partial,
+        close_rank_0_partial,
+        close_anyrank_partial,
+        os_remove_rank_0_partial,
+    ) = get_partials(mpi_config, config_options)
 
     ndims = 0
     if mpi_config.rank == 0:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -95,6 +95,15 @@ def get_partials(mpi_config: MpiConfig, config_options: ConfigOptions):
     os_remove_rank_0_partial = functools.partial(
         os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
     )
+    log_debug = functools.partial(
+        err_handler.log_msg, config_options, mpi_config, debug=True
+    )
+    log_info = functools.partial(
+        err_handler.log_msg, config_options, mpi_config, debug=False
+    )
+    log_warn = functools.partial(err_handler.log_warning, config_options, mpi_config)
+    log_err = functools.partial(err_handler.log_error, config_options, mpi_config)
+    log_crit = functools.partial(err_handler.log_critical, config_options, mpi_config)
     return (
         esmf_regridobj_call_retry_partial,
         esmf_field_retry_partial,
@@ -104,6 +113,11 @@ def get_partials(mpi_config: MpiConfig, config_options: ConfigOptions):
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     )
 
 
@@ -187,6 +201,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     ds = None
@@ -196,12 +215,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # exit out of this routine as the regridded fields have already been set to NDV.
         if not os.path.isfile(input_forcings.file_in2):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="No AK AnA in_2 file found for this timestep.",
-                )
+                log_debug(msg="No AK AnA in_2 file found for this timestep.")
             return
 
         # Check to see if the regrid complete flag for this
@@ -209,12 +223,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="No AK AnA regridding required for this timestep.",
-                )
+                log_debug(msg="No AK AnA regridding required for this timestep.")
             return
 
         # Only rank‐0 opens the file
@@ -401,11 +410,8 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             var_tmp = None
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}",
+                log_debug(
+                    msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}"
                 )
                 LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
@@ -544,6 +550,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -556,12 +567,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No StageIV regridding required for this timestep.",
-            )
+            log_debug(msg="No StageIV regridding required for this timestep.")
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -586,9 +592,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-6 hour acc fcst"
 
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
-                )
+                log_debug(msg=f"WGRIB2 command: {cmd}")
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -619,12 +623,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="Calculating STAGE IV regridding weights.",
-                )
+                log_debug(msg="Calculating STAGE IV regridding weights.")
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -641,11 +640,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp = id_tmp.variables[
@@ -674,11 +670,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp = id_tmp.variables[
@@ -707,11 +700,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp_elem = id_tmp.variables[
@@ -741,11 +731,8 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp = id_tmp.variables[
@@ -1100,6 +1087,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -1112,12 +1104,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No StageIV regridding required for this timestep.",
-            )
+            log_debug(msg="No StageIV regridding required for this timestep.")
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -1141,9 +1128,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-1 hour acc fcst"
 
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
-                )
+                log_debug(msg=f"WGRIB2 command: {cmd}")
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -1174,12 +1159,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="Calculating STAGE IV regridding weights.",
-                )
+                log_debug(msg="Calculating STAGE IV regridding weights.")
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -1196,11 +1176,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp = id_tmp.variables[
@@ -1229,11 +1206,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp = id_tmp.variables[
@@ -1262,11 +1236,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp_elem = id_tmp.variables[
@@ -1296,11 +1267,8 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    log_debug(
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     )
                 try:
                     var_tmp = id_tmp.variables[
@@ -1659,18 +1627,18 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
     if not os.path.isfile(input_forcings.file_in2):
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No HRRR in_2 file found for this timestep.",
-            )
+            log_debug(msg="No HRRR in_2 file found for this timestep.")
         return
 
     # Check to see if the regrid complete flag for this
@@ -1678,12 +1646,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No HRRR regridding required for this timestep.",
-            )
+            log_debug(msg="No HRRR regridding required for this timestep.")
         return
 
     # Create a path for a temporary NetCDF file
@@ -1695,7 +1658,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
     id_tmp = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS HRRR")
+        log_info(msg="Regrid CONUS HRRR")
 
         if input_forcings.file_type != NETCDF:
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
@@ -1704,12 +1667,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Converting HRRR Variable: {grib_var}",
-                    )
+                    log_debug(msg=f"Converting HRRR Variable: {grib_var}")
                 if 0 < input_forcings.cycle_freq < 60:
                     time_str = (
                         f"{input_forcings.fcst_min1}-{input_forcings.fcst_min2} min acc fcst"
@@ -1760,12 +1718,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing HRRR Variable: {grib_var}",
-                )
+                log_debug(msg=f"Processing HRRR Variable: {grib_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -1779,12 +1732,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculating HRRR regridding weights.",
-                    )
+                    log_debug(msg="Calculating HRRR regridding weights.")
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -1836,11 +1784,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -1911,11 +1856,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -1982,11 +1924,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -2059,11 +1998,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -2123,11 +2059,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2171,11 +2104,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2230,11 +2160,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2278,11 +2205,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2336,11 +2260,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2384,11 +2305,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -2445,11 +2363,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
@@ -2493,11 +2408,8 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -2573,6 +2485,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -2585,12 +2502,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No RAP regridding required for this timestep.",
-            )
+            log_debug(msg="No RAP regridding required for this timestep.")
         return
 
     # Create a path for a temporary NetCDF file
@@ -2604,19 +2516,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
     id_tmp = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS RAP")
+        log_info(msg="Regrid CONUS RAP")
         if input_forcings.file_type != NETCDF:
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Converting CONUS RAP Variable: {grib_var}",
-                    )
+                    log_debug(msg=f"Converting CONUS RAP Variable: {grib_var}")
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
@@ -2657,12 +2564,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing Conus RAP Variable: {grib_var}",
-                )
+                log_debug(msg=f"Processing Conus RAP Variable: {grib_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -2676,12 +2578,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculating RAP regridding weights.",
-                    )
+                    log_debug(msg="Calculating RAP regridding weights.")
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -2732,11 +2629,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -2807,11 +2701,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -2881,11 +2772,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -2958,11 +2846,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -3052,11 +2937,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3158,11 +3040,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3263,11 +3142,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out_elem = (
@@ -3372,11 +3248,8 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -3469,6 +3342,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -3484,12 +3362,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         # correction on incoming CFSv2 data. Because of the nature, we
         # need to regrid bias-corrected data every hour.
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No need to read in new CFSv2 data at this time.",
-            )
+            log_debug(msg="No need to read in new CFSv2 data at this time.")
         return
 
     # Create a path for a temporary NetCDF file
@@ -3503,19 +3376,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
     id_tmp = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Regrid CFSv2")
+        log_info(msg="Regrid CFSv2")
         if input_forcings.file_type != NETCDF:
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Converting CFSv2 Variable: {grib_var}",
-                    )
+                    log_debug(msg=f"Converting CFSv2 Variable: {grib_var}")
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -3551,12 +3419,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing CFSv2 Variable: {grib_var}",
-                )
+                log_debug(msg=f"Processing CFSv2 Variable: {grib_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -3570,12 +3433,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculate CFSv2 regridding weights.",
-                    )
+                    log_debug(msg="Calculate CFSv2 regridding weights.")
 
                 calculate_weights(
                     id_tmp,
@@ -3629,11 +3487,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain."
                         )
 
                     try:
@@ -3705,11 +3560,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain."
                         )
 
                     try:
@@ -3780,11 +3632,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain."
                         )
 
                     try:
@@ -3858,11 +3707,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain."
                         )
 
                     try:
@@ -3926,11 +3772,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        log_debug(
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         )
                     try:
                         var_tmp = id_tmp.variables[
@@ -4073,11 +3916,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        log_debug(
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         )
                     try:
                         var_tmp = id_tmp.variables[
@@ -4219,11 +4059,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        log_debug(
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         )
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -4368,11 +4205,8 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        log_debug(
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         )
                     try:
                         var_tmp = id_tmp.variables[
@@ -4535,6 +4369,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     ## Flag to jump to different regridding module for AWS NWM Forcing data
@@ -4552,12 +4391,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No NWM NetCDF regridding required for this timestep.",
-            )
+            log_debug(msg="No NWM NetCDF regridding required for this timestep.")
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4565,18 +4399,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         input_forcings.file_in2, config_options, mpi_config, open_on_all_procs=True
     )
 
-    err_handler.log_msg(
-        config_options, mpi_config, msg="Regrid NWM Custom NetCDF Forcing Variables"
-    )
+    log_info(msg="Regrid NWM Custom NetCDF Forcing Variables")
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-            )
+            log_debug(msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}")
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4598,23 +4425,15 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
+            log_debug(
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available."
             )
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4680,12 +4499,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4750,12 +4564,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4821,12 +4630,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
@@ -4910,6 +4714,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # Check to see if the regrid complete flag for this
@@ -4917,12 +4726,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No NWM NetCDF regridding required for this timestep.",
-            )
+            log_debug(msg="No NWM NetCDF regridding required for this timestep.")
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -4946,18 +4750,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 longitude=(["y", "x"], lon_coords), latitude=(["y", "x"], lat_coords)
             )
 
-    err_handler.log_msg(
-        config_options, mpi_config, msg="Regrid NWM Custom zarr Forcing Variables"
-    )
+    log_info(msg="Regrid NWM Custom zarr Forcing Variables")
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg=f"Processing Custom zarr Forcing Variable: {nc_var}",
-            )
+            log_debug(msg=f"Processing Custom zarr Forcing Variable: {nc_var}")
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4978,22 +4775,15 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
+            log_info(
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available."
             )
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom zarr input variable: {nc_var}")
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5059,12 +4849,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom zarr input variable: {nc_var}")
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5129,12 +4914,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom zarr input variable: {nc_var}")
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5200,12 +4980,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding Custom zarr input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding Custom zarr input variable: {nc_var}")
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
@@ -5295,6 +5070,11 @@ def regrid_custom_hourly_netcdf(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     with timing_block("Regrid AORC AWS"):
@@ -5316,11 +5096,8 @@ def regrid_custom_hourly_netcdf(
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="No Custom Hourly NetCDF regridding required for this timestep.",
+                log_debug(
+                    msg="No Custom Hourly NetCDF regridding required for this timestep."
                 )
             return
 
@@ -5340,20 +5117,11 @@ def regrid_custom_hourly_netcdf(
             "DLWRF": 310.0,
         }
 
-        err_handler.log_msg(
-            config_options,
-            mpi_config,
-            msg="Regrid Custom Hourly NetCDF Forcing Variables",
-        )
+        log_info(msg="Regrid Custom Hourly NetCDF Forcing Variables")
 
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-                )
+                log_debug(msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}")
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
                 force_count,
@@ -5407,11 +5175,8 @@ def regrid_custom_hourly_netcdf(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding elevation data to the WRF-Hydro domain."
                             )
                         try:
                             input_forcings.esmf_field_out = (
@@ -5478,11 +5243,8 @@ def regrid_custom_hourly_netcdf(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding elevation data to the WRF-Hydro domain."
                             )
                         try:
                             input_forcings.esmf_field_out = (
@@ -5550,11 +5312,8 @@ def regrid_custom_hourly_netcdf(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding elevation data to the WRF-Hydro domain."
                             )
                         try:
                             input_forcings.esmf_field_out_elem = (
@@ -5621,11 +5380,8 @@ def regrid_custom_hourly_netcdf(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding elevation data to the WRF-Hydro domain."
                             )
                         try:
                             input_forcings.esmf_field_out = (
@@ -5671,10 +5427,8 @@ def regrid_custom_hourly_netcdf(
                 else:
                     input_forcings.height = None
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
+                        log_info(
+                            msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available."
                         )
 
                 # close netCDF file on non-root ranks
@@ -5688,18 +5442,10 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
@@ -5803,18 +5549,10 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
@@ -5916,18 +5654,10 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
@@ -6035,18 +5765,10 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
@@ -6168,6 +5890,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -6180,12 +5907,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No ERA5-Interim regridding required for this timestep.",
-            )
+            log_debug(msg="No ERA5-Interim regridding required for this timestep.")
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -6208,18 +5930,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     )
     ind = np.where(seconds_index == np.min(seconds_index))[0][0]
 
-    err_handler.log_msg(
-        config_options, mpi_config, msg="Regrid Custom Hourly NetCDF Forcing Variables"
-    )
+    log_info(msg="Regrid Custom Hourly NetCDF Forcing Variables")
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}",
-            )
+            log_debug(msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}")
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -6246,10 +5961,8 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             else:
                 input_forcings.height = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to locate Geopoential height in: {input_forcings.file_in2}. Downscaling will not be available.",
+                    log_info(
+                        msg=f"Unable to locate Geopoential height in: {input_forcings.file_in2}. Downscaling will not be available."
                     )
 
             # close netCDF file on non-root ranks
@@ -6261,19 +5974,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
 
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding ERA5-Interim input variable: {nc_var}")
                 try:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Using -9999. to replace missing values in input",
-                    )
+                    log_debug(msg="Using -9999. to replace missing values in input")
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6378,19 +6081,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding ERA5-Interim input variable: {nc_var}")
                 try:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Using -9999. to replace missing values in input",
-                    )
+                    log_debug(msg="Using -9999. to replace missing values in input")
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6494,19 +6187,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding ERA5-Interim input variable: {nc_var}")
                 try:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Using -9999. to replace missing values in input",
-                    )
+                    log_debug(msg="Using -9999. to replace missing values in input")
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.0)[
                         ind, :, :
                     ]
@@ -6618,19 +6301,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
-                )
+                log_debug(msg=f"Regridding ERA5-Interim input variable: {nc_var}")
                 try:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Using -9999. to replace missing values in input",
-                    )
+                    log_debug(msg="Using -9999. to replace missing values in input")
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -6755,6 +6428,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -6767,12 +6445,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No 13km GFS regridding required for this timestep.",
-            )
+            log_debug(msg="No 13km GFS regridding required for this timestep.")
         return
 
     # Create a temporary NetCDF file name to hold converted GRIB2 data.
@@ -6797,9 +6470,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
     id_tmp = None
     try:
-        err_handler.log_msg(
-            config_options, mpi_config, msg="Regridding 13km GFS Variables."
-        )
+        log_info(msg="Regridding 13km GFS Variables.")
 
         if input_forcings.file_type != NETCDF:
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
@@ -6807,12 +6478,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Converting 13km GFS Variable: {grib_var}",
-                    )
+                    log_debug(msg=f"Converting 13km GFS Variable: {grib_var}")
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
                     # By far the most complicated of output variables. We need to calculate
@@ -6865,12 +6531,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing 13km GFS Variable: {grib_var}",
-                )
+                log_debug(msg=f"Processing 13km GFS Variable: {grib_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -6884,12 +6545,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculating 13km GFS regridding weights.",
-                    )
+                    log_debug(msg="Calculating 13km GFS regridding weights.")
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -6993,11 +6649,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain.",
+                    log_debug(
+                        msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain."
                     )
                 if config_options.grid_type == "gridded":
                     try:
@@ -7350,11 +7003,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if config_options.grid_type == "gridded":
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     begin = monotonic()
@@ -7365,12 +7015,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Regridding took {end - begin} seconds",
-                        )
+                        log_debug(msg=f"Regridding took {end - begin} seconds")
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7415,11 +7060,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "unstructured":
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     begin = monotonic()
@@ -7430,12 +7072,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Node Regridding took {end - begin} seconds",
-                        )
+                        log_debug(msg=f"Node Regridding took {end - begin} seconds")
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7479,11 +7116,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     begin = monotonic()
@@ -7496,12 +7130,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Element Regridding took {end - begin} seconds",
-                        )
+                        log_debug(msg=f"Element Regridding took {end - begin} seconds")
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7546,11 +7175,8 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "hydrofabric":
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}"
                     )
                 try:
                     begin = monotonic()
@@ -7561,12 +7187,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Element Regridding took {end - begin} seconds",
-                        )
+                        log_debug(msg=f"Element Regridding took {end - begin} seconds")
                 except ValueError as ve:
                     err_handler.log_critical(
                         config_options,
@@ -7635,6 +7256,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -7646,11 +7272,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        err_handler.log_msg(
-            config_options,
-            mpi_config,
-            debug=True,
-            msg="No regridding of NAM nest data necessary for this timestep - already completed.",
+        log_debug(
+            msg="No regridding of NAM nest data necessary for this timestep - already completed."
         )
         return
 
@@ -7665,19 +7288,14 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
     id_tmp = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Regridding NAM nest data")
+        log_info(msg="Regridding NAM nest data")
         if input_forcings.file_type != NETCDF:
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Converting NAM-Nest Variable: {grib_var}",
-                    )
+                    log_debug(msg=f"Converting NAM-Nest Variable: {grib_var}")
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -7716,12 +7334,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing NAM Nest Variable: {grib_var}",
-                )
+                log_debug(msg=f"Processing NAM Nest Variable: {grib_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -7735,12 +7348,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculating NAM nest regridding weights....",
-                    )
+                    log_debug(msg="Calculating NAM nest regridding weights....")
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -7785,11 +7393,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -7854,11 +7459,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -7922,11 +7524,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -7993,11 +7592,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -8059,11 +7655,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp = id_tmp.variables[
@@ -8145,11 +7738,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp = id_tmp.variables[
@@ -8230,11 +7820,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -8318,11 +7905,8 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp = id_tmp.variables[
@@ -8428,16 +8012,17 @@ def regrid_mrms_hourly(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # Do we want to use MRMS data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                msg="Exceeded max hours for MRMS precipitation",
-            )
+            log_info(msg="Exceeded max hours for MRMS precipitation")
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -8454,12 +8039,7 @@ def regrid_mrms_hourly(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No MRMS regridding required for this timestep.",
-            )
+            log_debug(msg="No MRMS regridding required for this timestep.")
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -8491,10 +8071,8 @@ def regrid_mrms_hourly(
     # alert the user, and set the final output grids to be the global NDV and return.
     if not supplemental_precip.file_in1 or not supplemental_precip.file_in2:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                msg="No MRMS Precipitation available. Supplemental precipitation will not be used.",
+            log_info(
+                msg="No MRMS Precipitation available. Supplemental precipitation will not be used."
             )
         supplemental_precip.regridded_precip2 = None
         supplemental_precip.regridded_precip1 = None
@@ -8519,7 +8097,7 @@ def regrid_mrms_hourly(
     id_mrms = None
     id_mrms_rqi = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Rrgrid MRMS")
+        log_info(msg="Rrgrid MRMS")
 
         if supplemental_precip.file_type != NETCDF:
             # Unzip MRMS files to temporary locations.
@@ -8604,12 +8182,7 @@ def regrid_mrms_hourly(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="Calculating MRMS regridding weights.",
-                )
+                log_debug(msg="Calculating MRMS regridding weights.")
             calculate_supp_pcp_weights(
                 supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config
             )
@@ -8648,12 +8221,7 @@ def regrid_mrms_hourly(
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding MRMS RQI Field.",
-                    )
+                    log_debug(msg="Regridding MRMS RQI Field.")
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -8675,11 +8243,8 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"{n_masked} masked cells in RQI field, will remove",
+                            log_debug(
+                                msg=f"{n_masked} masked cells in RQI field, will remove"
                             )
 
                     supplemental_precip.esmf_field_out.data[
@@ -8724,12 +8289,7 @@ def regrid_mrms_hourly(
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding MRMS RQI Field.",
-                    )
+                    log_debug(msg="Regridding MRMS RQI Field.")
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -8751,11 +8311,8 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"{n_masked} masked cells in RQI field, will remove",
+                            log_debug(
+                                msg=f"{n_masked} masked cells in RQI field, will remove"
                             )
 
                     supplemental_precip.esmf_field_out.data[
@@ -8799,12 +8356,7 @@ def regrid_mrms_hourly(
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding MRMS RQI Field.",
-                    )
+                    log_debug(msg="Regridding MRMS RQI Field.")
                 try:
                     supplemental_precip.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -8826,11 +8378,8 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask_elem == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"{n_masked} masked cells in RQI field, will remove",
+                            log_debug(
+                                msg=f"{n_masked} masked cells in RQI field, will remove"
                             )
 
                     supplemental_precip.esmf_field_out_elem.data[
@@ -8855,12 +8404,7 @@ def regrid_mrms_hourly(
                 supplemental_precip.regridded_rqi2[:] = 1.0
 
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="MRMS Will not be filtered using RQI values.",
-                )
+                log_debug(msg="MRMS Will not be filtered using RQI values.")
 
         elif supplemental_precip.rqiMethod == 2:
             # Read in the RQI field from monthly climatological files.
@@ -8891,12 +8435,7 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )
+                log_debug(msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}")
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -8967,11 +8506,8 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            log_debug(
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
@@ -9019,12 +8555,7 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )
+                log_debug(msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}")
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9095,11 +8626,8 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            log_debug(
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
@@ -9146,12 +8674,7 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )
+                log_debug(msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}")
                 try:
                     var_tmp_elem = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9227,11 +8750,8 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter_elem) > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            log_debug(
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             )
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = (
                         config_options.globalNdv
@@ -9278,12 +8798,7 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
-                )
+                log_debug(msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}")
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
@@ -9354,11 +8869,8 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            log_debug(
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
@@ -9435,6 +8947,11 @@ def regrid_mrms_precip_flag(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -9481,11 +8998,7 @@ def regrid_mrms_precip_flag(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                msg="Calculating MRMS PrecipFlag regridding weights.",
-            )
+            log_info(msg="Calculating MRMS PrecipFlag regridding weights.")
         calculate_supp_pcp_weights(
             supplemental_precip,
             id_tmp,
@@ -9499,9 +9012,7 @@ def regrid_mrms_precip_flag(
     var_tmp = None
     if mpi_config.rank == 0:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options, mpi_config, msg="Regridding MRMS PrecipFlag Fraction."
-            )
+            log_info(msg="Regridding MRMS PrecipFlag Fraction.")
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
@@ -9576,11 +9087,7 @@ def regrid_mrms_precip_flag(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    msg="Regridding MRMS PrecipFlag Fraction.",
-                )
+                log_info(msg="Regridding MRMS PrecipFlag Fraction.")
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_precip.netcdf_var_names[0]
@@ -9686,6 +9193,11 @@ def regrid_hourly_wrf_arw(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -9697,11 +9209,8 @@ def regrid_hourly_wrf_arw(
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        err_handler.log_msg(
-            config_options,
-            mpi_config,
-            debug=True,
-            msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed.",
+        log_debug(
+            msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed."
         )
         return
 
@@ -9717,7 +9226,7 @@ def regrid_hourly_wrf_arw(
 
     id_tmp = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Regrid WRF-ARW nest data")
+        log_info(msg="Regrid WRF-ARW nest data")
 
         if input_forcings.file_type != NETCDF:
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
@@ -9725,12 +9234,7 @@ def regrid_hourly_wrf_arw(
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Converting WRF-ARW Variable: {grib_var}",
-                    )
+                    log_debug(msg=f"Converting WRF-ARW Variable: {grib_var}")
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
@@ -9774,12 +9278,7 @@ def regrid_hourly_wrf_arw(
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing WRF-ARW Variable: {grib_var}",
-                )
+                log_debug(msg=f"Processing WRF-ARW Variable: {grib_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -9793,12 +9292,7 @@ def regrid_hourly_wrf_arw(
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculating WRF-ARW regridding weights....",
-                    )
+                    log_debug(msg="Calculating WRF-ARW regridding weights....")
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -9843,11 +9337,8 @@ def regrid_hourly_wrf_arw(
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -9911,11 +9402,8 @@ def regrid_hourly_wrf_arw(
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -9979,11 +9467,8 @@ def regrid_hourly_wrf_arw(
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -10050,11 +9535,8 @@ def regrid_hourly_wrf_arw(
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        log_debug(
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain."
                         )
                     try:
                         input_forcings.esmf_field_out = (
@@ -10116,11 +9598,8 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp = id_tmp.variables[
@@ -10226,11 +9705,8 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp = id_tmp.variables[
@@ -10335,11 +9811,8 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp_elem = id_tmp.variables[
@@ -10448,11 +9921,8 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    log_debug(
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     )
                     try:
                         var_tmp = id_tmp.variables[
@@ -10581,6 +10051,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -10593,12 +10068,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No ARW regridding required for this timestep.",
-            )
+            log_debug(msg="No ARW regridding required for this timestep.")
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -10609,7 +10079,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
     id_tmp = None
     try:
-        err_handler.log_msg(config_options, mpi_config, msg="Regrid ARW")
+        log_info(msg="Regrid ARW")
 
         if supplemental_precip.file_type != NETCDF:
             # These files shouldn't exist. If they do, remove them.
@@ -10670,12 +10140,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="Calculating WRF ARW regridding weights.",
-                )
+                log_debug(msg="Calculating WRF ARW regridding weights.")
             calculate_supp_pcp_weights(
                 supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config
             )
@@ -10686,12 +10151,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding WRF ARW APCP Precipitation.",
-                    )
+                    log_debug(msg="Regridding WRF ARW APCP Precipitation.")
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -10779,12 +10239,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding WRF ARW APCP Precipitation.",
-                    )
+                    log_debug(msg="Regridding WRF ARW APCP Precipitation.")
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -10871,12 +10326,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding WRF ARW APCP Precipitation.",
-                    )
+                    log_debug(msg="Regridding WRF ARW APCP Precipitation.")
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -10967,12 +10417,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Regridding WRF ARW APCP Precipitation.",
-                    )
+                    log_debug(msg="Regridding WRF ARW APCP Precipitation.")
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -11082,6 +10527,11 @@ def regrid_sbcv2_liquid_water_fraction(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -11107,12 +10557,7 @@ def regrid_sbcv2_liquid_water_fraction(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="Calculating SBCv2 Liquid Water Fraction regridding weights.",
-            )
+            log_debug(msg="Calculating SBCv2 Liquid Water Fraction regridding weights.")
         calculate_supp_pcp_weights(
             supplemental_forcings,
             id_tmp,
@@ -11129,11 +10574,7 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    msg="Regridding SBCv2 Liquid Water Fraction.",
-                )
+                log_info(msg="Regridding SBCv2 Liquid Water Fraction.")
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -11209,12 +10650,7 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="Regridding SBCv2 Liquid Water Fraction - unstructured",
-                )
+                log_debug(msg="Regridding SBCv2 Liquid Water Fraction - unstructured")
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -11289,12 +10725,7 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg="Regridding SBCv2 Liquid Water Fraction input variable.",
-                )
+                log_debug(msg="Regridding SBCv2 Liquid Water Fraction input variable.")
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_forcings.netcdf_var_names[0]
@@ -11374,11 +10805,7 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    msg="Regridding SBCv2 Liquid Water Fraction - hydrofabric",
-                )
+                log_info(msg="Regridding SBCv2 Liquid Water Fraction - hydrofabric")
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
@@ -11474,15 +10901,18 @@ def regrid_hourly_nbm(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # Do we want to use NBM data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                msg="Exceeded max hours for NBM data, will not use NBM in final layering.",
+            log_info(
+                msg="Exceeded max hours for NBM data, will not use NBM in final layering."
             )
         return
 
@@ -11522,12 +10952,7 @@ def regrid_hourly_nbm(
         fields = []
         for force_count, grib_var in enumerate(forcings_or_precip.grib_vars):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Converting NBM Variable: {grib_var}",
-                )
+                log_debug(msg=f"Converting NBM Variable: {grib_var}")
             time_str = (
                 f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
@@ -11560,16 +10985,11 @@ def regrid_hourly_nbm(
 
     err_handler.check_program_status(config_options, mpi_config)
 
-    err_handler.log_msg(config_options, mpi_config, msg="Processing NBM Variables")
+    log_info(msg="Processing NBM Variables")
 
     for force_count, nc_var in enumerate(forcings_or_precip.netcdf_var_names):
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg=f"Processing NBM Variable: {nc_var}",
-            )
+            log_debug(msg=f"Processing NBM Variable: {nc_var}")
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -11597,12 +11017,7 @@ def regrid_hourly_nbm(
         if calc_regrid_flag:
             if is_supp:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Calculating NBM {tag} regridding weights.",
-                    )
+                    log_debug(msg=f"Calculating NBM {tag} regridding weights.")
                 calculate_supp_pcp_weights(
                     forcings_or_precip,
                     id_tmp,
@@ -11613,12 +11028,7 @@ def regrid_hourly_nbm(
                 err_handler.check_program_status(config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Calculating NBM {tag} regridding weights.",
-                    )
+                    log_debug(msg=f"Calculating NBM {tag} regridding weights.")
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -11681,11 +11091,8 @@ def regrid_hourly_nbm(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain."
                             )
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -11753,11 +11160,8 @@ def regrid_hourly_nbm(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain."
                             )
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -11825,11 +11229,8 @@ def regrid_hourly_nbm(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
+                            log_debug(
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain."
                             )
                         try:
                             forcings_or_precip.esmf_field_out = (
@@ -11896,11 +11297,8 @@ def regrid_hourly_nbm(
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg="Regridding NBM elevation data to the unstructured domain.",
+                            log_debug(
+                                msg="Regridding NBM elevation data to the unstructured domain."
                             )
                         try:
                             forcings_or_precip.esmf_field_out_elem = (
@@ -11949,12 +11347,7 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding NBM {nc_var}",
-                )
+                log_debug(msg=f"Regridding NBM {nc_var}")
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12054,12 +11447,7 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding NBM {nc_var}",
-                )
+                log_debug(msg=f"Regridding NBM {nc_var}")
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12158,12 +11546,7 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding NBM {nc_var}",
-                )
+                log_debug(msg=f"Regridding NBM {nc_var}")
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12262,12 +11645,7 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Regridding NBM {nc_var}",
-                )
+                log_debug(msg=f"Regridding NBM {nc_var}")
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
@@ -12387,6 +11765,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # Check to see if the regrid complete flag for this
@@ -12394,15 +11777,10 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            err_handler.log_msg(
-                config_options,
-                mpi_config,
-                debug=True,
-                msg="No NDFD regridding required for this timestep.",
-            )
+            log_debug(msg="No NDFD regridding required for this timestep.")
         return
 
-    err_handler.log_msg(config_options, mpi_config, msg="Regrid NDFD")
+    log_info(msg="Regrid NDFD")
 
     hour = input_forcings.fcst_hour2
     current_cycle = config_options.current_fcst_cycle
@@ -12428,12 +11806,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         # Temp file may exist. If it does, and we don't need it again, remove it.....
         if not reuse_prev_file and mpi_config.rank == 0:
             if os.path.isfile(tmp_file):
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Deleting old temporary file: {tmp_file}",
-                )
+                log_debug(msg=f"Deleting old temporary file: {tmp_file}")
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
@@ -12448,20 +11821,14 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         try:
             if reuse_prev_file:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Cycle unchanged, reusing temporary file: {tmp_file}",
+                    log_debug(
+                        msg=f"Cycle unchanged, reusing temporary file: {tmp_file}"
                     )
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}",
+                    log_debug(
+                        msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}"
                     )
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
@@ -12483,49 +11850,32 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 times = [datetime.utcfromtimestamp(t) for t in id_tmp["time"][:]]
                 if ndfd_var != "qpf":
                     if forecast_time > times[-1] + timedelta(hours=3):
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Forecast time beyond NDFD range, skipping",
-                        )
+                        log_debug(msg="Forecast time beyond NDFD range, skipping")
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}",
+                        log_debug(
+                            msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}"
                         )
                     else:
                         time_index = min(
                             range(len(times)),
                             key=lambda i: abs(times[i] - forecast_time),
                         )
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}",
+                        log_debug(
+                            msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}"
                         )
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg="Forecast time beyond NDFD precip range, skipping",
+                        log_debug(
+                            msg="Forecast time beyond NDFD precip range, skipping"
                         )
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}",
+                        log_debug(
+                            msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}"
                         )
 
             skip_file = mpi_config.broadcast_parameter(
@@ -12552,12 +11902,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 continue
 
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing NDFD variable: {ndfd_var}",
-                )
+                log_debug(msg=f"Processing NDFD variable: {ndfd_var}")
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -12571,12 +11916,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg="Calculating NDFD regridding weights.",
-                    )
+                    log_debug(msg="Calculating NDFD regridding weights.")
                 calculate_weights(
                     id_tmp,
                     i,
@@ -12812,6 +12152,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     fill_values = {
@@ -12828,22 +12173,12 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         mpi_config.comm.barrier()
         id_tmp = config_options.aws_obj
 
-        err_handler.log_msg(
-            config_options,
-            mpi_config,
-            debug=True,
-            msg="Processing Custom NetCDF Forcing Variables",
-        )
+        log_debug(msg="Processing Custom NetCDF Forcing Variables")
 
     with timing_block(f"regrid step 2 | {mpi_config.rank}: loop over variables"):
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
-                )
+                log_debug(msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}")
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
             ):
@@ -12889,18 +12224,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
@@ -13004,18 +12331,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
@@ -13117,18 +12436,10 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    err_handler.log_msg(
-                        config_options,
-                        mpi_config,
-                        debug=True,
-                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
-                    )
+                    log_debug(msg=f"Regridding Custom netCDF input variable: {nc_var}")
                     try:
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Using {fill} to replace missing values in input",
+                        log_debug(
+                            msg=f"Using {fill} to replace missing values in input"
                         )
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
@@ -13243,21 +12554,15 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     with timing_block(
                         f"regrid step 2.5.1 | {mpi_config.rank}: regrid messages"
                     ):
-                        err_handler.log_msg(
-                            config_options,
-                            mpi_config,
-                            debug=True,
-                            msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                        log_debug(
+                            msg=f"Regridding Custom netCDF input variable: {nc_var}"
                         )
                     try:
                         with timing_block(
                             f"regrid step 2.5.2 | {mpi_config.rank}: messages2"
                         ):
-                            err_handler.log_msg(
-                                config_options,
-                                mpi_config,
-                                debug=True,
-                                msg=f"Using {fill} to replace missing values in input",
+                            log_debug(
+                                msg=f"Using {fill} to replace missing values in input"
                             )
                         with timing_block(
                             f"regrid step 2.5.3 | {mpi_config.rank}: fill missing"
@@ -13417,6 +12722,11 @@ def check_regrid_status(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the destination ESMF field hasn't been created, create it here.
@@ -13581,6 +12891,11 @@ def check_supp_pcp_regrid_status(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     # If the destination ESMF field hasn't been created, create it here.
@@ -14009,9 +13324,14 @@ def calculate_weights(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
-    err_handler.log_msg(config_options, mpi_config, debug=True, msg="Calculate Weights")
+    log_debug(msg="Calculate Weights")
 
     if mpi_config.rank == 0:
         if config_options.aws:
@@ -14128,11 +13448,8 @@ def calculate_weights(
                 ESMF.GridItem.MASK, ESMF.StaggerLoc.CENTER
             )
             if mpi_config.rank == 0:
-                err_handler.log_msg(
-                    config_options,
-                    mpi_config,
-                    debug=True,
-                    msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells",
+                log_debug(
+                    msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells"
                 )
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
@@ -14443,6 +13760,11 @@ def calculate_supp_pcp_weights(
         close_rank_0_partial,
         close_anyrank_partial,
         os_remove_rank_0_partial,
+        log_debug,
+        log_info,
+        log_warn,
+        log_err,
+        log_crit,
     ) = get_partials(mpi_config, config_options)
 
     ndims = 0

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -504,6 +504,9 @@ def _regrid_ak_ext_ana_pcp_stage4(
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -536,24 +539,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
     id_tmp = None
     try:
         if supplemental_precip.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0:
-                if os.path.isfile(stage4_tmp_nc):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
-                    )
-                    try:
-                        os_utils.os_remove_retry(stage4_tmp_nc)
-                    except OSError:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
-                        )
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(stage4_tmp_nc, "Found old tmp file. ")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
@@ -1087,6 +1073,9 @@ def _regrid_conus_ext_ana_pcp_stage4(
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -1118,24 +1107,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
     id_tmp = None
     try:
         if supplemental_precip.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0:
-                if os.path.isfile(stage4_tmp_nc):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
-                    )
-                    try:
-                        os_utils.os_remove_retry(stage4_tmp_nc)
-                    except OSError:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
-                        )
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(stage4_tmp_nc, "Found old tmp file. ")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
@@ -1713,8 +1685,6 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS HRRR")
 
         if input_forcings.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
             os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             # Build GRIB2 to NetCDF conversion
@@ -2600,6 +2570,9 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -2632,24 +2605,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     try:
         err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS RAP")
         if input_forcings.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0:
-                if os.path.isfile(input_forcings.tmpFile):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
-                    )
-                    try:
-                        os_utils.os_remove_retry(input_forcings.tmpFile)
-                    except OSError:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to remove file: {input_forcings.tmpFile}",
-                        )
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
@@ -3522,6 +3478,9 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -3557,24 +3516,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
     try:
         err_handler.log_msg(config_options, mpi_config, msg="Regrid CFSv2")
         if input_forcings.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0:
-                if os.path.isfile(input_forcings.tmpFile):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
-                    )
-                    try:
-                        os_utils.os_remove_retry(input_forcings.tmpFile)
-                    except OSError as err:
-                        err_handler.log_critical(
-                            config_options,
-                            mpi_config,
-                            msg=f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err}",
-                        )
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
@@ -6835,6 +6777,9 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -6881,23 +6826,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         )
 
         if input_forcings.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                err_handler.log_warning(
-                    config_options,
-                    mpi_config,
-                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
-                )
-                try:
-                    os_utils.os_remove_retry(input_forcings.tmpFile)
-                except OSError:
-                    err_handler.log_critical(
-                        config_options,
-                        mpi_config,
-                        msg=f"Unable to remove file: {input_forcings.tmpFile}",
-                    )
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
@@ -7743,6 +7672,9 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -7774,20 +7706,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     try:
         err_handler.log_msg(config_options, mpi_config, msg="Regridding NAM nest data")
         if input_forcings.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0:
-                if os.path.isfile(input_forcings.tmpFile):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
-                    )
-                    try:
-                        os_utils.os_remove_retry(input_forcings.tmpFile)
-                    except OSError:
-                        err_handler.err_out(config_options)
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
@@ -9842,6 +9761,9 @@ def regrid_hourly_wrf_arw(
     esmf_regridobj_call_retry_partial = functools.partial(
         esmf_regridobj_call_retry, mpi_config, config_options, err_handler
     )
+    os_remove_rank_0_partial = functools.partial(
+        os_utils.os_remove_rank_0, mpi_config, config_options, err_handler
+    )
 
     # If the expected file is missing, this means we are allowing missing files, simply
     # exit out of this routine as the regridded fields have already been set to NDV.
@@ -9875,20 +9797,7 @@ def regrid_hourly_wrf_arw(
         err_handler.log_msg(config_options, mpi_config, msg="Regrid WRF-ARW nest data")
 
         if input_forcings.file_type != NETCDF:
-            # This file shouldn't exist.... but if it does (previously failed
-            # execution of the program), remove it.....
-            if mpi_config.rank == 0:
-                if os.path.isfile(input_forcings.tmpFile):
-                    err_handler.log_warning(
-                        config_options,
-                        mpi_config,
-                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
-                    )
-                    try:
-                        os_utils.os_remove_retry(input_forcings.tmpFile)
-                    except OSError:
-                        err_handler.err_out(config_options)
-            err_handler.check_program_status(config_options, mpi_config)
+            os_remove_rank_0_partial(input_forcings.tmpFile, "Found old tmp file. ")
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/os_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/os_utils.py
@@ -54,18 +54,35 @@ def os_remove_rank_0(
     err_handler.check_program_status(config_options, mpi_config)
 
 
-def close_rank_0(
+def close_rank_0(mpi_config: MpiConfig, *args, **kwargs) -> None:
+    """If rank 0, close the file handle. Wraps _close.
+    Collective, must be called by all ranks.
+    file_handle must have a close() method or be None.
+    If rank != 0 or file_handle is None, do nothing except the error handler collective call."""
+    if mpi_config.rank == 0:
+        _close(mpi_config, *args, **kwargs)
+
+
+def close(mpi_config: MpiConfig, *args, **kwargs) -> None:
+    """Close the file handle. Wraps _close.
+    Collective, must be called by all ranks.
+    file_handle must have a close() method or be None.
+    If file_handle is None, do nothing except the error handler collective call."""
+    _close(mpi_config, *args, **kwargs)
+
+
+def _close(
     mpi_config: MpiConfig,
     config_options: ConfigOptions,
     err_handler: types.ModuleType,
     file_handle: typing.Any | None,
     msg_prefix: str = "",
 ) -> None:
-    """If rank 0, close the file handle.
+    """Close the file handle.
     Collective, must be called by all ranks.
     file_handle must have a close() method or be None.
-    If rank != 0 or file_handle is None, do nothing except the error handler collective call."""
-    if mpi_config.rank == 0 and file_handle is not None:
+    If file_handle is None, do nothing except the error handler collective call."""
+    if file_handle is not None:
         if not hasattr(file_handle, "close"):
             raise RuntimeError(
                 f"Provided object for file_handle does not have a close method: {file_handle}"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/os_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/os_utils.py
@@ -1,5 +1,6 @@
 from . import retry_utils
 import types
+import typing
 from .core.parallel import MpiConfig
 from .core.config import ConfigOptions
 import os
@@ -39,6 +40,9 @@ def os_remove_rank_0(
     file_path: str,
     msg_prefix: str = "",
 ) -> None:
+    """If rank 0, remove the file if it exists. Ignore FileNotFoundErrors.
+    Collective, must be called by all ranks.
+    If rank != 0 or file_handle is None, do nothing except the error handler collective call."""
     if mpi_config.rank == 0:
         if os.path.exists(file_path):
             err_handler.log_warning(
@@ -47,4 +51,37 @@ def os_remove_rank_0(
                 msg=f"{msg_prefix}Removing file: {file_path}",
             )
             os_remove_retry(file_path, ignore_filenotfound=True)
+    err_handler.check_program_status(config_options, mpi_config)
+
+
+def close_rank_0(
+    mpi_config: MpiConfig,
+    config_options: ConfigOptions,
+    err_handler: types.ModuleType,
+    file_handle: typing.Any | None,
+    msg_prefix: str = "",
+) -> None:
+    """If rank 0, close the file handle.
+    Collective, must be called by all ranks.
+    file_handle must have a close() method or be None.
+    If rank != 0 or file_handle is None, do nothing except the error handler collective call."""
+    if mpi_config.rank == 0 and file_handle is not None:
+        if not hasattr(file_handle, "close"):
+            raise RuntimeError(
+                f"Provided object for file_handle does not have a close method: {file_handle}"
+            )
+        # Get file name from the handle
+        if hasattr(file_handle, "filepath"):
+            fn = getattr(file_handle, "filepath")()  # filepath is a method
+        elif hasattr(file_handle, "name"):
+            fn = getattr(file_handle, "name")
+        else:
+            fn = "(UNKNOWN)"
+        # Close
+        try:
+            file_handle.close()
+        except Exception as e:
+            raise RuntimeError(
+                f"{msg_prefix}Could not close file object: {file_handle}. File name: {fn}"
+            ) from e
     err_handler.check_program_status(config_options, mpi_config)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/os_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/os_utils.py
@@ -22,6 +22,29 @@ def assert_path_exists_retry(
 @retry_utils.retry_simple(num_retries=3, sleep_start=1, sleep_factor=3)
 def os_remove_retry(
     path: str,
+    ignore_filenotfound: bool = False,
 ):
     """os.remove() call, wrapped by simple retry decorator."""
-    os.remove(path)
+    try:
+        os.remove(path)
+    except FileNotFoundError as e:
+        if not ignore_filenotfound:
+            raise e
+
+
+def os_remove_rank_0(
+    mpi_config: MpiConfig,
+    config_options: ConfigOptions,
+    err_handler: types.ModuleType,
+    file_path: str,
+    msg_prefix: str = "",
+) -> None:
+    if mpi_config.rank == 0:
+        if os.path.exists(file_path):
+            err_handler.log_warning(
+                config_options,
+                mpi_config,
+                msg=f"{msg_prefix}Removing file: {file_path}",
+            )
+            os_remove_retry(file_path, ignore_filenotfound=True)
+    err_handler.check_program_status(config_options, mpi_config)


### PR DESCRIPTION
The target of this PR can be changed to `development` if #83 is merged first, but I wanted to open this PR as stacked (at least initially) for simpler review.


This builds on https://github.com/NGWPC/ngen-forcing/pull/83 for refactoring `regrid.py` by defining new functions for repetitive calls to `os.remove()` and `filehandle.close()`, for cases where the calls are gated to rank 0 and for cases where all ranks call those.  

This also includes replacement of `err_handler.log_*` calls with equivalent partials that already contain the MPI Config and config options classes.


Both of the above significantly reduce the number of lines of code via shared logic and by allowing log calls to fit on less lines (when formatted to line length 88) due to less parameters per log call.

## Regex Code for Log Call Replacements

Here are the regex replacement strings that were applied in VS Code to perform the replacement of the various log calls throughout the file.  Within each block, these must be carried out in this order for them to work properly.

```
### Debug True, ending with comma and line break
err_handler\.log_msg\(\s*config_options,\s*mpi_config,\s*debug=True,\s*msg=(.*?),\n
log_debug(msg=$1

### Debug True, ending with close parens
err_handler\.log_msg\(\s*config_options,\s*mpi_config,\s*debug=True,\s*msg=(.*?)\)
log_debug(msg=$1)

### Debug True, ending with raw line break
err_handler\.log_msg\(\s*config_options,\s*mpi_config,\s*debug=True,\s*msg=(.*?)\n
log_debug(msg=$1


### Info (debug omitted), ending with comma and line break
err_handler\.log_msg\(\s*config_options,\s*mpi_config,\s*msg=(.*?),\n
log_msg(msg=$1

### Info (debug omitted), ending with close parens
err_handler\.log_msg\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\)
log_msg(msg=$1)

### Info (debug omitted), ending with raw line break
err_handler\.log_msg\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\n
log_msg(msg=$1


### Warning, ending with comma and line break
err_handler\.log_warning\(\s*config_options,\s*mpi_config,\s*msg=(.*?),\n
log_warn(msg=$1

### Warning, ending with close parens
err_handler\.log_warning\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\)
log_warn(msg=$1)

### Warning, ending with raw line break
err_handler\.log_warning\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\n
log_warn(msg=$1


### Error, ending with comma and line break
err_handler\.log_error\(\s*config_options,\s*mpi_config,\s*msg=(.*?),\n
log_err(msg=$1

### Error, ending with close parens
err_handler\.log_error\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\)
log_err(msg=$1)

### Error, ending with raw line break
err_handler\.log_error\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\n
log_err(msg=$1


### Critical, ending with comma and line break
err_handler\.log_critical\(\s*config_options,\s*mpi_config,\s*msg=(.*?),\n
log_crit(msg=$1

### Critical, ending with close parens
err_handler\.log_critical\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\)
log_crit(msg=$1)

### Critical, ending with raw line break
err_handler\.log_critical\(\s*config_options,\s*mpi_config,\s*msg=(.*?)\n
log_crit(msg=$1 
```

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

