### PR TITLE
Fix Stale Python OS Environment when EWTS runs with ngen.

### DIFF
--- a/nextgen_forcings_ewts/src/nextgen_forcings_ewts/config.py
+++ b/nextgen_forcings_ewts/src/nextgen_forcings_ewts/config.py
@@ -43,6 +43,7 @@ from .constants import (
 )
 from .formatter import CustomFormatter
 from .paths import get_log_file_path
+from .helper import getenv_any
 
 def translate_ngwpc_log_level(level: str) -> str:
     level = level.strip().upper()
@@ -75,7 +76,7 @@ def configure_logging():
         return logger # logger already initialized, nothing else to do
 
     # Default to enabled if flag not set or is set to disabled
-    raw_value = os.getenv(EV_EWTS_LOGGING)
+    raw_value = getenv_any(EV_EWTS_LOGGING, "")
     normalized = (raw_value or "").strip().lower()  # convert None or "" to "", lowercase for easy comparison
 
     # Determine if logging is enabled
@@ -102,7 +103,7 @@ def configure_logging():
     )
 
     log_level = translate_ngwpc_log_level(
-        os.getenv(EV_MODULE_LOGLEVEL, "INFO")
+        getenv_any(EV_MODULE_LOGLEVEL, "INFO")
     )
 
     module_fmt = MODULE_NAME.upper().ljust(LOG_MODULE_NAME_LEN)[:LOG_MODULE_NAME_LEN]

--- a/nextgen_forcings_ewts/src/nextgen_forcings_ewts/helper.py
+++ b/nextgen_forcings_ewts/src/nextgen_forcings_ewts/helper.py
@@ -1,0 +1,32 @@
+import os
+
+# NOTE:
+# ngen sets some env vars from C++ after the Python interpreter has started.
+# In embedded Python, os.environ may not reflect those changes.
+# getenv_any() falls back to libc getenv() and syncs os.environ.
+def getenv_any(key: str, default: str = "") -> str:
+    """
+    Get an environment variable reliably even when it is set from C/C++
+    after the Python interpreter has started (embedded Python).
+    Prefers os.environ/os.getenv, falls back to libc getenv.
+    """
+    # First try Python's mapping
+    v = os.environ.get(key)
+    if v is not None:
+        return v
+
+    # Fallback: direct libc getenv (sees process env even if Python mapping is stale)
+    try:
+        import ctypes, ctypes.util
+        libc = ctypes.CDLL(ctypes.util.find_library("c"))
+        libc.getenv.restype = ctypes.c_char_p
+        b = libc.getenv(key.encode("utf-8"))
+        if not b:
+            return default
+        s = b.decode("utf-8")
+
+        # Sync back into os.environ so future lookups work normally
+        os.environ[key] = s
+        return s
+    except Exception:
+        return default

--- a/nextgen_forcings_ewts/src/nextgen_forcings_ewts/paths.py
+++ b/nextgen_forcings_ewts/src/nextgen_forcings_ewts/paths.py
@@ -39,6 +39,8 @@ from .constants import (
     LOG_DIR_NGENCERF,
     LOG_FILE_EXT,
 )
+from .helper import getenv_any
+
 
 def create_timestamp(date_only=False, iso=False, append_ms=False):
     now = datetime.now(timezone.utc)
@@ -67,12 +69,12 @@ def get_log_file_path():
     moduleLogFileExists = False
 
      # Determine if a log file has laready been opened for this module (either the ngen log or default)
-    moduleEnvVar = os.getenv(EV_MODULE_LOGFILEPATH, "")
+    moduleEnvVar = getenv_any(EV_MODULE_LOGFILEPATH, "").strip()
     if moduleEnvVar:
         logFilePath = moduleEnvVar
         moduleLogFileExists = True
     else:
-        ngenEnvVar = os.getenv(EV_NGEN_LOGFILEPATH, "")
+        ngenEnvVar = getenv_any(EV_NGEN_LOGFILEPATH, "").strip()
         if ngenEnvVar:
             logFilePath = ngenEnvVar
         else:


### PR DESCRIPTION
ngen ( C++ ) is calling setenv() after Python has already initialized os.environ, and Python’s os.environ mapping is not automatically refreshed when the environment is mutated from C/C++ to run python code with ngen.

Python keeps an internal view of the environment that includes things set before Python started (like NGEN_RESULTS_DIR), but not variables injected later from C++ (like NGEN_LOG_FILE_PATH and <MODULE>_LOGLEVEL).

Added a helper method to ensure the Python os environment is not stale when ngen-focing BMI runs.

Merging this to `development` because the release being delivered on February 25, 2026 does not include BMI Forcing and this only is an issue when running ngen with BMI Forcing.