### PR TITLE
Add flexibility to run VPU-scale forcing 

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -64,7 +64,6 @@ class MpiConfig:
         wait_for_debug = os.getenv("WAIT_FOR_DEBUGPY", "")
         if wait_for_debug.lower() in ("true", "1"):
             self.wait_for_debugpy_client()
-        print("here")
 
     def __broadcast_new_64bit_uid(self, config_options):
         """Broadcast a random uint64 then save the hash of that to self.uid64, which effectively broadcasts the same unique string to all ranks."""

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -138,15 +138,7 @@ class BaseProcessor:
     @property
     def gage_id(self) -> str:
         """Return gage id from geospatial dataframe."""
-        match = re.search(
-            r"^gauge_(\d+)\.gpkg$", os.path.basename(self.config_options.geopackage)
-        )
-        if match:
-            return str(match.group(1))
-        else:
-            raise ValueError(
-                f"Unable to extract gage ID from geopackage filename: {self.config_options.geopackage}"
-            )
+        return os.path.splitext(os.path.basename(self.config_options.geopackage))[0]
 
     @property
     def nc_path(self) -> str:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -360,7 +360,7 @@ class AORCConusProcessor(BaseProcessor):
                     ).rename({self.x_label: "x", self.y_label: "y"})
         except Exception as e:
             LOG.critical(
-                f"Error opening {self.dataset_name} data from {self.url()}: {e}\n"
+                f"Error opening {self.dataset_name} data from {self.url(self.current_time.year)}: {e}\n"
             )
             raise e
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -136,14 +136,14 @@ class BaseProcessor:
         )
 
     @property
-    def gage_id(self) -> str:
-        """Return gage id from geospatial dataframe."""
+    def gpkg_name(self) -> str:
+        """Return name of the geopackage."""
         return os.path.splitext(os.path.basename(self.config_options.geopackage))[0]
 
     @property
     def nc_path(self) -> str:
         """Construct file path for cached netcdf files."""
-        return f"/tmp/{self.dataset_name}_{self.gage_id}_{self.current_time_str}_{self.end_time_str}.nc"
+        return f"/tmp/{self.dataset_name}_{self.gpkg_name}_{self.current_time_str}_{self.end_time_str}.nc"
 
     @property
     def end_time_datetime(self) -> pd.Timestamp:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -275,7 +275,9 @@ class BaseProcessor:
 
         :return: Cache size as np.timedelta64
         """
-        return np.timedelta64(round(24 * 365 * 20 / self.number_of_catchments), "h")
+        return np.timedelta64(
+            max(round(24 * 365 * 20 / self.number_of_catchments), 12), "h"
+        )
 
     def slice_ds(self, ds: xr.Dataset) -> xr.Dataset:
         """Subset dataset to spatial and temporal bounds.


### PR DESCRIPTION
Add flexibility to run VPU-scale forcing and set minimum time window.

## Additions

-

## Removals

- Removed regex that was parsing gage id for naming cache files. Now just use full name of the user provided gpkg file.

## Changes

- Set a minimum time window for caching (12hrs).
- Pass missing "year" arg to url method in AORCConusProcessor.

## Testing

1. RTE calibration runs
2. Regionalization (VPU-based run) 

## Screenshots


## Notes

-

## Todos

- Devise a more sophisticated way of determining time window for caching based on memory available on the OS. 

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

