### PR TITLE
uniquefying and making mesh files temporary

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -1,10 +1,12 @@
 # Need these for BMI
 # This is needed for get_var_bytes
+import atexit
 import gc
 import hashlib
 import os
 
 # time debugging
+import signal
 import time
 from collections import defaultdict
 from pathlib import Path
@@ -237,6 +239,13 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             self._mpi_meta.initialize_comm(self._job_meta, comm=comm)
         except Exception as e:
             err_handler.err_out_screen(self._job_meta.errMsg, e)
+
+        # cleanup meshfile on exit because it's temporary, now
+        # TODO: consider WCOSS gating
+        if self._mpi_meta.rank == 0:
+            atexit.register(self._cleanup_geogrid)
+            for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                signal.signal(sig, self._signal_handler)
 
         # LOG.debug(f"self._job_meta type: {type(self._job_meta)}")
         # Call ESMF mesh creation process
@@ -946,6 +955,24 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             )
             self._output_configured = True
 
+    def _cleanup_geogrid(self):
+        """Remove temporary geogrid file if it exists."""
+        try:
+            geofile = getattr(self, "_job_meta", None)
+            if geofile is not None:
+                geofile = getattr(geofile, "geogrid", None)
+            if geofile is not None and os.path.isfile(geofile):
+                os.remove(geofile)
+        except Exception:
+            pass
+
+    def _signal_handler(self, signum, frame):
+        """Handle termination signals by cleaning up before exit."""
+        self._cleanup_geogrid()
+        # Re-raise the signal to allow normal termination
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
     # ------------------------------------------------------------
     def update(self):
         """Update the model by advancing one time step.
@@ -1050,6 +1077,14 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
                         os.remove(file_path)
                     elif os.path.isdir(file_path):
                         os.rmdir(file_path)
+            # TODO: Consider if this can be gated for non-wcoss only
+            try:
+                atexit.unregister(self._cleanup_geogrid)
+            except Exception:
+                pass
+
+            # Do the cleanup
+            self._cleanup_geogrid()
 
     # -------------------------------------------------------------------
     # -------------------------------------------------------------------

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -4,6 +4,7 @@ import logging
 import re
 import os
 from datetime import datetime, timedelta, timezone
+import uuid
 
 import numpy as np
 
@@ -181,26 +182,30 @@ class ConfigOptions:
         # Ensure geogrid is set; if not, read from the configuration file
         if self.geogrid is None:
             try:
-                self.geogrid = cfg_bmi.get(
+                geogrid_base = cfg_bmi.get(
                     "GeogridIn", None
                 )  # Default to None if not found
-                if self.geogrid is None:
-                    err_out_screen(
-                        "Unable to locate GeogridIn in the configuration file."
-                    )
             except KeyError as e:
                 err_out_screen(
                     "Unable to locate GeogridIn in the configuration file.", e
                 )
+            if geogrid_base is None:
+                err_out_screen("Unable to locate GeogridIn in the configuration file.")
+                self.geogrid = None
+            else:
+                geogrid_parent = os.path.dirname(geogrid_base)
+                geogrid_filename = os.path.basename(geogrid_base)
+                self.geogrid = os.path.join(
+                    geogrid_parent, f"{uuid.uuid4().hex}_{geogrid_filename}"
+                )
             # Create directory for esmf_mesh file
-            geogrid_dir = os.path.dirname(self.geogrid)
-            if not os.path.isdir(geogrid_dir):
+            if not os.path.isdir(geogrid_parent):
                 try:
-                    os.makedirs(geogrid_dir, exist_ok=True)
-                    LOG.debug(f"Created esmf mesh directory: {geogrid_dir}")
+                    os.makedirs(geogrid_parent, exist_ok=True)
+                    LOG.debug(f"Created esmf mesh directory: {geogrid_parent}")
                 except OSError as e:
                     err_out_screen(
-                        f"Unable to create esmf_mesh directory: {geogrid_dir}. Error: {e}"
+                        f"Unable to create esmf_mesh directory: {geogrid_parent}. Error: {e}"
                     )
 
         # Read in the base input forcing options as an array of values to map.
@@ -2082,7 +2087,9 @@ class ConfigOptions:
         pattern = r"geo_em_([a-zA-Z-_]+)\.nc$"  # E.g. extract "Puerto_Rico" from /foo/bar/esmf_mesh/NWM/domain/geo_em_Puerto_Rico.nc
         groups = re.findall(pattern, self.nwm_geogrid)
         if len(groups) != 1:
-            raise ValueError(f"Could not determine NWM domain. {len(groups)} groups found (expected 1) in {self.nwm_geogrid} using regex pattern {pattern}")
+            raise ValueError(
+                f"Could not determine NWM domain. {len(groups)} groups found (expected 1) in {self.nwm_geogrid} using regex pattern {pattern}"
+            )
         domain = groups[0]
         if domain in ["PuertoRico", "Puerto_Rico", "PR"]:
             return "PR"


### PR DESCRIPTION
ESMF mesh files continue to cause problem on shared NFS. A file created by a previous simulation that is then reused by a later simulation can cause an Errno -51, which appears as a corrupted file, but which may be caused by stale metadata. The solution for running multiple concurrent simulations using the same geospatial discretization is to make meshfiles temporary, and unique. 
## Additions

-

## Removals

-

## Changes

- Made meshfiles unique by using uuid in config.py. 
- Added cleanup logic in bmi_model, so that it's cleaned at exit, or at finalize.

## Testing

1.Tested locally on multiple configurations. Examined file creation and removal, both at completion of run and when terminating the process early. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

