### PR TITLE
regrid.py Further Formatting and Direct Log Calls

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -107,14 +107,12 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
     """Create a symbolic link to the input file for processing."""
     if mpi_config.rank == 0:
         try:
-            config_options.statusMsg = name + " file being used: " + input_file
+            config_options.statusMsg = f"{name} file being used: {input_file}"
             err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
             os.symlink(input_file, tmpFile)
         except:
-            config_options.errMsg = (
-                "Unable to create link: " + input_file + " to: " + tmpFile
-            )
+            config_options.errMsg = f"Unable to create link: {input_file} to: {tmpFile}"
             err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -380,10 +378,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -403,10 +398,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds_elem]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -428,10 +420,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract ExtAnA forcing data from the AK AnA mesh field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -504,9 +493,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
                     config_options.statusMsg = (
-                        "Found old temporary file: "
-                        + stage4_tmp_nc
-                        + " - Removing....."
+                        f"Found old temporary file: {stage4_tmp_nc} - Removing....."
                     )
                     err_handler.log_warning(config_options, mpi_config)
                     try:
@@ -594,13 +581,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -628,13 +609,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -662,13 +637,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -697,13 +666,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -716,10 +679,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -731,7 +691,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -742,10 +702,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -764,10 +721,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -783,10 +737,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -798,7 +749,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -809,10 +760,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -831,10 +779,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -849,10 +794,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -866,7 +808,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -877,10 +819,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -900,10 +839,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -919,10 +855,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -934,7 +867,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -945,10 +878,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -967,10 +897,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1088,9 +1015,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
                     config_options.statusMsg = (
-                        "Found old temporary file: "
-                        + stage4_tmp_nc
-                        + " - Removing....."
+                        f"Found old temporary file: {stage4_tmp_nc} - Removing....."
                     )
                     err_handler.log_warning(config_options, mpi_config)
                     try:
@@ -1178,13 +1103,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1212,13 +1131,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1246,13 +1159,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp_elem,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1281,13 +1188,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from STAGE IV file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1300,10 +1201,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1315,7 +1213,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1326,10 +1224,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1348,10 +1243,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1367,10 +1259,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1382,7 +1271,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1393,10 +1282,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1415,10 +1301,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1433,10 +1316,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1450,7 +1330,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1461,10 +1341,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1484,10 +1361,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1503,10 +1377,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place STAGE IV precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1518,7 +1389,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid STAGE IV supplemental precipitation: " + str(ve)
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1529,10 +1400,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1556,10 +1424,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 del ind_valid
                 del invalid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on STAGE IV supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
@@ -1711,13 +1576,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         else f"{input_forcings.fcst_hour2} hour fcst"
                     )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
@@ -1726,7 +1585,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 pattern = "|".join(fields)
                 cmd = f'$WGRIB2 -match "({pattern})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -1752,7 +1611,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing HRRR Variable: " + grib_var
+                config_options.statusMsg = f"Processing HRRR Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -1804,12 +1663,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1821,10 +1675,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1842,10 +1693,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1855,20 +1703,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1882,12 +1724,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1899,10 +1736,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1920,10 +1754,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1933,20 +1764,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1956,12 +1781,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1973,10 +1793,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1994,10 +1811,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2007,10 +1821,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2019,10 +1830,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2036,12 +1844,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HRRR elevation from "
-                                + input_forcings.tmpFile
-                                + ": "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2053,10 +1856,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place input NetCDF HRRR data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2074,10 +1874,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid HRRR surface elevation using ESMF: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2087,20 +1884,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform HRRR mask search on elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract regridded HRRR elevation data from ESMF: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2123,10 +1914,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2149,15 +1937,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2170,16 +1950,13 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                        f"Unable to place input HRRR data into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2191,7 +1968,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                        f"Unable to regrid input HRRR forcing data: {ve!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2202,10 +1979,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2214,10 +1988,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2235,10 +2006,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2261,15 +2029,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2282,16 +2042,13 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                        f"Unable to place input HRRR data into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2303,7 +2060,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                        f"Unable to regrid input HRRR forcing data: {ve!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2314,10 +2071,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2326,10 +2080,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2346,10 +2097,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2372,15 +2120,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2393,16 +2133,13 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                        f"Unable to place input HRRR data into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2416,7 +2153,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                        f"Unable to regrid input HRRR forcing data: {ve!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2427,10 +2164,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2439,10 +2173,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2460,10 +2191,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Processing input HRRR variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2486,15 +2214,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2507,16 +2227,13 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place input HRRR data into ESMF field: " + str(err)
+                        f"Unable to place input HRRR data into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input HRRR Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -2528,7 +2245,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        "Unable to regrid input HRRR forcing data: " + str(ve)
+                        f"Unable to regrid input HRRR forcing data: {ve!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2539,10 +2256,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to perform mask test on regridded HRRR forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2551,10 +2265,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract regridded HRRR forcing data from the ESMF field: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2643,17 +2354,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing....."
-                    )
+                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
                     err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
                         config_options.errMsg = (
-                            "Unable to remove file: " + input_forcings.tmpFile
+                            f"Unable to remove file: {input_forcings.tmpFile}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -2662,41 +2369,26 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Converting CONUS RAP Variable: " + grib_var
+                        f"Converting CONUS RAP Variable: {grib_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
                 time_str = (
-                    "{}-{} hour acc fcst".format(
-                        input_forcings.fcst_hour1, input_forcings.fcst_hour2
-                    )
+                    f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
-                    else str(input_forcings.fcst_hour2) + " hour fcst"
+                    else f"{input_forcings.fcst_hour2!s} hour fcst"
                 )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -2722,7 +2414,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing Conus RAP Variable: " + grib_var
+                config_options.statusMsg = f"Processing Conus RAP Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -2770,13 +2462,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2788,10 +2474,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2810,7 +2493,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2821,20 +2504,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2845,13 +2522,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2863,10 +2534,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2885,7 +2553,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2896,20 +2564,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2919,13 +2581,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2937,10 +2593,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2959,7 +2612,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2970,10 +2623,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2982,10 +2632,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2996,13 +2643,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from : "
-                                + id_tmp
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3014,10 +2655,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place temporary RAP elevation variable into ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3036,7 +2674,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            "Unable to regrid RAP elevation data using ESMF: " + str(ve)
+                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3047,20 +2685,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on RAP elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF elevation field into local array: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3090,15 +2722,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3111,16 +2735,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                        f"Unable to place local RAP array into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -3131,11 +2752,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3145,13 +2762,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3162,8 +2773,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                            f"Unable to place RAP ESMF data into local array: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3205,15 +2815,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3226,16 +2828,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                        f"Unable to place local RAP array into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -3246,11 +2845,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3260,13 +2855,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3277,8 +2866,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                            f"Unable to place RAP ESMF data into local array: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3319,15 +2907,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp_elem /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3340,16 +2920,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                        f"Unable to place local RAP array into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -3362,11 +2939,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3376,13 +2949,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3392,10 +2959,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place RAP ESMF element data into local array: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place RAP ESMF element data into local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3437,15 +3001,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3458,16 +3014,13 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local RAP array into ESMF field: " + str(err)
+                        f"Unable to place local RAP array into ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input RAP Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -3478,11 +3031,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3492,13 +3041,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask calculation on RAP variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3509,8 +3052,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to place RAP ESMF data into local array: "
-                            + str(err)
+                            f"Unable to place RAP ESMF data into local array: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3619,53 +3161,32 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing....."
-                    )
+                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
                     err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError as err:
-                        config_options.errMsg = (
-                            "Unable to remove previous temporary file: "
-                            + input_forcings.tmpFile
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err!s}"
                         err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Converting CFSv2 Variable: " + grib_var
+                    config_options.statusMsg = f"Converting CFSv2 Variable: {grib_var}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + str(input_forcings.fcst_hour2)
-                    + " hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2!s} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -3691,7 +3212,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing CFSv2 Variable: " + grib_var
+                config_options.statusMsg = f"Processing CFSv2 Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -3742,13 +3263,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3760,10 +3275,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3784,10 +3296,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3797,20 +3306,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3821,13 +3324,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3839,10 +3336,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3863,10 +3357,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3876,20 +3367,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3899,13 +3384,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3917,10 +3396,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3941,10 +3417,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3954,10 +3427,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3966,10 +3436,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3980,13 +3447,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract HGT_surface from file: "
-                                + input_forcings.file_in2
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3998,10 +3459,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4022,10 +3480,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4035,20 +3490,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract CFSv2 regridded elevation data from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4074,10 +3523,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
+                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
@@ -4086,15 +3532,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4135,13 +3573,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4162,10 +3594,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4178,13 +3607,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4194,13 +3617,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4210,7 +3627,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -4238,10 +3655,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
+                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
@@ -4250,15 +3664,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4299,13 +3705,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4326,10 +3726,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4342,13 +3739,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4358,13 +3749,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4374,7 +3759,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -4401,10 +3786,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
+                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
@@ -4413,15 +3795,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4464,13 +3838,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count})
 
@@ -4491,10 +3859,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4507,13 +3872,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4523,13 +3882,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4539,7 +3892,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -4567,10 +3920,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                        )
+                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
@@ -4579,15 +3929,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from file: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -4628,13 +3970,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local CFSv2 input variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " into local numpy array. ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -4655,10 +3991,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place CFSv2 forcing data into temporary ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4671,13 +4004,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(ve)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4687,13 +4014,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to run mask calculation on CFSv2 variable: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " ("
-                            + str(npe)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4703,7 +4024,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            "Unable to extract ESMF field data for CFSv2: " + str(err)
+                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -4801,7 +4122,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = (
-                "Processing Custom NetCDF Forcing Variable: " + nc_var
+                f"Processing Custom NetCDF Forcing Variable: {nc_var}"
             )
             err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(
@@ -4836,7 +4157,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
+                    f"Regridding Custom netCDF input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -4844,15 +4165,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4865,7 +4178,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4877,10 +4190,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4889,10 +4199,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4911,7 +4218,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
+                    f"Regridding Custom netCDF input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -4919,15 +4226,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4940,7 +4239,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4952,10 +4251,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4964,10 +4260,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4985,7 +4278,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
+                    f"Regridding Custom netCDF input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -4993,15 +4286,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5014,7 +4299,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5026,10 +4311,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5038,10 +4320,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5060,7 +4339,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom netCDF input variable: " + nc_var
+                    f"Regridding Custom netCDF input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -5068,15 +4347,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5089,7 +4360,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5101,10 +4372,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5113,10 +4381,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5135,7 +4400,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -5192,7 +4457,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = (
-                "Processing Custom zarr Forcing Variable: " + nc_var
+                f"Processing Custom zarr Forcing Variable: {nc_var}"
             )
             err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(
@@ -5226,7 +4491,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
+                    f"Regridding Custom zarr input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -5234,15 +4499,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5255,7 +4512,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5267,10 +4524,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5279,10 +4533,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5301,7 +4552,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
+                    f"Regridding Custom zarr input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -5309,15 +4560,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5330,7 +4573,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5342,10 +4585,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5354,10 +4594,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5375,7 +4612,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
+                    f"Regridding Custom zarr input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -5383,15 +4620,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5404,7 +4633,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5416,10 +4645,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5428,10 +4654,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5450,7 +4673,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding Custom zarr input variable: " + nc_var
+                    f"Regridding Custom zarr input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -5458,15 +4681,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5483,7 +4698,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5495,10 +4710,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input Custom zarr forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5507,10 +4719,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5529,7 +4738,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -5599,7 +4808,7 @@ def regrid_custom_hourly_netcdf(
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Processing Custom NetCDF Forcing Variable: " + nc_var
+                    f"Processing Custom NetCDF Forcing Variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -5649,10 +4858,7 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5672,10 +4878,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5686,7 +4889,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                                f"Unable to compute mask on elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -5696,10 +4899,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5719,10 +4919,7 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5742,10 +4939,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5756,7 +4950,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                                f"Unable to compute mask on elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -5766,10 +4960,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5790,10 +4981,7 @@ def regrid_custom_hourly_netcdf(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5813,10 +5001,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5827,7 +5012,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                                f"Unable to compute mask on elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -5837,10 +5022,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5860,10 +5042,7 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NetCDF elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5883,10 +5062,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5897,7 +5073,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on elevation data: " + str(npe)
+                                f"Unable to compute mask on elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -5907,10 +5083,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5935,7 +5108,7 @@ def regrid_custom_hourly_netcdf(
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -5949,15 +5122,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5970,7 +5135,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -5982,10 +5147,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5995,10 +5157,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6017,10 +5176,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6029,10 +5185,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6054,7 +5207,7 @@ def regrid_custom_hourly_netcdf(
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -6068,15 +5221,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6089,7 +5234,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6101,10 +5246,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6114,10 +5256,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6135,10 +5274,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6147,10 +5283,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6171,7 +5304,7 @@ def regrid_custom_hourly_netcdf(
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -6185,15 +5318,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6206,7 +5331,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6220,10 +5345,7 @@ def regrid_custom_hourly_netcdf(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6233,10 +5355,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6257,10 +5376,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6269,10 +5385,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6294,7 +5407,7 @@ def regrid_custom_hourly_netcdf(
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -6308,15 +5421,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6328,7 +5433,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6340,10 +5445,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6353,10 +5455,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6379,10 +5478,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6391,10 +5487,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6413,7 +5506,7 @@ def regrid_custom_hourly_netcdf(
                 id_tmp.close()
             except OSError:
                 config_options.errMsg = (
-                    "Unable to close NetCDF file: " + input_forcings.tmpFile
+                    f"Unable to close NetCDF file: {input_forcings.tmpFile}"
                 )
                 err_handler.err_out(config_options)
 
@@ -6474,7 +5567,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
             config_options.statusMsg = (
-                "Processing ERA-5 Interim Forcing Variable: " + nc_var
+                f"Processing ERA-5 Interim Forcing Variable: {nc_var}"
             )
             err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(
@@ -6519,7 +5612,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
+                    f"Regridding ERA5-Interim input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -6544,15 +5637,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6565,7 +5650,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -6577,10 +5662,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6590,10 +5672,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6606,10 +5685,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6618,10 +5694,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6640,7 +5713,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
+                    f"Regridding ERA5-Interim input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -6665,15 +5738,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6686,7 +5751,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -6698,10 +5763,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6711,10 +5773,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6727,10 +5786,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6739,10 +5795,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6760,7 +5813,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
+                    f"Regridding ERA5-Interim input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -6789,15 +5842,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6810,7 +5855,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -6822,10 +5867,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6835,10 +5877,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask_elem == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6853,10 +5892,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6866,10 +5902,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ] = input_forcings.esmf_field_out_elem.data
 
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6888,7 +5921,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding ERA5-Interim input variable: " + nc_var
+                    f"Regridding ERA5-Interim input variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -6913,15 +5946,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = (
-                        "Unable to extract "
-                        + nc_var
-                        + " from: "
-                        + input_forcings.file_in2
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6934,7 +5959,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -6946,10 +5971,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    "Unable to regrid input ERA5-Interim forcing variables using ESMF: "
-                    + str(ve)
-                )
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6959,10 +5981,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to calculate mask from input ERA5-Interim regridded forcings: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6975,10 +5994,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run NDV search on ERA5-Interim precipitation: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6987,10 +6003,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7010,7 +6023,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + input_forcings.tmpFile
+                f"Unable to close NetCDF file: {input_forcings.tmpFile}"
             )
             err_handler.err_out(config_options)
 
@@ -7076,17 +6089,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = (
-                    "Found old temporary file: "
-                    + input_forcings.tmpFile
-                    + " - Removing....."
-                )
+                config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
                 err_handler.log_warning(config_options, mpi_config)
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
                     config_options.errMsg = (
-                        "Unable to remove file: " + input_forcings.tmpFile
+                        f"Unable to remove file: {input_forcings.tmpFile}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -7095,7 +6104,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Converting 13km GFS Variable: " + grib_var
+                        f"Converting 13km GFS Variable: {grib_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -7114,40 +6123,19 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         tmp_hr_previous = input_forcings.fcst_hour1
 
                     fields.append(
-                        ":"
-                        + grib_var
-                        + ":"
-                        + input_forcings.grib_levels[force_count]
-                        + ":"
-                        + str(tmp_hr_previous)
-                        + "-"
-                        + str(input_forcings.fcst_hour2)
-                        + " hour ave fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{tmp_hr_previous!s}-{input_forcings.fcst_hour2!s} hour ave fcst:"
                     )
                 else:
                     fields.append(
-                        ":"
-                        + grib_var
-                        + ":"
-                        + input_forcings.grib_levels[force_count]
-                        + ":"
-                        + str(input_forcings.fcst_hour2)
-                        + " hour fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2!s} hour fcst:"
                     )
 
             # if calc_regrid_flag:
             fields.append(":(HGT):(surface):")
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -7173,7 +6161,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing 13km GFS Variable: " + grib_var
+                config_options.statusMsg = f"Processing 13km GFS Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -7225,13 +6213,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7245,13 +6227,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7265,13 +6241,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7285,13 +6255,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract GFS elevation from: "
-                                + input_forcings.tmpFile
-                                + " ("
-                                + str(err)
-                                + ")"
-                            )
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7304,8 +6268,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local GFS array into an ESMF field: "
-                        + str(err)
+                        f"Unable to place local GFS array into an ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7326,7 +6289,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            "Unable to regrid GFS elevation data: " + str(ve)
+                            f"Unable to regrid GFS elevation data: {ve!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -7337,10 +6300,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7354,20 +6314,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data with ESMF mesh nodes: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local GFS array into an ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place local GFS array into an ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7380,10 +6334,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid GFS elevation data with ESMF mesh elements: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7393,10 +6344,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7406,10 +6354,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
@@ -7423,7 +6368,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            "Unable to regrid GFS elevation data: " + str(ve)
+                            f"Unable to regrid GFS elevation data: {ve!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -7434,10 +6379,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to perform mask search on GFS elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7445,20 +6387,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7467,10 +6403,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field with mesh elements: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7478,10 +6411,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract GFS elevation array from ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7509,15 +6439,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
@@ -7528,15 +6450,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7547,15 +6461,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -7566,15 +6472,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7646,48 +6544,33 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place GFS local array into ESMF element field object: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if config_options.grid_type == "gridded":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -7700,20 +6583,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding took {} seconds".format(
-                            end - begin
+                        config_options.statusMsg = (
+                            f"Regridding took {end - begin} seconds"
                         )
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7723,13 +6600,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7739,8 +6610,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7756,10 +6626,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "unstructured":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh nodes: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -7773,19 +6640,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = (
-                            "Node Regridding took {} seconds".format(end - begin)
+                            f"Node Regridding took {end - begin} seconds"
                         )
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Nodes: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7795,13 +6656,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7811,8 +6666,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7827,10 +6681,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -7846,19 +6697,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = (
-                            "Element Regridding took {} seconds".format(end - begin)
+                            f"Element Regridding took {end - begin} seconds"
                         )
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7868,13 +6713,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7884,8 +6723,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7901,10 +6739,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "hydrofabric":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding Input 13km GFS Field for Mesh Elements: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -7918,19 +6753,13 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     end = monotonic()
                     if mpi_config.rank == 0:
                         config_options.statusMsg = (
-                            "Element Regridding took {} seconds".format(end - begin)
+                            f"Element Regridding took {end - begin} seconds"
                         )
                         err_handler.log_msg(
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid GFS variable for Mesh Element: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(ve)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7940,13 +6769,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run mask search on GFS variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                        + " ("
-                        + str(npe)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7956,8 +6779,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to extract GFS ESMF field data to local array: "
-                        + str(err)
+                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8049,11 +6871,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing....."
-                    )
+                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
                     err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -8065,34 +6883,21 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Converting NAM-Nest Variable: " + grib_var
+                        f"Converting NAM-Nest Variable: {grib_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + str(input_forcings.fcst_hour2)
-                    + " hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2!s} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -8121,7 +6926,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing NAM Nest Variable: " + grib_var
+                config_options.statusMsg = f"Processing NAM Nest Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -8180,10 +6985,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8201,10 +7003,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8214,20 +7013,14 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8247,10 +7040,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8268,10 +7058,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8281,20 +7068,14 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8313,10 +7094,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8334,10 +7112,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8347,10 +7122,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8359,10 +7131,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8382,10 +7151,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF NAM nest elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8403,10 +7169,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid NAM nest elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8416,20 +7179,14 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to compute mask on NAM nest elevation data: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded NAM nest elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8454,10 +7211,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -8466,15 +7220,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8487,7 +7233,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8499,10 +7245,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8512,10 +7255,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8524,10 +7264,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8545,10 +7282,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -8557,15 +7291,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8578,7 +7304,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8590,10 +7316,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8603,10 +7326,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8615,10 +7335,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8635,10 +7352,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -8647,15 +7361,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8668,7 +7374,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8682,10 +7388,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8695,10 +7398,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8707,10 +7407,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8728,10 +7425,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding NAM nest input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -8740,15 +7434,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8761,7 +7447,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8773,10 +7459,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input NAM nest forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8786,10 +7469,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input NAM nest regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8798,10 +7478,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8964,7 +7641,7 @@ def regrid_mrms_hourly(
 
             # Perform a GRIB dump to NetCDF for the MRMS precip and RQI data.
             if WGRIB2_env:
-                cmd1 = "$WGRIB2 " + mrms_tmp_grib2 + " -netcdf " + mrms_tmp_nc
+                cmd1 = f"$WGRIB2 {mrms_tmp_grib2} -netcdf {mrms_tmp_nc}"
             else:
                 cmd1 = mrms_tmp_grib2
 
@@ -8981,9 +7658,7 @@ def regrid_mrms_hourly(
 
             if supplemental_precip.rqiMethod == 1:
                 if WGRIB2_env:
-                    cmd2 = (
-                        "$WGRIB2 " + mrms_tmp_rqi_grib2 + " -netcdf " + mrms_tmp_rqi_nc
-                    )
+                    cmd2 = f"$WGRIB2 {mrms_tmp_rqi_grib2} -netcdf {mrms_tmp_rqi_nc}"
                 else:
                     cmd2 = mrms_tmp_rqi_grib2
 
@@ -9050,15 +7725,7 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9071,7 +7738,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                        f"Unable to place MRMS data into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9090,9 +7757,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
-                    )
+                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9113,7 +7778,7 @@ def regrid_mrms_hourly(
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                        f"Unable to run mask calculation for MRMS RQI data: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9126,15 +7791,7 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9147,7 +7804,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                        f"Unable to place MRMS data into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9166,9 +7823,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
-                    )
+                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9189,7 +7844,7 @@ def regrid_mrms_hourly(
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                        f"Unable to run mask calculation for MRMS RQI data: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9201,15 +7856,7 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract: "
-                            + supplemental_precip.rqi_netcdf_var_names[0]
-                            + " from: "
-                            + mrms_tmp_rqi_grib2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9222,7 +7869,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place MRMS data into local ESMF field: " + str(err)
+                        f"Unable to place MRMS data into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9241,9 +7888,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = "Unable to regrid MRMS RQI field: " + str(
-                        ve
-                    )
+                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9264,7 +7909,7 @@ def regrid_mrms_hourly(
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run mask calculation for MRMS RQI data: " + str(npe)
+                        f"Unable to run mask calculation for MRMS RQI data: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9315,7 +7960,7 @@ def regrid_mrms_hourly(
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
+                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -9325,15 +7970,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9352,9 +7989,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
-                )
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9373,7 +8008,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9403,7 +8038,7 @@ def regrid_mrms_hourly(
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                        f"Unable to run MRMS RQI threshold search: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9420,10 +8055,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9443,7 +8075,7 @@ def regrid_mrms_hourly(
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
+                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -9453,15 +8085,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9480,9 +8104,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
-                )
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9501,7 +8123,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9531,7 +8153,7 @@ def regrid_mrms_hourly(
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                        f"Unable to run MRMS RQI threshold search: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9548,10 +8170,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9570,7 +8189,7 @@ def regrid_mrms_hourly(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
+                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -9580,15 +8199,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9609,9 +8220,7 @@ def regrid_mrms_hourly(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
-                )
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9633,7 +8242,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9663,7 +8272,7 @@ def regrid_mrms_hourly(
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                        f"Unable to run MRMS RQI threshold search: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9680,8 +8289,7 @@ def regrid_mrms_hourly(
                 del ind_valid_elem
             except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
                 config_options.errMsg = (
-                    "Unable to run global NDV search on MRMS regridded precip: "
-                    + str(npe)
+                    f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9702,7 +8310,7 @@ def regrid_mrms_hourly(
             var_tmp = None
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Regridding: " + supplemental_precip.netcdf_var_names[0]
+                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -9712,15 +8320,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract: "
-                        + supplemental_precip.netcdf_var_names[0]
-                        + " from: "
-                        + mrms_tmp_nc
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9739,9 +8339,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = "Unable to regrid MRMS precipitation: " + str(
-                    ve
-                )
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9760,7 +8358,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    "Unable to run mask search on MRMS supplemental precip: " + str(npe)
+                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9790,7 +8388,7 @@ def regrid_mrms_hourly(
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        "Unable to run MRMS RQI threshold search: " + str(npe)
+                        f"Unable to run MRMS RQI threshold search: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9807,10 +8405,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = (
-                        "Unable to run global NDV search on MRMS regridded precip: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9896,7 +8491,7 @@ def regrid_mrms_precip_flag(
     err_handler.check_program_status(config_options, mpi_config)
 
     # Perform a GRIB dump to NetCDF for the MRMS precip and RQI data.
-    cmd1 = "$WGRIB2 " + mrms_tmp_grib2 + " -netcdf " + mrms_tmp_nc
+    cmd1 = f"$WGRIB2 {mrms_tmp_grib2} -netcdf {mrms_tmp_nc}"
     id_tmp = ioMod.open_grib2(
         mrms_tmp_grib2,
         mrms_tmp_nc,
@@ -9935,13 +8530,7 @@ def regrid_mrms_precip_flag(
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to extract PrecipFlag from file: "
-                + supplemental_precip.file_in2
-                + " ("
-                + str(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err!s})"
             err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9957,7 +8546,7 @@ def regrid_mrms_precip_flag(
         supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
     except (ValueError, KeyError, AttributeError) as err:
         config_options.errMsg = (
-            "Unable to place MRMS PrecipFlag into local ESMF field: " + str(err)
+            f"Unable to place MRMS PrecipFlag into local ESMF field: {err!s}"
         )
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
@@ -9969,7 +8558,7 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_out,
         )
     except ValueError as ve:
-        config_options.errMsg = "Unable to regrid MRMS PrecipFlag: " + str(ve)
+        config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve!s}"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9982,9 +8571,7 @@ def regrid_mrms_precip_flag(
             np.where(supplemental_precip.esmf_field_out.data < 0)
         ] = 1.0
     except (ValueError, ArithmeticError) as npe:
-        config_options.errMsg = "Unable to run mask search on MRMS PrecipFlag: " + str(
-            npe
-        )
+        config_options.errMsg = f"Unable to run mask search on MRMS PrecipFlag: {npe!s}"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10011,13 +8598,7 @@ def regrid_mrms_precip_flag(
                     supplemental_precip.netcdf_var_names[0]
                 ][0, :, :]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract PrecipFlag from file: "
-                    + supplemental_precip.file_in2
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10037,7 +8618,7 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
         except (ValueError, KeyError, AttributeError) as err:
             config_options.errMsg = (
-                "Unable to place MRMS PrecipFlag into local ESMF field: " + str(err)
+                f"Unable to place MRMS PrecipFlag into local ESMF field: {err!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10049,7 +8630,7 @@ def regrid_mrms_precip_flag(
                 supplemental_precip.esmf_field_out_elem,
             )
         except ValueError as ve:
-            config_options.errMsg = "Unable to regrid MRMS PrecipFlag: " + str(ve)
+            config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve!s}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10063,7 +8644,7 @@ def regrid_mrms_precip_flag(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                "Unable to run mask search on MRMS PrecipFlag: " + str(npe)
+                f"Unable to run mask search on MRMS PrecipFlag: {npe!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10159,11 +8740,7 @@ def regrid_hourly_wrf_arw(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = (
-                        "Found old temporary file: "
-                        + input_forcings.tmpFile
-                        + " - Removing....."
-                    )
+                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
                     err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
@@ -10175,41 +8752,26 @@ def regrid_hourly_wrf_arw(
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Converting WRF-ARW Variable: " + grib_var
+                        f"Converting WRF-ARW Variable: {grib_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
                 time_str = (
-                    "{}-{} hour acc fcst".format(
-                        input_forcings.fcst_hour1, input_forcings.fcst_hour2
-                    )
+                    f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
-                    else str(input_forcings.fcst_hour2) + " hour fcst"
+                    else f"{input_forcings.fcst_hour2!s} hour fcst"
                 )
                 fields.append(
-                    ":"
-                    + grib_var
-                    + ":"
-                    + input_forcings.grib_levels[force_count]
-                    + ":"
-                    + time_str
-                    + ":"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
                 )
             fields.append(":(HGT):(surface):")
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    '$WGRIB2 -match "('
-                    + "|".join(fields)
-                    + ')" '
-                    + input_forcings.file_in2
-                    + " -netcdf "
-                    + input_forcings.tmpFile
-                )
+                cmd = f'$WGRIB2 -match "({"|".join(fields)})" {input_forcings.file_in2} -netcdf {input_forcings.tmpFile}'
             else:
-                cmd = "(" + "|".join(fields) + ")"
+                cmd = f"({'|'.join(fields)})"
 
             id_tmp = ioMod.open_grib2(
                 input_forcings.file_in2,
@@ -10238,7 +8800,7 @@ def regrid_hourly_wrf_arw(
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing WRF-ARW Variable: " + grib_var
+                config_options.statusMsg = f"Processing WRF-ARW Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -10297,10 +8859,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10320,10 +8879,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10334,8 +8890,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -10343,10 +8898,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -10365,10 +8917,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10388,10 +8937,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10402,8 +8948,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -10411,10 +8956,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10433,10 +8975,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10456,10 +8995,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10470,8 +9006,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -10481,10 +9016,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10504,10 +9036,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10527,10 +9056,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain "
-                            "using ESMF: " + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10541,8 +9067,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            "Unable to compute mask on WRF-ARW elevation data: "
-                            + str(npe)
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -10550,10 +9075,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract ESMF regridded WRF-ARW elevation data to a local "
-                            "array: " + str(err)
-                        )
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10578,10 +9100,7 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -10590,15 +9109,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10611,7 +9122,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -10623,10 +9134,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10636,10 +9144,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10660,10 +9165,7 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10672,10 +9174,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10693,10 +9192,7 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -10705,15 +9201,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10726,7 +9214,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -10738,10 +9226,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10751,10 +9236,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10775,10 +9257,7 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10787,10 +9266,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10807,10 +9283,7 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -10819,15 +9292,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10840,7 +9305,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -10854,10 +9319,7 @@ def regrid_hourly_wrf_arw(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10867,10 +9329,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10892,10 +9351,7 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -10904,10 +9360,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10925,10 +9378,7 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Regridding WRF-ARW input variable: "
-                        + input_forcings.netcdf_var_names[force_count]
-                    )
+                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
                         config_options, mpi_config, True
                     )  # log at debug level
@@ -10937,15 +9387,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + input_forcings.netcdf_var_names[force_count]
-                            + " from: "
-                            + input_forcings.tmpFile
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10958,7 +9400,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -10970,10 +9412,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input WRF-ARW forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -10983,10 +9422,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input WRF-ARW regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11007,10 +9443,7 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on WRF ARW precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11019,10 +9452,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11112,7 +9542,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             if mpi_config.rank == 0:
                 if os.path.isfile(arw_tmp_nc):
                     config_options.statusMsg = (
-                        "Found old temporary file: " + arw_tmp_nc + " - Removing....."
+                        f"Found old temporary file: {arw_tmp_nc} - Removing....."
                     )
                     err_handler.log_warning(config_options, mpi_config)
                     try:
@@ -11133,26 +9563,9 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = (
-                    "$WGRIB2 "
-                    + supplemental_precip.file_in1
-                    + ' -match ":('
-                    + "APCP):(surface):("
-                    + str(supplemental_precip.fcst_hour1 - 1)
-                    + "-"
-                    + str(supplemental_precip.fcst_hour1)
-                    + ' hour acc fcst):"'
-                    + " -netcdf "
-                    + arw_tmp_nc
-                )
+                cmd = f'$WGRIB2 {supplemental_precip.file_in1} -match ":(APCP):(surface):({supplemental_precip.fcst_hour1 - 1!s}-{supplemental_precip.fcst_hour1!s} hour acc fcst):" -netcdf {arw_tmp_nc}'
             else:
-                cmd = (
-                    "(APCP):(surface):("
-                    + str(supplemental_precip.fcst_hour1 - 1)
-                    + "-"
-                    + str(supplemental_precip.fcst_hour1)
-                    + " hour acc fcst)"
-                )
+                cmd = f"(APCP):(surface):({supplemental_precip.fcst_hour1 - 1!s}-{supplemental_precip.fcst_hour1!s} hour acc fcst)"
 
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in1,
@@ -11203,13 +9616,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11221,10 +9628,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11236,7 +9640,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -11247,10 +9651,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11269,10 +9670,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11296,13 +9694,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11314,10 +9706,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11329,7 +9718,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -11340,10 +9729,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11362,10 +9748,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11388,13 +9771,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11406,10 +9783,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11423,7 +9797,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -11434,10 +9808,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11457,10 +9828,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid_elem
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11484,13 +9852,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract precipitation from WRF ARW file: "
-                        + supplemental_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11502,10 +9864,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place WRF ARW precipitation into local ESMF field: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11517,7 +9876,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    "Unable to regrid WRF ARW supplemental precipitation: " + str(ve)
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -11528,10 +9887,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11550,10 +9906,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = (
-                    "Unable to run NDV search on WRF ARW supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11658,13 +10011,7 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11678,10 +10025,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
-            )
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11693,7 +10037,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11708,7 +10052,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11740,13 +10084,7 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11760,10 +10098,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
-            )
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11775,7 +10110,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11790,7 +10125,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11823,13 +10158,7 @@ def regrid_sbcv2_liquid_water_fraction(
                     supplemental_forcings.netcdf_var_names[0]
                 ][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11843,10 +10172,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp_elem / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
-            )
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11860,7 +10186,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11875,7 +10201,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11905,13 +10231,7 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Liquid Water Fraction from SBCv2 file: "
-                    + supplemental_forcings.file_in1
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11925,10 +10245,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                "Unable to place SBCv2 Liquid Water Fraction into local ESMF field: "
-                + str(err)
-            )
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -11940,7 +10257,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                "Unable to regrid SBCv2 Liquid Water Fraction: " + str(ve)
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11955,7 +10272,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                "Unable to run mask search on SBCv2 Liquid Water Fraction: " + str(npe)
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -11979,7 +10296,7 @@ def regrid_sbcv2_liquid_water_fraction(
             id_tmp.close()
         except OSError:
             config_options.errMsg = (
-                "Unable to close NetCDF file: " + supplemental_forcings.file_in1
+                f"Unable to close NetCDF file: {supplemental_forcings.file_in1}"
             )
             err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
@@ -12028,13 +10345,13 @@ def regrid_hourly_nbm(
     if mpi_config.rank == 0:
         if os.path.isfile(nbm_tmp_nc):
             config_options.statusMsg = (
-                "Found old temporary file: " + nbm_tmp_nc + " - Removing....."
+                f"Found old temporary file: {nbm_tmp_nc} - Removing....."
             )
             err_handler.log_warning(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
             except OSError:
-                config_options.errMsg = "Unable to remove file: " + nbm_tmp_nc
+                config_options.errMsg = f"Unable to remove file: {nbm_tmp_nc}"
                 err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12042,59 +10359,29 @@ def regrid_hourly_nbm(
         fields = []
         for force_count, grib_var in enumerate(forcings_or_precip.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Converting NBM Variable: " + grib_var
+                config_options.statusMsg = f"Converting NBM Variable: {grib_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
             time_str = (
-                "{}-{} hour acc fcst".format(
-                    forcings_or_precip.fcst_hour1, forcings_or_precip.fcst_hour2
-                )
+                f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
-                else str(forcings_or_precip.fcst_hour2) + " hour fcst"
+                else f"{forcings_or_precip.fcst_hour2!s} hour fcst"
             )
             fields.append(
-                ":"
-                + grib_var
-                + ":"
-                + forcings_or_precip.grib_levels[force_count]
-                + ":"
-                + time_str
-                + ":"
+                f":{grib_var}:{forcings_or_precip.grib_levels[force_count]}:{time_str}:"
             )
         # fields.append(":(HGT):(surface):")
         # Create a temporary NetCDF file from the GRIB2 file.
-        cmd = (
-            '$WGRIB2 -match "('
-            + "|".join(fields)
-            + ')" -not "prob" -not "ens" '
-            + forcings_or_precip.file_in1
-            + " -netcdf "
-            + nbm_tmp_nc
-        )
+        cmd = f'$WGRIB2 -match "({"|".join(fields)})" -not "prob" -not "ens" {forcings_or_precip.file_in1} -netcdf {nbm_tmp_nc}'
     else:
         # Perform a GRIB dump to NetCDF for the precip data.
         fieldnbm_match1 = '":APCP:"'
         fieldnbm_match2 = (
-            '"'
-            + str(forcings_or_precip.fcst_hour1)
-            + "-"
-            + str(forcings_or_precip.fcst_hour2)
-            + '"'
+            f'"{forcings_or_precip.fcst_hour1!s}-{forcings_or_precip.fcst_hour2!s}"'
         )
         fieldnbm_notmatch1 = '"prob"'  # We don't want the probabilistic QPF layers
-        cmd = (
-            "$WGRIB2 "
-            + forcings_or_precip.file_in1
-            + " -match "
-            + fieldnbm_match1
-            + " -match "
-            + fieldnbm_match2
-            + " -not "
-            + fieldnbm_notmatch1
-            + " -netcdf "
-            + nbm_tmp_nc
-        )
+        cmd = f"$WGRIB2 {forcings_or_precip.file_in1} -match {fieldnbm_match1} -match {fieldnbm_match2} -not {fieldnbm_notmatch1} -netcdf {nbm_tmp_nc}"
 
     id_tmp = ioMod.open_grib2(
         forcings_or_precip.file_in1,
@@ -12113,7 +10400,7 @@ def regrid_hourly_nbm(
 
     for force_count, nc_var in enumerate(forcings_or_precip.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Processing NBM Variable: " + nc_var
+            config_options.statusMsg = f"Processing NBM Variable: {nc_var}"
             err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
         # Check to see if we need to calculate regridding weights.
@@ -12214,10 +10501,7 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12237,10 +10521,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12251,8 +10532,7 @@ def regrid_hourly_nbm(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                                f"Unable to compute mask on NBM elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -12262,10 +10542,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12286,10 +10563,7 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12309,10 +10583,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12323,8 +10594,7 @@ def regrid_hourly_nbm(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                                f"Unable to compute mask on NBM elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -12334,10 +10604,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12358,10 +10625,7 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12381,10 +10645,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the WRF-Hydro domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12395,8 +10656,7 @@ def regrid_hourly_nbm(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                "Unable to compute mask on NBM elevation data: "
-                                + str(npe)
+                                f"Unable to compute mask on NBM elevation data: {npe!s}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -12406,10 +10666,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12429,10 +10686,7 @@ def regrid_hourly_nbm(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to place NBM elevation data into the ESMF field object: "
-                                + str(err)
-                            )
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12450,10 +10704,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = (
-                                "Unable to regrid NBM elevation data to the unstructured domain "
-                                "using ESMF: " + str(ve)
-                            )
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12463,10 +10714,7 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                "Unable to compute element mask on NBM elevation data: "
-                                + str(npe)
-                            )
+                            config_options.errMsg = f"Unable to compute element mask on NBM elevation data: {npe!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12475,10 +10723,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                "Unable to extract ESMF regridded NBM elevation data to a local "
-                                "array: " + str(err)
-                            )
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12496,13 +10741,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12515,7 +10754,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -12527,7 +10766,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12537,10 +10776,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12576,7 +10812,7 @@ def regrid_hourly_nbm(
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -12597,13 +10833,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12616,7 +10846,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -12628,7 +10858,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -12637,10 +10867,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12676,7 +10903,7 @@ def regrid_hourly_nbm(
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -12697,13 +10924,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12716,7 +10937,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -12728,7 +10949,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -12737,10 +10958,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12776,7 +10994,7 @@ def regrid_hourly_nbm(
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -12797,13 +11015,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to extract data from NBM file: "
-                        + forcings_or_precip.file_in1
-                        + " ("
-                        + str(err)
-                        + ")"
-                    )
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12816,7 +11028,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: " + str(err)
+                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -12830,7 +11042,7 @@ def regrid_hourly_nbm(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: " + str(ve)
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -12839,10 +11051,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    "Unable to run mask search on NBM supplemental precipitation: "
-                    + str(npe)
-                )
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -12882,7 +11091,7 @@ def regrid_hourly_nbm(
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        "Unable to run NDV search on NBM precipitation: " + str(npe)
+                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -13071,7 +11280,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 continue
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Processing NDFD variable: " + ndfd_var
+                config_options.statusMsg = f"Processing NDFD variable: {ndfd_var}"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -13145,7 +11354,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    "Unable to place local array into local ESMF field: " + str(err)
+                    f"Unable to place local array into local ESMF field: {err!s}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -13281,10 +11490,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[i], :
                     ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to place local ESMF regridded data into local array: "
-                    + str(err)
-                )
+                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
         finally:
@@ -13348,7 +11554,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
                 config_options.statusMsg = (
-                    "Processing Custom NetCDF Forcing Variable: " + nc_var
+                    f"Processing Custom NetCDF Forcing Variable: {nc_var}"
                 )
                 err_handler.log_msg(
                     config_options, mpi_config, True
@@ -13399,7 +11605,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -13413,15 +11619,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13434,7 +11632,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -13446,10 +11644,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13459,10 +11654,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13481,10 +11673,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13493,10 +11682,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13518,7 +11704,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -13532,15 +11718,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13553,7 +11731,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -13565,10 +11743,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13578,10 +11753,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13599,10 +11771,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13611,10 +11780,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13635,7 +11801,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 )
                 if mpi_config.rank == 0:
                     config_options.statusMsg = (
-                        "Regridding Custom netCDF input variable: " + nc_var
+                        f"Regridding Custom netCDF input variable: {nc_var}"
                     )
                     err_handler.log_msg(
                         config_options, mpi_config, True
@@ -13649,15 +11815,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )  # log at debug level
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = (
-                            "Unable to extract "
-                            + nc_var
-                            + " from: "
-                            + input_forcings.file_in2
-                            + " ("
-                            + str(err)
-                            + ")"
-                        )
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13670,7 +11828,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        "Unable to place local array into local ESMF field: " + str(err)
+                        f"Unable to place local array into local ESMF field: {err!s}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -13684,10 +11842,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                        + str(ve)
-                    )
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13697,10 +11852,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                        + str(npe)
-                    )
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13721,10 +11873,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            "Unable to run NDV search on Custom netCDF precipitation: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13733,10 +11882,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        "Unable to place local ESMF regridded data into local array: "
-                        + str(err)
-                    )
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -13765,7 +11911,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         f"regrid step 2.5.1 | {mpi_config.rank}: regrid messages"
                     ):
                         config_options.statusMsg = (
-                            "Regridding Custom netCDF input variable: " + nc_var
+                            f"Regridding Custom netCDF input variable: {nc_var}"
                         )
                         err_handler.log_msg(
                             config_options, mpi_config, True
@@ -13810,10 +11956,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local array into local ESMF field: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place local array into local ESMF field: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13829,10 +11972,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            "Unable to regrid input Custom netCDF forcing variables using ESMF: "
-                            + str(ve)
-                        )
+                        config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13845,10 +11985,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = fill
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            "Unable to calculate mask from input Custom netCDF regridded forcings: "
-                            + str(npe)
-                        )
+                        config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13875,10 +12012,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             AttributeError,
                             KeyError,
                         ) as npe:
-                            config_options.errMsg = (
-                                "Unable to run NDV search on Custom netCDF precipitation: "
-                                + str(npe)
-                            )
+                            config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13890,10 +12024,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            "Unable to place local ESMF regridded data into local array: "
-                            + str(err)
-                        )
+                        config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -13936,15 +12067,10 @@ def check_regrid_status(
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error!s}"
                 err_handler.log_critical(config_options, mpi_config)
 
         elif config_options.grid_type == "unstructured":
@@ -13952,44 +12078,29 @@ def check_regrid_status(
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.NODE,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field node mesh object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error!s}"
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field element mesh object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error!s}"
                 err_handler.log_critical(config_options, mpi_config)
         elif config_options.grid_type == "hydrofabric":
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=input_forcings.product_name + "FORCING_REGRIDDED",
+                    name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + input_forcings.product_name
-                    + " destination ESMF field element mesh object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error!s}"
                 err_handler.log_critical(config_options, mpi_config)
 
     err_handler.check_program_status(config_options, mpi_config)
@@ -14101,45 +12212,30 @@ def check_supp_pcp_regrid_status(
             try:
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF field object: {esmf_error!s}"
                 err_handler.err_out(config_options)
         elif config_options.grid_type == "unstructured":
             try:
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.NODE,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF node field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF node field object: {esmf_error!s}"
                 err_handler.err_out(config_options)
 
             try:
                 supplemental_precip.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF element field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error!s}"
                 err_handler.err_out(config_options)
 
         elif config_options.grid_type == "hydrofabric":
@@ -14147,15 +12243,10 @@ def check_supp_pcp_regrid_status(
                 supplemental_precip.esmf_field_out = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
                     meshloc=ESMF.MeshLoc.ELEMENT,
-                    name=supplemental_precip.product_name + "SUPP_PCP_REGRIDDED",
+                    name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = (
-                    "Unable to create "
-                    + supplemental_precip.product_name
-                    + " destination ESMF element field object: "
-                    + str(esmf_error)
-                )
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error!s}"
                 err_handler.err_out(config_options)
 
     # Determine if we need to calculate a regridding object. The following situations warrant the calculation of
@@ -14373,7 +12464,7 @@ def load_weight_file(
         end = monotonic()
     except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
         config_options.errMsg = (
-            f"Unable to load cached ESMF{msg_augment}weight file: " + str(esmf_error)
+            f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error!s}"
         )
         err_handler.log_warning(config_options, mpi_config)
     else:
@@ -14438,10 +12529,7 @@ def make_regrid(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = (
-            f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: "
-            + str(esmf_error)
-        )
+        config_options.errMsg = f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error!s}"
         err_handler.log_critical(config_options, mpi_config)
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
@@ -14482,7 +12570,7 @@ def execute_regrid(
         )
     except ValueError as ve:
         config_options.errMsg = (
-            "Unable to extract regridded data from ESMF regridded field: " + str(ve)
+            f"Unable to extract regridded data from ESMF regridded field: {ve!s}"
         )
         err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
@@ -14537,22 +12625,14 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[0]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Y shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object"
-                )
+                config_options.errMsg = f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object"
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract X shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from aws object"
-                )
+                config_options.errMsg = f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object"
                 err_handler.log_critical(config_options, mpi_config)
         else:
             try:
@@ -14560,30 +12640,14 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract Y shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from: "
-                    + input_forcings.tmpFile
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[2]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    "Unable to extract X shape size from: "
-                    + input_forcings.netcdf_var_names[force_count]
-                    + " from: "
-                    + input_forcings.tmpFile
-                    + " ("
-                    + str(err)
-                    + ")"
-                )
+                config_options.errMsg = f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
                 err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14605,13 +12669,7 @@ def calculate_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = (
-            "Unable to create source ESMF grid from temporary file: "
-            + input_forcings.tmpFile
-            + " ("
-            + str(esmf_error)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error!s})"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14635,26 +12693,14 @@ def calculate_weights(
             input_forcings.y_upper_bound - input_forcings.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to extract local X/Y boundaries from global grid from temporary "
-            + "file: "
-            + input_forcings.tmpFile
-            + " ("
-            + str(err)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err!s})"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if input_forcings.nx_local < 2 or input_forcings.ny_local < 2:
-        config_options.errMsg = (
-            "You have either specified too many cores for: "
-            + input_forcings.product_name
-            + ", or  your input forcing grid is too small to process. Local grid must "
-            "have x/y dimension size of 2."
-        )
+        config_options.errMsg = f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2."
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14666,11 +12712,7 @@ def calculate_weights(
                 ESMF.GridItem.MASK, ESMF.StaggerLoc.CENTER
             )
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Trimming input forcing `{}` by {} grid cells".format(
-                        input_forcings.product_name, border
-                    )
-                )
+                config_options.statusMsg = f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells"
                 err_handler.log_msg(
                     config_options, mpi_config, True
                 )  # log at debug level
@@ -14782,20 +12824,14 @@ def calculate_weights(
     try:
         input_forcings.esmf_lats = input_forcings.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate latitude coordinate object within input ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate latitude coordinate object within input ESMF grid: {ge!s}"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
         input_forcings.esmf_lons = input_forcings.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate longitude coordinate object within input ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate longitude coordinate object within input ESMF grid: {ge!s}"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -14811,11 +12847,11 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            config_options.errMsg = (
+                f"Unable to create ESMF field object: {esmf_error!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -14825,11 +12861,11 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            config_options.errMsg = (
+                f"Unable to create ESMF field object: {esmf_error!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -14838,11 +12874,11 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in_elem = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE_ELEMENT",
+                name=f"{input_forcings.product_name}_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            config_options.errMsg = (
+                f"Unable to create ESMF field object: {esmf_error!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -14852,11 +12888,11 @@ def calculate_weights(
         try:
             input_forcings.esmf_field_in = esmf_field_retry_partial(
                 input_forcings.esmf_grid_in,
-                name=input_forcings.product_name + "_NATIVE",
+                name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = "Unable to create ESMF field object: " + str(
-                esmf_error
+            config_options.errMsg = (
+                f"Unable to create ESMF field object: {esmf_error!s}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -14996,7 +13032,7 @@ def calculate_supp_pcp_weights(
         else:
             latdim = londim = -1
             config_options.errMsg = (
-                "Unable to determine lat/lon grid size from " + tmp_file
+                f"Unable to determine lat/lon grid size from {tmp_file}"
             )
             err_handler.err_out(config_options)
 
@@ -15005,34 +13041,14 @@ def calculate_supp_pcp_weights(
                 supplemental_precip.netcdf_var_names[0]
             ].shape[latdim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = (
-                "Unable to extract Y shape size from: "
-                + supplemental_precip.netcdf_var_names[0]
-                + " from: "
-                + tmp_file
-                + " ("
-                + str(err)
-                + ", "
-                + type(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract Y shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err!s}, {type(err)})"
             err_handler.err_out(config_options)
         try:
             supplemental_precip.nx_global = id_tmp.variables[
                 supplemental_precip.netcdf_var_names[0]
             ].shape[londim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = (
-                "Unable to extract X shape size from: "
-                + supplemental_precip.netcdf_var_names[0]
-                + " from: "
-                + tmp_file
-                + " ("
-                + str(err)
-                + ", "
-                + type(err)
-                + ")"
-            )
+            config_options.errMsg = f"Unable to extract X shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err!s}, {type(err)})"
             err_handler.err_out(config_options)
 
     # mpi_config.comm.barrier()
@@ -15054,13 +13070,7 @@ def calculate_supp_pcp_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = (
-            "Unable to create source ESMF grid from temporary file: "
-            + tmp_file
-            + " ("
-            + str(esmf_error)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {tmp_file} ({esmf_error!s})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -15084,26 +13094,14 @@ def calculate_supp_pcp_weights(
             supplemental_precip.y_upper_bound - supplemental_precip.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            "Unable to extract local X/Y boundaries from global grid from temporary "
-            + "file: "
-            + tmp_file
-            + " ("
-            + str(err)
-            + ")"
-        )
+        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {tmp_file} ({err!s})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if supplemental_precip.nx_local < 2 or supplemental_precip.ny_local < 2:
-        config_options.errMsg = (
-            "You have either specified too many cores for: "
-            + supplemental_precip.product_name
-            + ", or  your input forcing grid is too small to process. Local grid "
-            "must have x/y dimension size of 2."
-        )
+        config_options.errMsg = f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2."
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -15153,20 +13151,14 @@ def calculate_supp_pcp_weights(
     try:
         supplemental_precip.esmf_lats = supplemental_precip.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate latitude coordinate object within supplemental precip ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate latitude coordinate object within supplemental precip ESMF grid: {ge!s}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
     try:
         supplemental_precip.esmf_lons = supplemental_precip.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            "Unable to locate longitude coordinate object within supplemental precip ESMF grid: "
-            + str(ge)
-        )
+        config_options.errMsg = f"Unable to locate longitude coordinate object within supplemental precip ESMF grid: {ge!s}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -15181,7 +13173,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -15236,7 +13228,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -15299,7 +13291,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in_elem = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()
@@ -15356,7 +13348,7 @@ def calculate_supp_pcp_weights(
         # Create a ESMF field to hold the incoming data.
         supplemental_precip.esmf_field_in = esmf_field_retry_partial(
             supplemental_precip.esmf_grid_in,
-            name=supplemental_precip.product_name + "_NATIVE",
+            name=f"{supplemental_precip.product_name}_NATIVE",
         )
 
         # mpi_config.comm.barrier()

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -378,7 +378,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA field: {err!s}"
+                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -398,7 +398,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds_elem]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err!s}"
+                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -420,7 +420,7 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err!s}"
+                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
@@ -581,7 +581,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -609,7 +609,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -637,7 +637,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -666,7 +666,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -679,7 +679,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -691,7 +691,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -702,7 +702,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -721,7 +721,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -737,7 +737,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -749,7 +749,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -760,7 +760,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -779,7 +779,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -794,7 +794,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -808,7 +808,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -819,7 +819,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -839,7 +839,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -855,7 +855,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -867,7 +867,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -878,7 +878,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -897,7 +897,7 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1103,7 +1103,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1131,7 +1131,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1159,7 +1159,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp_elem,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1188,7 +1188,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1201,7 +1201,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1213,7 +1213,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1224,7 +1224,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1243,7 +1243,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1259,7 +1259,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1271,7 +1271,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1282,7 +1282,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1301,7 +1301,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1316,7 +1316,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1330,7 +1330,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1341,7 +1341,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1361,7 +1361,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1377,7 +1377,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1389,7 +1389,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve!s}"
+                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -1400,7 +1400,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -1424,7 +1424,7 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 del ind_valid
                 del invalid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
@@ -1663,7 +1663,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1675,7 +1675,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1693,7 +1693,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
+                        config_options.errMsg = (
+                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1703,14 +1705,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1724,7 +1726,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1736,7 +1738,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1754,7 +1756,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
+                        config_options.errMsg = (
+                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1764,14 +1768,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1781,7 +1785,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1793,7 +1797,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1811,7 +1815,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
+                        config_options.errMsg = (
+                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1821,7 +1827,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1830,7 +1836,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1844,7 +1850,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             else:
                                 var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err!s}"
+                            config_options.errMsg = f"Unable to extract HRRR elevation from {input_forcings.tmpFile}: {err}"
 
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1856,7 +1862,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1874,7 +1880,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid HRRR surface elevation using ESMF: {ve!s}"
+                        config_options.errMsg = (
+                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1884,14 +1892,14 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err!s}"
+                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1937,7 +1945,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -1950,7 +1958,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err!s}"
+                        f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -1968,7 +1976,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve!s}"
+                        f"Unable to regrid input HRRR forcing data: {ve}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -1979,7 +1987,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -1988,7 +1998,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2029,7 +2039,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2042,7 +2052,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err!s}"
+                        f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2060,7 +2070,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve!s}"
+                        f"Unable to regrid input HRRR forcing data: {ve}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2071,7 +2081,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2080,7 +2092,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2120,7 +2132,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2133,7 +2145,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err!s}"
+                        f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2153,7 +2165,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve!s}"
+                        f"Unable to regrid input HRRR forcing data: {ve}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2164,7 +2176,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2173,7 +2187,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2214,7 +2228,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2227,7 +2241,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err!s}"
+                        f"Unable to place input HRRR data into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2245,7 +2259,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     )
                 except ValueError as ve:
                     config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve!s}"
+                        f"Unable to regrid input HRRR forcing data: {ve}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2256,7 +2270,9 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to perform mask test on regridded HRRR forcings: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2265,7 +2281,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err!s}"
+                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2377,7 +2393,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
-                    else f"{input_forcings.fcst_hour2!s} hour fcst"
+                    else f"{input_forcings.fcst_hour2} hour fcst"
                 )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
@@ -2462,7 +2478,9 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
+                            config_options.errMsg = (
+                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            )
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2474,7 +2492,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2493,7 +2511,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
+                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2504,14 +2522,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2522,7 +2540,9 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
+                            config_options.errMsg = (
+                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            )
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2534,7 +2554,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2553,7 +2573,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
+                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2564,14 +2584,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2581,7 +2601,9 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
+                            config_options.errMsg = (
+                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            )
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2593,7 +2615,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2612,7 +2634,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
+                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2623,7 +2645,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2632,7 +2654,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2643,7 +2665,9 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from : {id_tmp} ({err!s})"
+                            config_options.errMsg = (
+                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            )
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2655,7 +2679,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2674,7 +2698,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve!s}"
+                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2685,14 +2709,14 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err!s}"
+                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -2722,7 +2746,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2735,7 +2759,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err!s}"
+                        f"Unable to place local RAP array into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2752,7 +2776,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2762,7 +2786,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2773,7 +2797,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to place RAP ESMF data into local array: {err!s}"
+                            f"Unable to place RAP ESMF data into local array: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2815,7 +2839,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2828,7 +2852,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err!s}"
+                        f"Unable to place local RAP array into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2845,7 +2869,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2855,7 +2879,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2866,7 +2890,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to place RAP ESMF data into local array: {err!s}"
+                            f"Unable to place RAP ESMF data into local array: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -2907,7 +2931,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp_elem /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2920,7 +2944,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err!s}"
+                        f"Unable to place local RAP array into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -2939,7 +2963,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2949,7 +2973,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -2959,7 +2983,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF element data into local array: {err!s}"
+                        config_options.errMsg = f"Unable to place RAP ESMF element data into local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
@@ -3001,7 +3025,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3014,7 +3038,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err!s}"
+                        f"Unable to place local RAP array into ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -3031,7 +3055,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve!s}"
+                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3041,7 +3065,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3052,7 +3076,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to place RAP ESMF data into local array: {err!s}"
+                            f"Unable to place RAP ESMF data into local array: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3166,7 +3190,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError as err:
-                        config_options.errMsg = f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err!s}"
+                        config_options.errMsg = f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err}"
                         err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -3178,7 +3202,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         config_options, mpi_config, True
                     )  # log at debug level
                 fields.append(
-                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2!s} hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
@@ -3263,7 +3287,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3275,7 +3299,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3296,7 +3320,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3306,14 +3330,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3324,7 +3348,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3336,7 +3360,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3357,7 +3381,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3367,14 +3391,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3384,7 +3408,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3396,7 +3420,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3417,7 +3441,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3427,7 +3451,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3436,7 +3460,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3447,7 +3471,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err!s})"
+                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3459,7 +3483,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3480,7 +3504,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3490,14 +3514,14 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3532,7 +3556,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3573,7 +3597,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -3594,7 +3618,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3607,7 +3631,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3617,7 +3641,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3627,7 +3651,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
+                            f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3664,7 +3688,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3705,7 +3729,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -3726,7 +3750,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3739,7 +3763,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3749,7 +3773,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3759,7 +3783,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
+                            f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3795,7 +3819,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3838,7 +3862,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count})
 
@@ -3859,7 +3883,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3872,7 +3896,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3882,7 +3906,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -3892,7 +3916,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
+                            f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -3929,7 +3953,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -3970,7 +3994,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err!s})"
+                        config_options.errMsg = f"Unable to place local CFSv2 input variable: {input_forcings.netcdf_var_names[force_count]} into local numpy array. ({err})"
                     # except TypeError:
                     #    LOG.error(f"{input_forcings.coarse_input_forcings2}, {input_forcings.input_map_output}, {force_count}")
 
@@ -3991,7 +4015,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4004,7 +4028,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4014,7 +4038,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -4024,7 +4048,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
                         config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err!s}"
+                            f"Unable to extract ESMF field data for CFSv2: {err}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -4165,7 +4189,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4178,7 +4202,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4190,7 +4214,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4199,7 +4223,9 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4226,7 +4252,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4239,7 +4265,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4251,7 +4277,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4260,7 +4286,9 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4286,7 +4314,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4299,7 +4327,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4311,7 +4339,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4320,7 +4348,9 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4347,7 +4377,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4360,7 +4390,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4372,7 +4402,7 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4381,7 +4411,9 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4499,7 +4531,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4512,7 +4544,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4524,7 +4556,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4533,7 +4565,9 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4560,7 +4594,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4573,7 +4607,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4585,7 +4619,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4594,7 +4628,9 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4620,7 +4656,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4633,7 +4669,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4645,7 +4681,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4654,7 +4690,9 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4681,7 +4719,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4698,7 +4736,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -4710,7 +4748,7 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4719,7 +4757,9 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -4858,7 +4898,7 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -4878,7 +4918,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -4889,7 +4929,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe!s}"
+                                f"Unable to compute mask on elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -4899,7 +4939,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -4919,7 +4959,7 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -4939,7 +4979,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -4950,7 +4990,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe!s}"
+                                f"Unable to compute mask on elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -4960,7 +5000,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -4981,7 +5021,7 @@ def regrid_custom_hourly_netcdf(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5001,7 +5041,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5012,7 +5052,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe!s}"
+                                f"Unable to compute mask on elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -5022,7 +5062,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5042,7 +5082,7 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5062,7 +5102,7 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5073,7 +5113,7 @@ def regrid_custom_hourly_netcdf(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe!s}"
+                                f"Unable to compute mask on elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -5083,7 +5123,7 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -5122,7 +5162,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5135,7 +5175,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -5147,7 +5187,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5157,7 +5197,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5176,7 +5216,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5185,7 +5225,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5221,7 +5261,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5234,7 +5274,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -5246,7 +5286,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5256,7 +5296,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5274,7 +5314,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5283,7 +5323,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5318,7 +5358,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5331,7 +5371,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -5345,7 +5385,7 @@ def regrid_custom_hourly_netcdf(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5355,7 +5395,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5376,7 +5416,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5385,7 +5425,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5421,7 +5461,7 @@ def regrid_custom_hourly_netcdf(
                         )  # log at debug level
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5433,7 +5473,7 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -5445,7 +5485,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5455,7 +5495,7 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5478,7 +5518,7 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -5487,7 +5527,7 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5637,7 +5677,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5650,7 +5690,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5662,7 +5702,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5672,7 +5712,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe!s}"
+                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5685,7 +5725,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5694,7 +5736,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5738,7 +5782,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5751,7 +5795,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5763,7 +5807,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5773,7 +5817,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe!s}"
+                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5786,7 +5830,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5795,7 +5841,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5842,7 +5890,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5855,7 +5903,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5867,7 +5915,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5877,7 +5925,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask_elem == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5892,7 +5940,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -5902,7 +5952,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ] = input_forcings.esmf_field_out_elem.data
 
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5946,7 +5998,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5959,7 +6011,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -5971,7 +6023,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve!s}"
+                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5981,7 +6033,7 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe!s}"
+                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -5994,7 +6046,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run NDV search on ERA5-Interim precipitation: {npe!s}"
+                    config_options.errMsg = (
+                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6003,7 +6057,9 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -6123,11 +6179,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         tmp_hr_previous = input_forcings.fcst_hour1
 
                     fields.append(
-                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{tmp_hr_previous!s}-{input_forcings.fcst_hour2!s} hour ave fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{tmp_hr_previous}-{input_forcings.fcst_hour2} hour ave fcst:"
                     )
                 else:
                     fields.append(
-                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2!s} hour fcst:"
+                        f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                     )
 
             # if calc_regrid_flag:
@@ -6213,7 +6269,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6227,7 +6283,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6241,7 +6297,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6255,7 +6311,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err!s})"
+                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
                             err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6268,7 +6324,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local GFS array into an ESMF field: {err!s}"
+                        f"Unable to place local GFS array into an ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6289,7 +6345,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            f"Unable to regrid GFS elevation data: {ve!s}"
+                            f"Unable to regrid GFS elevation data: {ve}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -6300,7 +6356,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6314,14 +6370,16 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local GFS array into an ESMF field: {err!s}"
+                        config_options.errMsg = (
+                            f"Unable to place local GFS array into an ESMF field: {err}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6334,7 +6392,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6344,7 +6402,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6354,7 +6412,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
@@ -6368,7 +6426,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     except ValueError as ve:
                         config_options.errMsg = (
-                            f"Unable to regrid GFS elevation data: {ve!s}"
+                            f"Unable to regrid GFS elevation data: {ve}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -6379,7 +6437,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe!s}"
+                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6387,14 +6445,14 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6403,7 +6461,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err!s}"
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6411,7 +6469,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err!s}"
+                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -6439,7 +6497,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
@@ -6450,7 +6508,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6461,7 +6519,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
@@ -6472,7 +6530,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6544,27 +6602,27 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err!s}"
+                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6590,7 +6648,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                    config_options.errMsg = f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6600,7 +6658,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6610,7 +6668,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
+                        f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6646,7 +6704,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6656,7 +6714,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6666,7 +6724,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
+                        f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6703,7 +6761,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6713,7 +6771,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6723,7 +6781,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
+                        f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6759,7 +6817,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             config_options, mpi_config, True
                         )  # log at debug level
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve!s})"
+                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6769,7 +6827,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe!s})"
+                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -6779,7 +6837,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err!s}"
+                        f"Unable to extract GFS ESMF field data to local array: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -6889,7 +6947,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         config_options, mpi_config, True
                     )  # log at debug level
                 fields.append(
-                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2!s} hour fcst:"
+                    f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
             fields.append(":(HGT):(surface):")
 
@@ -6985,7 +7043,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7003,7 +7061,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7013,14 +7071,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7040,7 +7100,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7058,7 +7118,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7068,14 +7128,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7094,7 +7156,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7112,7 +7174,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7122,7 +7184,9 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7131,7 +7195,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7151,7 +7215,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7169,7 +7233,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7179,14 +7243,16 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to compute mask on NAM nest elevation data: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -7220,7 +7286,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7233,7 +7299,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7245,7 +7311,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7255,7 +7321,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7264,7 +7330,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7291,7 +7357,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7304,7 +7370,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7316,7 +7382,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7326,7 +7392,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7335,7 +7401,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7361,7 +7427,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7374,7 +7440,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7388,7 +7454,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7398,7 +7464,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7407,7 +7473,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7434,7 +7500,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7447,7 +7513,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7459,7 +7525,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7469,7 +7535,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7478,7 +7544,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7725,7 +7791,7 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7738,7 +7804,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place MRMS data into local ESMF field: {err!s}"
+                        f"Unable to place MRMS data into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7757,7 +7823,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7778,7 +7844,7 @@ def regrid_mrms_hourly(
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run mask calculation for MRMS RQI data: {npe!s}"
+                        f"Unable to run mask calculation for MRMS RQI data: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7791,7 +7857,7 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7804,7 +7870,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place MRMS data into local ESMF field: {err!s}"
+                        f"Unable to place MRMS data into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7823,7 +7889,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7844,7 +7910,7 @@ def regrid_mrms_hourly(
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run mask calculation for MRMS RQI data: {npe!s}"
+                        f"Unable to run mask calculation for MRMS RQI data: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7856,7 +7922,7 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7869,7 +7935,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place MRMS data into local ESMF field: {err!s}"
+                        f"Unable to place MRMS data into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7888,7 +7954,7 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -7909,7 +7975,7 @@ def regrid_mrms_hourly(
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run mask calculation for MRMS RQI data: {npe!s}"
+                        f"Unable to run mask calculation for MRMS RQI data: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -7970,7 +8036,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -7989,7 +8055,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8008,7 +8074,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
+                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -8038,7 +8104,7 @@ def regrid_mrms_hourly(
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe!s}"
+                        f"Unable to run MRMS RQI threshold search: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8055,7 +8121,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
+                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8085,7 +8151,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8104,7 +8170,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8123,7 +8189,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
+                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -8153,7 +8219,7 @@ def regrid_mrms_hourly(
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe!s}"
+                        f"Unable to run MRMS RQI threshold search: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8170,7 +8236,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
+                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8199,7 +8265,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8220,7 +8286,7 @@ def regrid_mrms_hourly(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8242,7 +8308,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
+                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -8272,7 +8338,7 @@ def regrid_mrms_hourly(
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe!s}"
+                        f"Unable to run MRMS RQI threshold search: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8289,7 +8355,7 @@ def regrid_mrms_hourly(
                 del ind_valid_elem
             except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
                 config_options.errMsg = (
-                    f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
+                    f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -8320,7 +8386,7 @@ def regrid_mrms_hourly(
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err!s})"
+                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8339,7 +8405,7 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve!s}"
+                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -8358,7 +8424,7 @@ def regrid_mrms_hourly(
 
             except (ValueError, ArithmeticError) as npe:
                 config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe!s}"
+                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -8388,7 +8454,7 @@ def regrid_mrms_hourly(
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe!s}"
+                        f"Unable to run MRMS RQI threshold search: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -8405,7 +8471,7 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe!s}"
+                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -8530,7 +8596,7 @@ def regrid_mrms_precip_flag(
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err!s})"
+            config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})"
             err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8546,7 +8612,7 @@ def regrid_mrms_precip_flag(
         supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
     except (ValueError, KeyError, AttributeError) as err:
         config_options.errMsg = (
-            f"Unable to place MRMS PrecipFlag into local ESMF field: {err!s}"
+            f"Unable to place MRMS PrecipFlag into local ESMF field: {err}"
         )
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
@@ -8558,7 +8624,7 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_out,
         )
     except ValueError as ve:
-        config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve!s}"
+        config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve}"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8571,7 +8637,7 @@ def regrid_mrms_precip_flag(
             np.where(supplemental_precip.esmf_field_out.data < 0)
         ] = 1.0
     except (ValueError, ArithmeticError) as npe:
-        config_options.errMsg = f"Unable to run mask search on MRMS PrecipFlag: {npe!s}"
+        config_options.errMsg = f"Unable to run mask search on MRMS PrecipFlag: {npe}"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8598,7 +8664,7 @@ def regrid_mrms_precip_flag(
                     supplemental_precip.netcdf_var_names[0]
                 ][0, :, :]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err!s})"
+                config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -8618,7 +8684,7 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
         except (ValueError, KeyError, AttributeError) as err:
             config_options.errMsg = (
-                f"Unable to place MRMS PrecipFlag into local ESMF field: {err!s}"
+                f"Unable to place MRMS PrecipFlag into local ESMF field: {err}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -8630,7 +8696,7 @@ def regrid_mrms_precip_flag(
                 supplemental_precip.esmf_field_out_elem,
             )
         except ValueError as ve:
-            config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve!s}"
+            config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -8644,7 +8710,7 @@ def regrid_mrms_precip_flag(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                f"Unable to run mask search on MRMS PrecipFlag: {npe!s}"
+                f"Unable to run mask search on MRMS PrecipFlag: {npe}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -8760,7 +8826,7 @@ def regrid_hourly_wrf_arw(
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
-                    else f"{input_forcings.fcst_hour2!s} hour fcst"
+                    else f"{input_forcings.fcst_hour2} hour fcst"
                 )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{time_str}:"
@@ -8859,7 +8925,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8879,7 +8945,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8890,7 +8956,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -8898,7 +8964,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
@@ -8917,7 +8983,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8937,7 +9003,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8948,7 +9014,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -8956,7 +9022,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8975,7 +9041,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -8995,7 +9061,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9006,7 +9072,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -9016,7 +9082,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9036,7 +9102,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err!s}"
+                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9056,7 +9122,7 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9067,7 +9133,7 @@ def regrid_hourly_wrf_arw(
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
                         config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe!s}"
+                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
                         )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
@@ -9075,7 +9141,7 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err!s}"
+                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9109,7 +9175,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9122,7 +9188,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9134,7 +9200,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9144,7 +9210,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9165,7 +9231,9 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9174,7 +9242,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9201,7 +9269,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9214,7 +9282,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9226,7 +9294,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9236,7 +9304,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9257,7 +9325,9 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9266,7 +9336,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9292,7 +9362,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9305,7 +9375,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9319,7 +9389,7 @@ def regrid_hourly_wrf_arw(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9329,7 +9399,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9351,7 +9421,9 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9360,7 +9432,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9387,7 +9459,7 @@ def regrid_hourly_wrf_arw(
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9400,7 +9472,7 @@ def regrid_hourly_wrf_arw(
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -9412,7 +9484,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9422,7 +9494,7 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9443,7 +9515,9 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on WRF ARW precipitation: {npe!s}"
+                        config_options.errMsg = (
+                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9452,7 +9526,7 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -9563,9 +9637,9 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
             # Create a temporary NetCDF file from the GRIB2 file.
             if WGRIB2_env:
-                cmd = f'$WGRIB2 {supplemental_precip.file_in1} -match ":(APCP):(surface):({supplemental_precip.fcst_hour1 - 1!s}-{supplemental_precip.fcst_hour1!s} hour acc fcst):" -netcdf {arw_tmp_nc}'
+                cmd = f'$WGRIB2 {supplemental_precip.file_in1} -match ":(APCP):(surface):({supplemental_precip.fcst_hour1 - 1}-{supplemental_precip.fcst_hour1} hour acc fcst):" -netcdf {arw_tmp_nc}'
             else:
-                cmd = f"(APCP):(surface):({supplemental_precip.fcst_hour1 - 1!s}-{supplemental_precip.fcst_hour1!s} hour acc fcst)"
+                cmd = f"(APCP):(surface):({supplemental_precip.fcst_hour1 - 1}-{supplemental_precip.fcst_hour1} hour acc fcst)"
 
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in1,
@@ -9616,7 +9690,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9628,7 +9702,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9640,7 +9714,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9651,7 +9725,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9670,7 +9744,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9694,7 +9768,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9706,7 +9780,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9718,7 +9792,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9729,7 +9803,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9748,7 +9822,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9771,7 +9845,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9783,7 +9857,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9797,7 +9871,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9808,7 +9882,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9828,7 +9902,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid_elem
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9852,7 +9926,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9864,7 +9938,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err!s}"
+                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9876,7 +9950,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
             except ValueError as ve:
                 config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve!s}"
+                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -9887,7 +9961,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -9906,7 +9980,7 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10011,7 +10085,7 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10025,7 +10099,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10037,7 +10111,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10052,7 +10126,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10084,7 +10158,7 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10098,7 +10172,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10110,7 +10184,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10125,7 +10199,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10158,7 +10232,7 @@ def regrid_sbcv2_liquid_water_fraction(
                     supplemental_forcings.netcdf_var_names[0]
                 ][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10172,7 +10246,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp_elem / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10186,7 +10260,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10201,7 +10275,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10231,7 +10305,7 @@ def regrid_sbcv2_liquid_water_fraction(
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err!s})"
+                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10245,7 +10319,7 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err!s}"
+            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10257,7 +10331,7 @@ def regrid_sbcv2_liquid_water_fraction(
             )
         except ValueError as ve:
             config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve!s}"
+                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10272,7 +10346,7 @@ def regrid_sbcv2_liquid_water_fraction(
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
             config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe!s}"
+                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
             )
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
@@ -10366,7 +10440,7 @@ def regrid_hourly_nbm(
             time_str = (
                 f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
-                else f"{forcings_or_precip.fcst_hour2!s} hour fcst"
+                else f"{forcings_or_precip.fcst_hour2} hour fcst"
             )
             fields.append(
                 f":{grib_var}:{forcings_or_precip.grib_levels[force_count]}:{time_str}:"
@@ -10378,7 +10452,7 @@ def regrid_hourly_nbm(
         # Perform a GRIB dump to NetCDF for the precip data.
         fieldnbm_match1 = '":APCP:"'
         fieldnbm_match2 = (
-            f'"{forcings_or_precip.fcst_hour1!s}-{forcings_or_precip.fcst_hour2!s}"'
+            f'"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2}"'
         )
         fieldnbm_notmatch1 = '"prob"'  # We don't want the probabilistic QPF layers
         cmd = f"$WGRIB2 {forcings_or_precip.file_in1} -match {fieldnbm_match1} -match {fieldnbm_match2} -not {fieldnbm_notmatch1} -netcdf {nbm_tmp_nc}"
@@ -10501,7 +10575,7 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10521,7 +10595,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10532,7 +10606,7 @@ def regrid_hourly_nbm(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on NBM elevation data: {npe!s}"
+                                f"Unable to compute mask on NBM elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -10542,7 +10616,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10563,7 +10637,7 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10583,7 +10657,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10594,7 +10668,7 @@ def regrid_hourly_nbm(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on NBM elevation data: {npe!s}"
+                                f"Unable to compute mask on NBM elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -10604,7 +10678,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10625,7 +10699,7 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10645,7 +10719,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10656,7 +10730,7 @@ def regrid_hourly_nbm(
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
                             config_options.errMsg = (
-                                f"Unable to compute mask on NBM elevation data: {npe!s}"
+                                f"Unable to compute mask on NBM elevation data: {npe}"
                             )
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
@@ -10666,7 +10740,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10686,7 +10760,7 @@ def regrid_hourly_nbm(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err!s}"
+                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10704,7 +10778,7 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve!s}"
+                            config_options.errMsg = f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10714,7 +10788,7 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = f"Unable to compute element mask on NBM elevation data: {npe!s}"
+                            config_options.errMsg = f"Unable to compute element mask on NBM elevation data: {npe}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10723,7 +10797,7 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err!s}"
+                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -10741,7 +10815,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10754,7 +10828,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
+                    f"Unable to place NBM {tag} into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -10766,7 +10840,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10776,7 +10850,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10812,7 +10886,7 @@ def regrid_hourly_nbm(
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
+                        f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -10833,7 +10907,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10846,7 +10920,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
+                    f"Unable to place NBM {tag} into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -10858,7 +10932,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -10867,7 +10941,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10903,7 +10977,7 @@ def regrid_hourly_nbm(
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
+                        f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -10924,7 +10998,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10937,7 +11011,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
+                    f"Unable to place NBM {tag} into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -10949,7 +11023,7 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -10958,7 +11032,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -10994,7 +11068,7 @@ def regrid_hourly_nbm(
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
+                        f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -11015,7 +11089,7 @@ def regrid_hourly_nbm(
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err!s})"
+                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
                     err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11028,7 +11102,7 @@ def regrid_hourly_nbm(
                 forcings_or_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err!s}"
+                    f"Unable to place NBM {tag} into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -11042,7 +11116,7 @@ def regrid_hourly_nbm(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve!s}"
+                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
@@ -11051,7 +11125,7 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe!s}"
+                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -11091,7 +11165,7 @@ def regrid_hourly_nbm(
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
                     config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe!s}"
+                        f"Unable to run NDV search on NBM precipitation: {npe}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -11354,7 +11428,7 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
                 config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err!s}"
+                    f"Unable to place local array into local ESMF field: {err}"
                 )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
@@ -11490,7 +11564,9 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[i], :
                     ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                config_options.errMsg = (
+                    f"Unable to place local ESMF regridded data into local array: {err}"
+                )
                 err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
         finally:
@@ -11619,7 +11695,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11632,7 +11708,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -11644,7 +11720,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11654,7 +11730,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11673,7 +11749,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11682,7 +11758,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11718,7 +11794,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )  # log at debug level
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11731,7 +11807,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -11743,7 +11819,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11753,7 +11829,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11771,7 +11847,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11780,7 +11856,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11815,7 +11891,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )  # log at debug level
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err!s})"
+                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
                         err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11828,7 +11904,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
                     config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err!s}"
+                        f"Unable to place local array into local ESMF field: {err}"
                     )
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
@@ -11842,7 +11918,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11852,7 +11928,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11873,7 +11949,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11882,7 +11958,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                     err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
@@ -11956,7 +12032,9 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local array into local ESMF field: {err!s}"
+                        config_options.errMsg = (
+                            f"Unable to place local array into local ESMF field: {err}"
+                        )
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11972,7 +12050,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve!s}"
+                        config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -11985,7 +12063,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = fill
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe!s}"
+                        config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12012,7 +12090,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             AttributeError,
                             KeyError,
                         ) as npe:
-                            config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe!s}"
+                            config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
                             err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12024,7 +12102,7 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err!s}"
+                        config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
                         err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12070,7 +12148,7 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}"
                 err_handler.log_critical(config_options, mpi_config)
 
         elif config_options.grid_type == "unstructured":
@@ -12081,7 +12159,7 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}"
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
@@ -12090,7 +12168,7 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}"
                 err_handler.log_critical(config_options, mpi_config)
         elif config_options.grid_type == "hydrofabric":
             try:
@@ -12100,7 +12178,7 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}"
                 err_handler.log_critical(config_options, mpi_config)
 
     err_handler.check_program_status(config_options, mpi_config)
@@ -12215,7 +12293,7 @@ def check_supp_pcp_regrid_status(
                     name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF field object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF field object: {esmf_error}"
                 err_handler.err_out(config_options)
         elif config_options.grid_type == "unstructured":
             try:
@@ -12225,7 +12303,7 @@ def check_supp_pcp_regrid_status(
                     name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF node field object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF node field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
             try:
@@ -12235,7 +12313,7 @@ def check_supp_pcp_regrid_status(
                     name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
         elif config_options.grid_type == "hydrofabric":
@@ -12246,7 +12324,7 @@ def check_supp_pcp_regrid_status(
                     name=f"{supplemental_precip.product_name}SUPP_PCP_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error!s}"
+                config_options.errMsg = f"Unable to create {supplemental_precip.product_name} destination ESMF element field object: {esmf_error}"
                 err_handler.err_out(config_options)
 
     # Determine if we need to calculate a regridding object. The following situations warrant the calculation of
@@ -12464,7 +12542,7 @@ def load_weight_file(
         end = monotonic()
     except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
         config_options.errMsg = (
-            f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error!s}"
+            f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error}"
         )
         err_handler.log_warning(config_options, mpi_config)
     else:
@@ -12529,7 +12607,7 @@ def make_regrid(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error!s}"
+        config_options.errMsg = f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error}"
         err_handler.log_critical(config_options, mpi_config)
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
@@ -12570,7 +12648,7 @@ def execute_regrid(
         )
     except ValueError as ve:
         config_options.errMsg = (
-            f"Unable to extract regridded data from ESMF regridded field: {ve!s}"
+            f"Unable to extract regridded data from ESMF regridded field: {ve}"
         )
         err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
@@ -12640,14 +12718,14 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                config_options.errMsg = f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[2]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err!s})"
+                config_options.errMsg = f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
                 err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12669,7 +12747,7 @@ def calculate_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error!s})"
+        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12693,7 +12771,7 @@ def calculate_weights(
             input_forcings.y_upper_bound - input_forcings.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err!s})"
+        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})"
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12824,14 +12902,18 @@ def calculate_weights(
     try:
         input_forcings.esmf_lats = input_forcings.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = f"Unable to locate latitude coordinate object within input ESMF grid: {ge!s}"
+        config_options.errMsg = (
+            f"Unable to locate latitude coordinate object within input ESMF grid: {ge}"
+        )
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
         input_forcings.esmf_lons = input_forcings.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = f"Unable to locate longitude coordinate object within input ESMF grid: {ge!s}"
+        config_options.errMsg = (
+            f"Unable to locate longitude coordinate object within input ESMF grid: {ge}"
+        )
         err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12850,9 +12932,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = (
-                f"Unable to create ESMF field object: {esmf_error!s}"
-            )
+            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12864,9 +12944,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = (
-                f"Unable to create ESMF field object: {esmf_error!s}"
-            )
+            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12877,9 +12955,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = (
-                f"Unable to create ESMF field object: {esmf_error!s}"
-            )
+            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -12891,9 +12967,7 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = (
-                f"Unable to create ESMF field object: {esmf_error!s}"
-            )
+            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
             err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -13041,14 +13115,14 @@ def calculate_supp_pcp_weights(
                 supplemental_precip.netcdf_var_names[0]
             ].shape[latdim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = f"Unable to extract Y shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err!s}, {type(err)})"
+            config_options.errMsg = f"Unable to extract Y shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err}, {type(err)})"
             err_handler.err_out(config_options)
         try:
             supplemental_precip.nx_global = id_tmp.variables[
                 supplemental_precip.netcdf_var_names[0]
             ].shape[londim]
         except (ValueError, KeyError, AttributeError, Exception) as err:
-            config_options.errMsg = f"Unable to extract X shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err!s}, {type(err)})"
+            config_options.errMsg = f"Unable to extract X shape size from: {supplemental_precip.netcdf_var_names[0]} from: {tmp_file} ({err}, {type(err)})"
             err_handler.err_out(config_options)
 
     # mpi_config.comm.barrier()
@@ -13070,7 +13144,7 @@ def calculate_supp_pcp_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {tmp_file} ({esmf_error!s})"
+        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {tmp_file} ({esmf_error})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -13094,7 +13168,7 @@ def calculate_supp_pcp_weights(
             supplemental_precip.y_upper_bound - supplemental_precip.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {tmp_file} ({err!s})"
+        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {tmp_file} ({err})"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
@@ -13151,14 +13225,14 @@ def calculate_supp_pcp_weights(
     try:
         supplemental_precip.esmf_lats = supplemental_precip.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = f"Unable to locate latitude coordinate object within supplemental precip ESMF grid: {ge!s}"
+        config_options.errMsg = f"Unable to locate latitude coordinate object within supplemental precip ESMF grid: {ge}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 
     try:
         supplemental_precip.esmf_lons = supplemental_precip.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = f"Unable to locate longitude coordinate object within supplemental precip ESMF grid: {ge!s}"
+        config_options.errMsg = f"Unable to locate longitude coordinate object within supplemental precip ESMF grid: {ge}"
         err_handler.err_out(config_options)
     # mpi_config.comm.barrier()
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -107,13 +107,20 @@ def create_link(name, input_file, tmpFile, config_options, mpi_config):
     """Create a symbolic link to the input file for processing."""
     if mpi_config.rank == 0:
         try:
-            config_options.statusMsg = f"{name} file being used: {input_file}"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"{name} file being used: {input_file}",
+            )
 
             os.symlink(input_file, tmpFile)
         except:
-            config_options.errMsg = f"Unable to create link: {input_file} to: {tmpFile}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to create link: {input_file} to: {tmpFile}",
+            )
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -148,12 +155,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # exit out of this routine as the regridded fields have already been set to NDV.
         if not os.path.isfile(input_forcings.file_in2):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No AK AnA in_2 file found for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No AK AnA in_2 file found for this timestep.",
+                )
             return
 
         # Check to see if the regrid complete flag for this
@@ -161,12 +168,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No AK AnA regridding required for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No AK AnA regridding required for this timestep.",
+                )
             return
 
         # Only rank‐0 opens the file
@@ -176,10 +183,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds = Dataset(input_forcings.file_in2, "r")
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to open input NetCDF file: {input_forcings.file_in2} ({e})",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
             # turn off automatic masking but keep scaling
             ds.set_auto_scale(True)
@@ -209,8 +217,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         coord_sys=ESMF.CoordSys.SPH_DEG,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF grid from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -241,8 +252,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.y_upper_bound - input_forcings.y_lower_bound
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global grid from netCDF file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
                 try:
@@ -255,8 +269,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -273,8 +290,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in_elem.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
@@ -283,8 +303,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         filetype=ESMF.FileFormat.ESMFMESH,
                     )
                 except ESMF.ESMPyException as esmf_error:
-                    config_options.errMsg = f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to create source ESMF Mesh from netCDF file: {input_forcings.file_in} ({str(esmf_error)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -295,8 +318,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_grid_in.esmf_grid_in.coords[0][1]
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract local X/Y boundaries from global mesh file: {input_forcings.file_in} ({str(err)})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Create out regridded numpy arrays to hold the regridded data.
@@ -334,10 +360,12 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             var_tmp = None
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing input AK AnA variable: {nc_var} from {input_forcings.file_in2}",
+                )
                 LOG.debug(f"{config_options.statusMsg}")
                 if config_options.grid_type == "gridded":
                     try:
@@ -345,8 +373,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
                 elif config_options.grid_type == "unstructured":
                     try:
                         var_tmp = ds.variables[nc_var][0, :]
@@ -355,16 +386,22 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         var_tmp_elem = ds.variables[nc_var][0, :]
                         var_tmp_elem = np.float32(var_tmp_elem)
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
                 elif config_options.grid_type == "hydrofabric":
                     try:
                         var_tmp = ds.variables[nc_var][0, :]
                         var_tmp = np.float32(var_tmp)
 
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                        )
 
             err_handler.check_program_status(config_options, mpi_config)
 
@@ -378,8 +415,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -398,8 +438,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds_elem]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -420,8 +463,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = var_tmp[wrf_hydro_geo_meta.mesh_inds]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract ExtAnA forcing data from the AK AnA mesh field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -436,10 +482,11 @@ def regrid_ak_ext_ana(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 ds.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close input NetCDF file: {input_forcings.file_in2}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close input NetCDF file: {input_forcings.file_in2}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -469,10 +516,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No StageIV regridding required for this timestep."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No StageIV regridding required for this timestep.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -492,17 +541,19 @@ def _regrid_ak_ext_ana_pcp_stage4(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
-                    config_options.statusMsg = (
-                        f"Found old temporary file: {stage4_tmp_nc} - Removing....."
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove temporary file: {stage4_tmp_nc}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Create a temporary NetCDF file from the GRIB2 file.
@@ -512,10 +563,9 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-6 hour acc fcst"
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"WGRIB2 command: {cmd}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
+                )
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -546,10 +596,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating STAGE IV regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating STAGE IV regridding weights.",
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -566,10 +618,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -581,8 +635,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -594,10 +651,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -609,8 +668,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -622,10 +684,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -637,8 +701,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -651,10 +718,12 @@ def _regrid_ak_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -666,8 +735,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -679,8 +751,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -690,10 +765,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -702,8 +778,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -721,8 +800,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -737,8 +819,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -748,10 +833,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -760,8 +846,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -779,8 +868,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -794,8 +886,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -807,10 +902,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -819,8 +915,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -839,8 +938,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -855,8 +957,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -866,10 +971,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -878,8 +984,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -897,8 +1006,11 @@ def _regrid_ak_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -915,24 +1027,25 @@ def _regrid_ak_ext_ana_pcp_stage4(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
             except FileNotFoundError:
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {stage4_tmp_nc}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {stage4_tmp_nc}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -992,10 +1105,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No StageIV regridding required for this timestep."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No StageIV regridding required for this timestep.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -1014,17 +1129,19 @@ def _regrid_conus_ext_ana_pcp_stage4(
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(stage4_tmp_nc):
-                    config_options.statusMsg = (
-                        f"Found old temporary file: {stage4_tmp_nc} - Removing....."
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {stage4_tmp_nc} - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(stage4_tmp_nc)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove temporary file: {stage4_tmp_nc}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove temporary file: {stage4_tmp_nc}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Create a temporary NetCDF file from the GRIB2 file.
@@ -1034,10 +1151,9 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 cmd = "APCP:surface:0-1 hour acc fcst"
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"WGRIB2 command: {cmd}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options, mpi_config, debug=True, msg=f"WGRIB2 command: {cmd}"
+                )
             id_tmp = ioMod.open_grib2(
                 supplemental_precip.file_in2,
                 stage4_tmp_nc,
@@ -1068,10 +1184,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating STAGE IV regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating STAGE IV regridding weights.",
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip,
                 id_tmp,
@@ -1088,10 +1206,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1103,8 +1223,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1116,10 +1239,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1131,8 +1256,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1144,10 +1272,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1159,8 +1289,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp_elem,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -1173,10 +1306,12 @@ def _regrid_conus_ext_ana_pcp_stage4(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding STAGE IV '{supplemental_precip.netcdf_var_names[-1]}' Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables[
                         supplemental_precip.netcdf_var_names[-1]
@@ -1188,8 +1323,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                         var_tmp,
                     )
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from STAGE IV file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -1201,8 +1339,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1212,10 +1353,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1224,8 +1366,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -1243,8 +1388,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1259,8 +1407,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1270,10 +1421,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1282,8 +1434,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -1301,8 +1456,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1316,8 +1474,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1329,10 +1490,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1341,8 +1503,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -1361,8 +1526,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -1377,8 +1545,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place STAGE IV precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place STAGE IV precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -1388,10 +1559,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid STAGE IV supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid STAGE IV supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -1400,8 +1572,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -1424,8 +1599,11 @@ def _regrid_conus_ext_ana_pcp_stage4(
                 del ind_valid
                 del invalid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on STAGE IV supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # If we are on the first timestep, set the previous regridded field to be
             # the latest as there are no states for time 0.
@@ -1441,24 +1619,25 @@ def _regrid_conus_ext_ana_pcp_stage4(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(stage4_tmp_nc)
             except FileNotFoundError:
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {stage4_tmp_nc}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {stage4_tmp_nc}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {stage4_tmp_nc}: {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -1511,8 +1690,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # exit out of this routine as the regridded fields have already been set to NDV.
     if not os.path.isfile(input_forcings.file_in2):
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No HRRR in_2 file found for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No HRRR in_2 file found for this timestep.",
+            )
         return
 
     # Check to see if the regrid complete flag for this
@@ -1520,8 +1703,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No HRRR regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No HRRR regridding required for this timestep.",
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -1533,34 +1720,37 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CONUS HRRR"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS HRRR")
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = (
-                    f"Found old temporary file: {input_forcings.tmpFile} - Removing..."
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing...",
                 )
-                err_handler.log_warning(config_options, mpi_config)
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
-                    config_options.errMsg = (
-                        f"Unable to remove temporary file: {input_forcings.tmpFile}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove temporary file: {input_forcings.tmpFile}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Build GRIB2 to NetCDF conversion
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Converting HRRR Variable: {grib_var}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting HRRR Variable: {grib_var}",
+                    )
                 if 0 < input_forcings.cycle_freq < 60:
                     time_str = (
                         f"{input_forcings.fcst_min1}-{input_forcings.fcst_min2} min acc fcst"
@@ -1611,10 +1801,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing HRRR Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing HRRR Variable: {grib_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -1628,10 +1820,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating HRRR regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating HRRR regridding weights.",
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -1645,7 +1839,7 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # # Read in the HRRR height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in HRRR elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -1675,15 +1869,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -1693,10 +1892,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1705,15 +1905,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -1738,15 +1944,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -1756,10 +1967,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1768,15 +1980,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -1797,15 +2015,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -1815,10 +2038,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1827,8 +2051,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -1836,8 +2063,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -1862,15 +2092,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place input NetCDF HRRR data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding HRRR surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding HRRR surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -1880,10 +2115,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid HRRR surface elevation using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid HRRR surface elevation using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -1892,15 +2128,21 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform HRRR mask search on elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform HRRR mask search on elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract regridded HRRR elevation data from ESMF: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract regridded HRRR elevation data from ESMF: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -1922,10 +2164,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -1945,8 +2189,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -1957,17 +2204,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -1975,10 +2225,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -1987,10 +2238,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -1998,8 +2250,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2016,10 +2271,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2039,8 +2296,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2051,17 +2311,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2069,10 +2332,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2081,10 +2345,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2092,8 +2357,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2109,10 +2377,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp_elem = id_tmp.variables[
@@ -2132,8 +2402,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2144,17 +2417,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -2164,10 +2440,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2176,10 +2453,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2187,8 +2465,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2205,10 +2486,12 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Processing input HRRR variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         if 0 < input_forcings.cycle_freq < 60:
                             var_tmp = id_tmp.variables[
@@ -2228,8 +2511,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                                 1.0  # assume all liquid if not specifically given
                             )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2240,17 +2526,20 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place input HRRR data into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place input HRRR data into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input HRRR Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2258,10 +2547,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = (
-                        f"Unable to regrid input HRRR forcing data: {ve}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input HRRR forcing data: {ve}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2270,10 +2560,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to perform mask test on regridded HRRR forcings: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to perform mask test on regridded HRRR forcings: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -2281,8 +2572,11 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract regridded HRRR forcing data from the ESMF field: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -2301,26 +2595,27 @@ def regrid_conus_hrrr(input_forcings, config_options, wrf_hydro_geo_meta, mpi_co
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -2348,8 +2643,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No RAP regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No RAP regridding required for this timestep.",
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -2363,33 +2662,36 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CONUS RAP"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CONUS RAP")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
-                    err_handler.log_warning(config_options, mpi_config)
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
+                    )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
-                        config_options.errMsg = (
-                            f"Unable to remove file: {input_forcings.tmpFile}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove file: {input_forcings.tmpFile}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Converting CONUS RAP Variable: {grib_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting CONUS RAP Variable: {grib_var}",
+                    )
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var in ("APCP", "FROZR")
@@ -2430,10 +2732,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing Conus RAP Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing Conus RAP Variable: {grib_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -2447,10 +2751,12 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating RAP regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating RAP regridding weights.",
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -2464,7 +2770,7 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in RAP elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -2478,10 +2784,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2492,15 +2799,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2510,10 +2822,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2522,15 +2835,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -2540,10 +2859,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2554,15 +2874,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2572,10 +2897,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2584,15 +2910,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -2601,10 +2933,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2615,15 +2948,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -2633,10 +2971,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2645,8 +2984,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -2654,8 +2996,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -2665,10 +3010,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = (
-                                f"Unable to extract HGT_surface from : {id_tmp} ({err})"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from : {id_tmp} ({err})",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -2679,15 +3025,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place temporary RAP elevation variable into ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place temporary RAP elevation variable into ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding RAP surface elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding RAP surface elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -2697,10 +3048,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid RAP elevation data using ESMF: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid RAP elevation data using ESMF: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -2709,15 +3061,21 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on RAP elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on RAP elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF elevation field into local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF elevation field into local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -2746,8 +3104,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2758,17 +3119,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2776,8 +3140,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2786,8 +3153,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -2796,10 +3166,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to place RAP ESMF data into local array: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -2839,8 +3210,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -2851,17 +3225,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -2869,8 +3246,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2879,8 +3259,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -2889,10 +3272,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to place RAP ESMF data into local array: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -2931,8 +3315,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp_elem /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -2943,17 +3330,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -2963,8 +3353,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -2973,8 +3366,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -2983,8 +3379,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place RAP ESMF element data into local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF element data into local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3025,8 +3424,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         if grib_var in ("APCP", "FROZR"):
                             var_tmp /= 3600  # convert hourly accumulated precip to instantaneous rate
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -3037,17 +3439,20 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local RAP array into ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local RAP array into ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input RAP Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
                         input_forcings.regridObj,
@@ -3055,8 +3460,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid RAP variable: {input_forcings.netcdf_var_names[force_count]}{ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -3065,8 +3473,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation on RAP variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if force_count < 8:
@@ -3075,10 +3486,11 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to place RAP ESMF data into local array: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place RAP ESMF data into local array: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     # handle liquid-phase precip calculation
@@ -3113,26 +3525,27 @@ def regrid_conus_rap(input_forcings, config_options, wrf_hydro_geo_meta, mpi_con
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -3163,8 +3576,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
         # correction on incoming CFSv2 data. Because of the nature, we
         # need to regrid bias-corrected data every hour.
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No need to read in new CFSv2 data at this time."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No need to read in new CFSv2 data at this time.",
+            )
         return
 
     # Create a path for a temporary NetCDF file
@@ -3178,29 +3595,36 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid CFSv2"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid CFSv2")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
-                    err_handler.log_warning(config_options, mpi_config)
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
+                    )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError as err:
-                        config_options.errMsg = f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove previous temporary file: {input_forcings.tmpFile}{err}",
+                        )
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Converting CFSv2 Variable: {grib_var}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting CFSv2 Variable: {grib_var}",
+                    )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -3236,10 +3660,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing CFSv2 Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing CFSv2 Variable: {grib_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -3253,10 +3679,12 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculate CFSv2 regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculate CFSv2 regridding weights.",
+                    )
 
                 calculate_weights(
                     id_tmp,
@@ -3271,7 +3699,7 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in CFSv2 elevation data."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 #
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
@@ -3287,8 +3715,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3299,17 +3730,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3320,8 +3754,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3330,15 +3767,21 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -3348,8 +3791,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3360,17 +3806,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3381,8 +3830,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3391,15 +3843,21 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -3408,8 +3866,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -3420,17 +3881,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        )
 
                     try:
                         input_forcings.esmf_field_out_elem = (
@@ -3441,8 +3905,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3451,8 +3918,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3460,8 +3930,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -3471,8 +3944,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract HGT_surface from file: {input_forcings.file_in2} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -3483,17 +3959,20 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding CFSv2 elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding CFSv2 elevation data to the WRF-Hydro domain.",
+                        )
 
                     try:
                         input_forcings.esmf_field_out = (
@@ -3504,8 +3983,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 elevation data to the WRF-Hydro domain: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3514,15 +3996,21 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract CFSv2 regridded elevation data from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -3547,17 +4035,22 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -3618,8 +4111,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3631,8 +4127,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3641,8 +4140,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3650,10 +4152,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :, :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -3679,17 +4182,22 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -3750,8 +4258,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3763,8 +4274,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3773,8 +4287,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3782,10 +4299,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -3810,17 +4328,22 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -3883,8 +4406,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3896,8 +4422,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -3906,8 +4435,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -3915,10 +4447,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out_elem.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -3944,17 +4477,22 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                 var_tmp = None
                 if mpi_config.rank == 0:
                     if not config_options.runCfsNldasBiasCorrect:
-                        config_options.statusMsg = f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Regridding CFSv2 variable: {input_forcings.netcdf_var_names[force_count]}",
+                        )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from file: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Scatter the global CFSv2 data to the local processors.
@@ -4015,8 +4553,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place CFSv2 forcing data into temporary ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4028,8 +4569,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -4038,8 +4582,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run mask calculation on CFSv2 variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -4047,10 +4594,11 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to extract ESMF field data for CFSv2: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF field data for CFSv2: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # If we are on the first timestep, set the previous regridded field to be
@@ -4077,26 +4625,27 @@ def regrid_cfsv2(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config)
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -4129,10 +4678,12 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No NWM NetCDF regridding required for this timestep."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NWM NetCDF regridding required for this timestep.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -4140,15 +4691,18 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         input_forcings.file_in2, config_options, mpi_config, open_on_all_procs=True
     )
 
-    config_options.statusMsg = "Regrid NWM Custom NetCDF Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid NWM Custom NetCDF Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Processing Custom NetCDF Forcing Variable: {nc_var}"
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4170,27 +4724,31 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                f"Downscaling will not be available."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom netCDF input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4201,10 +4759,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4214,8 +4773,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4223,10 +4785,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4243,17 +4806,20 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom netCDF input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4264,10 +4830,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4277,8 +4844,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4286,10 +4856,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4305,17 +4876,20 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom netCDF input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                )
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -4326,10 +4900,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4339,8 +4914,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4348,10 +4926,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4368,17 +4947,20 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom netCDF input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][:][0, :, :]
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4389,10 +4971,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4402,8 +4985,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4411,10 +4997,11 @@ def regrid_nwm(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4456,10 +5043,12 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No NWM NetCDF regridding required for this timestep."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NWM NetCDF regridding required for this timestep.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
     mpi_config.comm.barrier()
     with MPICommExecutor(comm=mpi_config.comm, root=0) as executor:
@@ -4483,15 +5072,18 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                 longitude=(["y", "x"], lon_coords), latitude=(["y", "x"], lat_coords)
             )
 
-    config_options.statusMsg = "Regrid NWM Custom zarr Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid NWM Custom zarr Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Processing Custom zarr Forcing Variable: {nc_var}"
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Processing Custom zarr Forcing Variable: {nc_var}",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -4512,27 +5104,30 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
 
         input_forcings.height = None
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                f"Downscaling will not be available."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
             )
-            err_handler.log_msg(config_options, mpi_config)
 
         if config_options.grid_type == "gridded":
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom zarr input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4543,10 +5138,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4556,8 +5152,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4565,10 +5164,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4585,17 +5185,20 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom zarr input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -4606,10 +5209,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4619,8 +5223,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4628,10 +5235,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4647,17 +5255,20 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom zarr input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
+                )
                 try:
                     var_tmp_elem = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -4668,10 +5279,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4681,8 +5293,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4690,10 +5305,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4710,17 +5326,20 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding Custom zarr input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding Custom zarr input variable: {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp[nc_var].to_masked_array()
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             # convert to array for NWM
@@ -4735,10 +5354,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4748,8 +5368,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input Custom zarr forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -4757,10 +5380,11 @@ def regrid_nwm_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_confi
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -4818,12 +5442,12 @@ def regrid_custom_hourly_netcdf(
         # inputs have already been regridded and we can move on.
         if input_forcings.regridComplete:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "No Custom Hourly NetCDF regridding required for this timestep."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="No Custom Hourly NetCDF regridding required for this timestep.",
+                )
             return
 
         # Open the input NetCDF file containing necessary data.
@@ -4842,17 +5466,20 @@ def regrid_custom_hourly_netcdf(
             "DLWRF": 310.0,
         }
 
-        config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            msg="Regrid Custom Hourly NetCDF Forcing Variables",
+        )
 
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Processing Custom NetCDF Forcing Variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
+                )
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
                 force_count,
@@ -4898,17 +5525,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -4918,8 +5548,11 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -4928,10 +5561,11 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -4939,8 +5573,11 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                     elif config_options.grid_type == "unstructured":
@@ -4959,17 +5596,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -4979,8 +5619,11 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -4989,10 +5632,11 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5000,8 +5644,11 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Regrid the height variable.
@@ -5021,17 +5668,20 @@ def regrid_custom_hourly_netcdf(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             input_forcings.esmf_field_out_elem = (
                                 esmf_regridobj_call_retry_partial(
@@ -5041,8 +5691,11 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5051,10 +5704,11 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5062,8 +5716,11 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                     elif config_options.grid_type == "hydrofabric":
@@ -5082,17 +5739,20 @@ def regrid_custom_hourly_netcdf(
                         try:
                             input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NetCDF elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NetCDF elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             input_forcings.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -5102,8 +5762,11 @@ def regrid_custom_hourly_netcdf(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -5112,10 +5775,11 @@ def regrid_custom_hourly_netcdf(
                                 np.where(input_forcings.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -5123,18 +5787,21 @@ def regrid_custom_hourly_netcdf(
                                 input_forcings.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                 else:
                     input_forcings.height = None
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Unable to locate HGT_surface in: {input_forcings.file_in2}. "
-                            f"Downscaling will not be available."
+                        err_handler.log_msg(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to locate HGT_surface in: {input_forcings.file_in2}. Downscaling will not be available.",
                         )
-                        err_handler.log_msg(config_options, mpi_config)
 
                 # close netCDF file on non-root ranks
                 if mpi_config.rank != 0:
@@ -5147,23 +5814,26 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -5174,10 +5844,11 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5187,8 +5858,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -5197,8 +5871,11 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -5216,8 +5893,11 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5225,8 +5905,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -5246,23 +5929,26 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -5273,10 +5959,11 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5286,8 +5973,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -5296,8 +5986,11 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -5314,8 +6007,11 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5323,8 +6019,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -5343,23 +6042,26 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp_elem = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -5370,10 +6072,11 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5385,8 +6088,11 @@ def regrid_custom_hourly_netcdf(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -5395,8 +6101,11 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -5416,8 +6125,11 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5425,8 +6137,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -5446,23 +6161,26 @@ def regrid_custom_hourly_netcdf(
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp = id_tmp.variables[nc_var][:].filled(fill)[0, :, :]
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -5472,10 +6190,11 @@ def regrid_custom_hourly_netcdf(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5485,8 +6204,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -5495,8 +6217,11 @@ def regrid_custom_hourly_netcdf(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if nc_var == "DSWRF_surface":
@@ -5518,8 +6243,11 @@ def regrid_custom_hourly_netcdf(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -5527,8 +6255,11 @@ def regrid_custom_hourly_netcdf(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -5575,10 +6306,12 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No ERA5-Interim regridding required for this timestep."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No ERA5-Interim regridding required for this timestep.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Open the input NetCDF file containing necessary data.
@@ -5601,15 +6334,18 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     )
     ind = np.where(seconds_index == np.min(seconds_index))[0][0]
 
-    config_options.statusMsg = "Regrid Custom Hourly NetCDF Forcing Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(
+        config_options, mpi_config, msg="Regrid Custom Hourly NetCDF Forcing Variables"
+    )
 
     for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                f"Processing ERA-5 Interim Forcing Variable: {nc_var}"
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Processing ERA-5 Interim Forcing Variable: {nc_var}",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calc_regrid_flag = check_regrid_status(
             id_tmp,
             force_count,
@@ -5636,11 +6372,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             else:
                 input_forcings.height = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Unable to locate Geopoential height in: {input_forcings.file_in2}. "
-                        f"Downscaling will not be available."
+                    err_handler.log_msg(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to locate Geopoential height in: {input_forcings.file_in2}. Downscaling will not be available.",
                     )
-                    err_handler.log_msg(config_options, mpi_config)
 
             # close netCDF file on non-root ranks
             if mpi_config.rank != 0:
@@ -5651,19 +6387,19 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             var_tmp = None
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding ERA5-Interim input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
+                )
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -5677,8 +6413,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5689,10 +6428,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5702,8 +6442,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -5712,8 +6455,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -5725,10 +6471,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5736,10 +6483,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :, :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5756,19 +6504,19 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding ERA5-Interim input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
+                )
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -5782,8 +6530,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -5794,10 +6545,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5807,8 +6559,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -5817,8 +6572,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -5830,10 +6588,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5841,10 +6600,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5860,19 +6620,19 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding ERA5-Interim input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
+                )
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
+                    )
                     var_tmp_elem = id_tmp.variables[nc_var][:].filled(-9999.0)[
                         ind, :, :
                     ]
@@ -5890,8 +6650,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -5902,10 +6665,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5915,8 +6679,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out_elem,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -5925,8 +6692,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask_elem == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -5940,10 +6710,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -5952,10 +6723,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 ] = input_forcings.esmf_field_out_elem.data
 
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -5972,19 +6744,19 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding ERA5-Interim input variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding ERA5-Interim input variable: {nc_var}",
+                )
                 try:
-                    config_options.statusMsg = (
-                        "Using -9999. to replace missing values in input"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Using -9999. to replace missing values in input",
+                    )
                     var_tmp = id_tmp.variables[nc_var][:].filled(-9999.0)[ind, :, :]
                     # Since ERA5-Interim only supplies dew points
                     # we will need to calculate the specific humidity
@@ -5998,8 +6770,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         del e
                         del pres
                 except Exception as err:
-                    config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -6010,10 +6785,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6023,8 +6799,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input ERA5-Interim forcing variables using ESMF: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -6033,8 +6812,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     np.where(input_forcings.regridded_mask == 0)
                 ] = -9999.0
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input ERA5-Interim regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -6046,10 +6828,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on ERA5-Interim precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on ERA5-Interim precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -6057,10 +6840,11 @@ def regrid_era5(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.input_map_output[force_count], :
                 ] = input_forcings.esmf_field_out.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -6110,10 +6894,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No 13km GFS regridding required for this timestep."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No 13km GFS regridding required for this timestep.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         return
 
     # Create a temporary NetCDF file name to hold converted GRIB2 data.
@@ -6138,33 +6924,38 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regridding 13km GFS Variables."
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(
+            config_options, mpi_config, msg="Regridding 13km GFS Variables."
+        )
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0 and os.path.isfile(input_forcings.tmpFile):
-                config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
-                err_handler.log_warning(config_options, mpi_config)
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
+                )
                 try:
                     os_utils.os_remove_retry(input_forcings.tmpFile)
                 except OSError:
-                    config_options.errMsg = (
-                        f"Unable to remove file: {input_forcings.tmpFile}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove file: {input_forcings.tmpFile}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Converting 13km GFS Variable: {grib_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting 13km GFS Variable: {grib_var}",
+                    )
                 # Create a temporary NetCDF file from the GRIB2 file.
                 if grib_var == "PRATE":
                     # By far the most complicated of output variables. We need to calculate
@@ -6217,10 +7008,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing 13km GFS Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing 13km GFS Variable: {grib_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -6234,12 +7027,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating 13km GFS regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating 13km GFS regridding weights.",
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -6253,7 +7046,7 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # Read in the GFS height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #    config_options.statusMsg = "Reading in 13km GFS elevation data."
-                #    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #    err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #    "\":(HGT):(surface):\" " + \
                 #    " -netcdf " + input_forcings.tmpFileHeight
@@ -6269,8 +7062,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -6283,8 +7079,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -6297,8 +7096,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp_elem = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp_elem = mpi_config.scatter_array(
@@ -6311,8 +7113,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         try:
                             var_tmp = id_tmp.variables["HGT_surface"][0, :, :]
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract GFS elevation from: {input_forcings.tmpFile} ({err})",
+                            )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     var_sub_tmp = mpi_config.scatter_array(
@@ -6323,17 +7128,20 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local GFS array into an ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local GFS array into an ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding 13km GFS surface elevation data to the WRF-Hydro domain."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding 13km GFS surface elevation data to the WRF-Hydro domain.",
+                    )
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.esmf_field_out = (
@@ -6344,10 +7152,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid GFS elevation data: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid GFS elevation data: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -6356,8 +7165,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -6370,17 +7182,21 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh nodes: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to place local GFS array into an ESMF field: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place local GFS array into an ESMF field: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -6392,8 +7208,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid GFS elevation data with ESMF mesh elements: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -6402,8 +7221,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -6412,8 +7234,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "hydrofabric":
                     try:
@@ -6425,10 +7250,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = (
-                            f"Unable to regrid GFS elevation data: {ve}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid GFS elevation data: {ve}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -6437,23 +7263,32 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to perform mask search on GFS elevation data: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to perform mask search on GFS elevation data: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 if config_options.grid_type == "gridded":
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -6461,16 +7296,22 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract GFS elevation array from ESMF field with mesh elements: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract GFS elevation array from ESMF field: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract GFS elevation array from ESMF field: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -6497,8 +7338,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "unstructured":
                 var_tmp = None
@@ -6508,8 +7352,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_tmp_elem = None
@@ -6519,8 +7366,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 var_tmp = None
@@ -6530,8 +7380,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are regridding GFS data, and this is precipitation, we need to run calculations
@@ -6602,36 +7455,50 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             if config_options.grid_type == "unstructured":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
             elif config_options.grid_type == "hydrofabric":
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place GFS local array into ESMF element field object: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place GFS local array into ESMF element field object: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             if config_options.grid_type == "gridded":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input 13km GFS Field: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -6641,15 +7508,18 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Regridding took {end - begin} seconds"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Regridding took {end - begin} seconds",
+                        )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid GFS variable: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6658,8 +7528,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6667,10 +7540,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -6684,10 +7558,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "unstructured":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input 13km GFS Field for Mesh nodes: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -6697,15 +7573,18 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Node Regridding took {end - begin} seconds"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Node Regridding took {end - begin} seconds",
+                        )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid GFS variable for Mesh Nodes: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6714,8 +7593,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6723,10 +7605,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -6739,10 +7622,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input 13km GFS Field for Mesh elements: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out_elem = (
@@ -6754,15 +7639,18 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Element Regridding took {end - begin} seconds"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Element Regridding took {end - begin} seconds",
+                        )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid GFS variable for Mesh Elements: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6771,8 +7659,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6780,10 +7671,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -6797,10 +7689,12 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             elif config_options.grid_type == "hydrofabric":
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Input 13km GFS Field for Mesh Elements: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                 try:
                     begin = monotonic()
                     input_forcings.esmf_field_out = esmf_regridobj_call_retry_partial(
@@ -6810,15 +7704,18 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     )
                     end = monotonic()
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            f"Element Regridding took {end - begin} seconds"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Element Regridding took {end - begin} seconds",
+                        )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid GFS variable for Mesh Element: {input_forcings.netcdf_var_names[force_count]} ({ve})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -6827,8 +7724,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask search on GFS variable: {input_forcings.netcdf_var_names[force_count]} ({npe})",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -6836,10 +7736,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract GFS ESMF field data to local array: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract GFS ESMF field data to local array: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
                 # If we are on the first timestep, set the previous regridded field to be
                 # the latest as there are no states for time 0.
@@ -6857,11 +7758,11 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
             # reinstituting removal - overwriting can cause issues on some file systems
             # benefits of reuse seem unclear
@@ -6869,17 +7770,18 @@ def regrid_gfs(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -6907,8 +7809,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        config_options.statusMsg = "No regridding of NAM nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="No regridding of NAM nest data necessary for this timestep - already completed.",
+        )
         return
 
     # Create a path for a temporary NetCDF file
@@ -6922,15 +7828,17 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regridding NAM nest data"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regridding NAM nest data")
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
-                    err_handler.log_warning(config_options, mpi_config)
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
+                    )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
@@ -6940,12 +7848,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Converting NAM-Nest Variable: {grib_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting NAM-Nest Variable: {grib_var}",
+                    )
                 fields.append(
                     f":{grib_var}:{input_forcings.grib_levels[force_count]}:{input_forcings.fcst_hour2} hour fcst:"
                 )
@@ -6984,10 +7892,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing NAM Nest Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing NAM Nest Variable: {grib_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -7001,12 +7911,12 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating NAM nest regridding weights...."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating NAM nest regridding weights....",
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -7020,7 +7930,7 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in NAM nest elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -7043,15 +7953,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -7061,8 +7976,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7071,17 +7989,21 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "unstructured":
@@ -7100,15 +8022,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -7118,8 +8045,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7128,17 +8058,21 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -7156,15 +8090,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -7174,8 +8113,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7184,10 +8126,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -7195,8 +8138,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -7215,15 +8161,20 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF NAM nest elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = "Regridding NAM nest elevation data to the WRF-Hydro domain."
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding NAM nest elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -7233,8 +8184,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid NAM nest elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -7243,17 +8197,21 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on NAM nest elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on NAM nest elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded NAM nest elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -7277,17 +8235,22 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -7298,10 +8261,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7311,8 +8275,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7321,8 +8288,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7330,8 +8300,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7348,17 +8321,22 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -7369,10 +8347,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7382,8 +8361,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7392,8 +8374,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7401,8 +8386,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7418,17 +8406,22 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -7439,10 +8432,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7454,8 +8448,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7464,8 +8461,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7473,8 +8473,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7491,17 +8494,22 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding NAM nest input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -7512,10 +8520,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7525,8 +8534,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input NAM nest forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7535,8 +8547,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input NAM nest regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input NAM nest regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -7544,8 +8559,11 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -7564,26 +8582,27 @@ def regrid_nam_nest(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -7607,8 +8626,11 @@ def regrid_mrms_hourly(
     # Do we want to use MRMS data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Exceeded max hours for MRMS precipitation"
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Exceeded max hours for MRMS precipitation",
+            )
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -7625,8 +8647,12 @@ def regrid_mrms_hourly(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No MRMS regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No MRMS regridding required for this timestep.",
+            )
         return
     # MRMS data originally is stored as .gz files. We need to compose a series
     # of temporary paths.
@@ -7658,11 +8684,11 @@ def regrid_mrms_hourly(
     # alert the user, and set the final output grids to be the global NDV and return.
     if not supplemental_precip.file_in1 or not supplemental_precip.file_in2:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "No MRMS Precipitation available. Supplemental precipitation will "
-                "not be used."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="No MRMS Precipitation available. Supplemental precipitation will not be used.",
             )
-            err_handler.log_msg(config_options, mpi_config)
         supplemental_precip.regridded_precip2 = None
         supplemental_precip.regridded_precip1 = None
         if config_options.grid_type == "unstructured":
@@ -7686,8 +8712,7 @@ def regrid_mrms_hourly(
     id_mrms = None
     id_mrms_rqi = None
     try:
-        config_options.statusMsg = "Rrgrid MRMS"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Rrgrid MRMS")
 
         if supplemental_precip.file_type != NETCDF:
             # Unzip MRMS files to temporary locations.
@@ -7772,10 +8797,12 @@ def regrid_mrms_hourly(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating MRMS regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating MRMS regridding weights.",
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip, id_mrms, mrms_tmp_nc, config_options, mpi_config
             )
@@ -7791,8 +8818,11 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -7803,17 +8833,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place MRMS data into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
+                    )
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -7823,8 +8856,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7832,21 +8868,22 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
+                            )
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run mask calculation for MRMS RQI data: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             elif config_options.grid_type == "unstructured":
@@ -7857,8 +8894,11 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -7869,17 +8909,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place MRMS data into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
+                    )
                 try:
                     supplemental_precip.esmf_field_out = (
                         esmf_regridobj_call_retry_partial(
@@ -7889,8 +8932,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7898,21 +8944,22 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
+                            )
 
                     supplemental_precip.esmf_field_out.data[
                         np.where(supplemental_precip.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run mask calculation for MRMS RQI data: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_tmp_elem = None
@@ -7922,8 +8969,11 @@ def regrid_mrms_hourly(
                             supplemental_precip.rqi_netcdf_var_names[0]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract: {supplemental_precip.rqi_netcdf_var_names[0]} from: {mrms_tmp_rqi_grib2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -7934,17 +8984,20 @@ def regrid_mrms_hourly(
                 try:
                     supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place MRMS data into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place MRMS data into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding MRMS RQI Field."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding MRMS RQI Field.",
+                    )
                 try:
                     supplemental_precip.esmf_field_out_elem = (
                         esmf_regridobj_call_retry_partial(
@@ -7954,8 +9007,11 @@ def regrid_mrms_hourly(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid MRMS RQI field: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid MRMS RQI field: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -7963,21 +9019,22 @@ def regrid_mrms_hourly(
                     n_masked = len((supplemental_precip.regridded_mask_elem == 0))
                     if n_masked > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                f"{n_masked} masked cells in RQI field, will remove"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"{n_masked} masked cells in RQI field, will remove",
+                            )
 
                     supplemental_precip.esmf_field_out_elem.data[
                         np.where(supplemental_precip.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run mask calculation for MRMS RQI data: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run mask calculation for MRMS RQI data: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
         if not supplemental_precip.rqiMethod:
@@ -7991,10 +9048,12 @@ def regrid_mrms_hourly(
                 supplemental_precip.regridded_rqi2[:] = 1.0
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = "MRMS Will not be filtered using RQI values."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="MRMS Will not be filtered using RQI values.",
+                )
 
         elif supplemental_precip.rqiMethod == 2:
             # Read in the RQI field from monthly climatological files.
@@ -8025,19 +9084,22 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -8055,8 +9117,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8073,10 +9138,11 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -8094,19 +9160,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -8121,8 +9190,11 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -8140,19 +9212,22 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -8170,8 +9245,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8188,10 +9266,11 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -8209,19 +9288,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -8236,8 +9318,11 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -8254,19 +9339,22 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
+                )
                 try:
                     var_tmp_elem = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -8286,8 +9374,11 @@ def regrid_mrms_hourly(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8307,10 +9398,11 @@ def regrid_mrms_hourly(
                     # err_handler.log_warning(config_options, mpi_config)
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -8328,19 +9420,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter_elem) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            )
                     supplemental_precip.regridded_precip2_elem[ind_filter_elem] = (
                         config_options.globalNdv
                     )
                     del ind_filter_elem
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -8354,10 +9449,11 @@ def regrid_mrms_hourly(
                 )
                 del ind_valid_elem
             except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                config_options.errMsg = (
-                    f"Unable to run global NDV search on MRMS regridded precip: {npe}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -8375,19 +9471,22 @@ def regrid_mrms_hourly(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Regridding: {supplemental_precip.netcdf_var_names[0]}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding: {supplemental_precip.netcdf_var_names[0]}",
+                )
                 try:
                     var_tmp = id_mrms.variables[
                         supplemental_precip.netcdf_var_names[0]
                     ][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract: {supplemental_precip.netcdf_var_names[0]} from: {mrms_tmp_nc} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -8405,8 +9504,11 @@ def regrid_mrms_hourly(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid MRMS precipitation: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid MRMS precipitation: {ve}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and set negative precip values to 0
@@ -8423,10 +9525,11 @@ def regrid_mrms_hourly(
                 ] = config_options.globalNdv
 
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = (
-                    f"Unable to run mask search on MRMS supplemental precip: {npe}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on MRMS supplemental precip: {npe}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -8444,19 +9547,22 @@ def regrid_mrms_hourly(
                     )
                     if len(ind_filter) > 0:
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}"
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Removing {len(ind_filter)} MRMS cells below RQI threshold of {supplemental_precip.rqiThresh}",
+                            )
                     supplemental_precip.regridded_precip2[ind_filter] = (
                         config_options.globalNdv
                     )
                     del ind_filter
                 except (ValueError, AttributeError, KeyError, ArithmeticError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run MRMS RQI threshold search: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run MRMS RQI threshold search: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             if supplemental_precip.keyValue != 14:
@@ -8471,8 +9577,11 @@ def regrid_mrms_hourly(
                     )
                     del ind_valid
                 except (ValueError, AttributeError, ArithmeticError, KeyError) as npe:
-                    config_options.errMsg = f"Unable to run global NDV search on MRMS regridded precip: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run global NDV search on MRMS regridded precip: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -8492,17 +9601,21 @@ def regrid_mrms_hourly(
             try:
                 id_mrms.close()
             except OSError:
-                config_options.errMsg = f"Unable to close NetCDF file: {mrms_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {mrms_tmp_nc}",
+                )
 
         if id_mrms_rqi is not None:
             try:
                 id_mrms_rqi.close()
             except OSError:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {mrms_tmp_rqi_nc}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
 
         if mpi_config.rank == 0:
             for f in (mrms_tmp_grib2, mrms_tmp_nc, mrms_tmp_rqi_grib2, mrms_tmp_rqi_nc):
@@ -8510,8 +9623,11 @@ def regrid_mrms_hourly(
                     try:
                         os_utils.os_remove_retry(f)
                     except OSError:
-                        config_options.errMsg = f"Unable to remove scratch file: {f}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to remove scratch file: {f}",
+                        )
         mpi_config.comm.barrier()
         err_handler.check_program_status(config_options, mpi_config)
 
@@ -8576,8 +9692,11 @@ def regrid_mrms_precip_flag(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Calculating MRMS PrecipFlag regridding weights."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Calculating MRMS PrecipFlag regridding weights.",
+            )
         calculate_supp_pcp_weights(
             supplemental_precip,
             id_tmp,
@@ -8591,13 +9710,17 @@ def regrid_mrms_precip_flag(
     var_tmp = None
     if mpi_config.rank == 0:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "Regridding MRMS PrecipFlag Fraction."
-            err_handler.log_msg(config_options, mpi_config)
+            err_handler.log_msg(
+                config_options, mpi_config, msg="Regridding MRMS PrecipFlag Fraction."
+            )
         try:
             var_tmp = id_tmp.variables[supplemental_precip.netcdf_var_names[0]][0, :, :]
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
+            )
     err_handler.check_program_status(config_options, mpi_config)
 
     var_sub_tmp = mpi_config.scatter_array(supplemental_precip, var_tmp, config_options)
@@ -8611,10 +9734,11 @@ def regrid_mrms_precip_flag(
 
         supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = (
-            f"Unable to place MRMS PrecipFlag into local ESMF field: {err}"
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -8624,8 +9748,9 @@ def regrid_mrms_precip_flag(
             supplemental_precip.esmf_field_out,
         )
     except ValueError as ve:
-        config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve}"
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options, mpi_config, msg=f"Unable to regrid MRMS PrecipFlag: {ve}"
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -8637,8 +9762,11 @@ def regrid_mrms_precip_flag(
             np.where(supplemental_precip.esmf_field_out.data < 0)
         ] = 1.0
     except (ValueError, ArithmeticError) as npe:
-        config_options.errMsg = f"Unable to run mask search on MRMS PrecipFlag: {npe}"
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     supplemental_precip.regridded_precip2[:] = supplemental_precip.esmf_field_out.data
@@ -8657,15 +9785,21 @@ def regrid_mrms_precip_flag(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding MRMS PrecipFlag Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding MRMS PrecipFlag Fraction.",
+                )
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_precip.netcdf_var_names[0]
                 ][0, :, :]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract PrecipFlag from file: {supplemental_precip.file_in2} ({err})",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp_elem = mpi_config.scatter_array(
@@ -8683,10 +9817,11 @@ def regrid_mrms_precip_flag(
 
             supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = (
-                f"Unable to place MRMS PrecipFlag into local ESMF field: {err}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to place MRMS PrecipFlag into local ESMF field: {err}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -8696,8 +9831,11 @@ def regrid_mrms_precip_flag(
                 supplemental_precip.esmf_field_out_elem,
             )
         except ValueError as ve:
-            config_options.errMsg = f"Unable to regrid MRMS PrecipFlag: {ve}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to regrid MRMS PrecipFlag: {ve}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -8709,10 +9847,11 @@ def regrid_mrms_precip_flag(
                 np.where(supplemental_precip.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                f"Unable to run mask search on MRMS PrecipFlag: {npe}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to run mask search on MRMS PrecipFlag: {npe}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_precip.regridded_precip2_elem[:] = (
@@ -8733,26 +9872,27 @@ def regrid_mrms_precip_flag(
         try:
             id_tmp.close()
         except Exception as e:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {mrms_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to close NetCDF file: {mrms_tmp_nc} - {e}\n{traceback.format_exc()}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(mrms_tmp_nc)
         except FileNotFoundError:
             # File doesn't exist
-            config_options.statusMsg = (
-                f"NetCDF file not found, continuing: {mrms_tmp_nc}"
+            err_handler.log_warning(
+                config_options,
+                mpi_config,
+                msg=f"NetCDF file not found, continuing: {mrms_tmp_nc}",
             )
-            err_handler.log_warning(config_options, mpi_config)
         except Exception as e:
             # Any other exception is critical
-            config_options.errMsg = (
-                f"Unable to remove NetCDF file: {mrms_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to remove NetCDF file: {mrms_tmp_nc} - {e}\n{traceback.format_exc()}",
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -8782,8 +9922,12 @@ def regrid_hourly_wrf_arw(
     # output time step is true. This entails the necessary
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
-        config_options.statusMsg = "No regridding of WRF-ARW nest data necessary for this timestep - already completed."
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="No regridding of WRF-ARW nest data necessary for this timestep - already completed.",
+        )
         return
 
     # Create a path for a temporary NetCDF file
@@ -8798,16 +9942,18 @@ def regrid_hourly_wrf_arw(
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid WRF-ARW nest data"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid WRF-ARW nest data")
 
         if input_forcings.file_type != NETCDF:
             # This file shouldn't exist.... but if it does (previously failed
             # execution of the program), remove it.....
             if mpi_config.rank == 0:
                 if os.path.isfile(input_forcings.tmpFile):
-                    config_options.statusMsg = f"Found old temporary file: {input_forcings.tmpFile} - Removing....."
-                    err_handler.log_warning(config_options, mpi_config)
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {input_forcings.tmpFile} - Removing.....",
+                    )
                     try:
                         os_utils.os_remove_retry(input_forcings.tmpFile)
                     except OSError:
@@ -8817,12 +9963,12 @@ def regrid_hourly_wrf_arw(
             fields = []
             for force_count, grib_var in enumerate(input_forcings.grib_vars):
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Converting WRF-ARW Variable: {grib_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Converting WRF-ARW Variable: {grib_var}",
+                    )
                 time_str = (
                     f"{input_forcings.fcst_hour1}-{input_forcings.fcst_hour2} hour acc fcst"
                     if grib_var == "APCP"
@@ -8866,10 +10012,12 @@ def regrid_hourly_wrf_arw(
         # array slice in the output arrays.
         for force_count, grib_var in enumerate(input_forcings.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing WRF-ARW Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing WRF-ARW Variable: {grib_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -8883,12 +10031,12 @@ def regrid_hourly_wrf_arw(
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        "Calculating WRF-ARW regridding weights...."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating WRF-ARW regridding weights....",
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -8902,7 +10050,7 @@ def regrid_hourly_wrf_arw(
                 # Read in the RAP height field, which is used for downscaling purposes.
                 # if mpi_config.rank == 0:
                 #     config_options.statusMsg = "Reading in WRF-ARW elevation data from GRIB2."
-                #     err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+                #     err_handler.log_msg(config_options, mpi_config, True)
                 # cmd = "$WGRIB2 " + input_forcings.file_in2 + " -match " + \
                 #       "\":(HGT):(surface):\" " + \
                 #       " -netcdf " + input_forcings.tmpFileHeight
@@ -8925,17 +10073,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -8945,8 +10096,11 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -8955,17 +10109,21 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:, :] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
                 elif config_options.grid_type == "unstructured":
                     # Regrid the height variable.
@@ -8983,17 +10141,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -9003,8 +10164,11 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -9013,17 +10177,21 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Regrid the height variable.
@@ -9041,17 +10209,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out_elem = (
                             esmf_regridobj_call_retry_partial(
@@ -9061,8 +10232,11 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -9071,10 +10245,11 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask_elem == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
@@ -9082,8 +10257,11 @@ def regrid_hourly_wrf_arw(
                             input_forcings.esmf_field_out_elem.data
                         )
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 elif config_options.grid_type == "hydrofabric":
@@ -9102,17 +10280,20 @@ def regrid_hourly_wrf_arw(
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place NetCDF WRF-ARW elevation data into the ESMF field object: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     if mpi_config.rank == 0:
-                        config_options.statusMsg = (
-                            "Regridding WRF-ARW elevation data to the WRF-Hydro domain."
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Regridding WRF-ARW elevation data to the WRF-Hydro domain.",
+                        )
                     try:
                         input_forcings.esmf_field_out = (
                             esmf_regridobj_call_retry_partial(
@@ -9122,8 +10303,11 @@ def regrid_hourly_wrf_arw(
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid WRF-ARW elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     # Set any pixel cells outside the input domain to the global missing value.
@@ -9132,17 +10316,21 @@ def regrid_hourly_wrf_arw(
                             np.where(input_forcings.regridded_mask == 0)
                         ] = config_options.globalNdv
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = (
-                            f"Unable to compute mask on WRF-ARW elevation data: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to compute mask on WRF-ARW elevation data: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                     try:
                         input_forcings.height[:] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract ESMF regridded WRF-ARW elevation data to a local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 # Close the temporary NetCDF file and remove it.
@@ -9166,17 +10354,22 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9187,10 +10380,11 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9200,8 +10394,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9210,8 +10407,11 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -9231,10 +10431,11 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9242,8 +10443,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -9260,17 +10464,22 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9281,10 +10490,11 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9294,8 +10504,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9304,8 +10517,11 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -9325,10 +10541,11 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9336,8 +10553,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -9353,17 +10573,22 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp_elem = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp_elem = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9374,10 +10599,11 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9389,8 +10615,11 @@ def regrid_hourly_wrf_arw(
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9399,8 +10628,11 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -9421,10 +10653,11 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9432,8 +10665,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -9450,17 +10686,22 @@ def regrid_hourly_wrf_arw(
                 # Regrid the input variables.
                 var_tmp = None
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding WRF-ARW input variable: {input_forcings.netcdf_var_names[force_count]}",
+                    )
                     try:
                         var_tmp = id_tmp.variables[
                             input_forcings.netcdf_var_names[force_count]
                         ][0, :, :]
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -9471,10 +10712,11 @@ def regrid_hourly_wrf_arw(
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9484,8 +10726,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input WRF-ARW forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -9494,8 +10739,11 @@ def regrid_hourly_wrf_arw(
                         np.where(input_forcings.regridded_mask == 0)
                     ] = config_options.globalNdv
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input WRF-ARW regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -9515,10 +10763,11 @@ def regrid_hourly_wrf_arw(
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = (
-                            f"Unable to run NDV search on WRF ARW precipitation: {npe}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on WRF ARW precipitation: {npe}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -9526,8 +10775,11 @@ def regrid_hourly_wrf_arw(
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -9546,26 +10798,27 @@ def regrid_hourly_wrf_arw(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(input_forcings.tmpFile)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {input_forcings.tmpFile} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
     # noinspection PyUnreachableCode
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -9596,8 +10849,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
     # inputs have already been regridded and we can move on.
     if supplemental_precip.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No ARW regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No ARW regridding required for this timestep.",
+            )
         return
 
     # Create a path for a temporary NetCDF files that will
@@ -9608,17 +10865,17 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
     id_tmp = None
     try:
-        config_options.statusMsg = "Regrid ARW"
-        err_handler.log_msg(config_options, mpi_config)
+        err_handler.log_msg(config_options, mpi_config, msg="Regrid ARW")
 
         if supplemental_precip.file_type != NETCDF:
             # These files shouldn't exist. If they do, remove them.
             if mpi_config.rank == 0:
                 if os.path.isfile(arw_tmp_nc):
-                    config_options.statusMsg = (
-                        f"Found old temporary file: {arw_tmp_nc} - Removing....."
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"Found old temporary file: {arw_tmp_nc} - Removing.....",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     try:
                         os_utils.os_remove_retry(arw_tmp_nc)
                     except IOError:
@@ -9669,10 +10926,12 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
 
         if calc_regrid_flag:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Calculating WRF ARW regridding weights."
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Calculating WRF ARW regridding weights.",
+                )
             calculate_supp_pcp_weights(
                 supplemental_precip, id_tmp, arw_tmp_nc, config_options, mpi_config
             )
@@ -9683,15 +10942,20 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9702,8 +10966,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -9713,10 +10980,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -9725,8 +10993,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:, :] = (
@@ -9744,8 +11015,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9761,15 +11035,20 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9780,8 +11059,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -9791,10 +11073,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -9803,8 +11086,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -9822,8 +11108,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9838,15 +11127,20 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp_elem = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
+                    )
                 try:
                     var_tmp_elem = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -9857,8 +11151,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -9870,10 +11167,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -9882,8 +11180,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2_elem[:] = (
@@ -9902,8 +11203,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid_elem
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9919,15 +11223,20 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             var_tmp = None
             if mpi_config.rank == 0:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Regridding WRF ARW APCP Precipitation."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Regridding WRF ARW APCP Precipitation.",
+                    )
                 try:
                     var_tmp = id_tmp.variables["APCP_surface"][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract precipitation from WRF ARW file: {supplemental_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -9938,8 +11247,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 supplemental_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to place WRF ARW precipitation into local ESMF field: {err}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place WRF ARW precipitation into local ESMF field: {err}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -9949,10 +11261,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     supplemental_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid WRF ARW supplemental precipitation: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid WRF ARW supplemental precipitation: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -9961,8 +11274,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                     np.where(supplemental_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             supplemental_precip.regridded_precip2[:] = (
@@ -9980,8 +11296,11 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
                 )
                 del ind_valid
             except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                config_options.errMsg = f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run NDV search on WRF ARW supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -9998,26 +11317,27 @@ def regrid_hourly_wrf_arw_hi_res_pcp(
             try:
                 id_tmp.close()
             except Exception as e:
-                config_options.errMsg = (
-                    f"Unable to close NetCDF file: {arw_tmp_nc} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to close NetCDF file: {arw_tmp_nc} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(arw_tmp_nc)
             except FileNotFoundError:
                 # File doesn't exist
-                config_options.statusMsg = (
-                    f"NetCDF file not found, continuing: {arw_tmp_nc}"
+                err_handler.log_warning(
+                    config_options,
+                    mpi_config,
+                    msg=f"NetCDF file not found, continuing: {arw_tmp_nc}",
                 )
-                err_handler.log_warning(config_options, mpi_config)
             except Exception as e:
                 # Any other exception is critical
-                config_options.errMsg = (
-                    f"Unable to remove NetCDF file: {arw_tmp_nc} - {e}\n"
-                    f"{traceback.format_exc()}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove NetCDF file: {arw_tmp_nc} - {e}\n{traceback.format_exc()}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -10060,10 +11380,12 @@ def regrid_sbcv2_liquid_water_fraction(
 
     if calc_regrid_flag:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Calculating SBCv2 Liquid Water Fraction regridding weights."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="Calculating SBCv2 Liquid Water Fraction regridding weights.",
             )
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
         calculate_supp_pcp_weights(
             supplemental_forcings,
             id_tmp,
@@ -10080,13 +11402,19 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = "Regridding SBCv2 Liquid Water Fraction."
-                err_handler.log_msg(config_options, mpi_config)
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding SBCv2 Liquid Water Fraction.",
+                )
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -10099,8 +11427,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -10110,10 +11441,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10125,10 +11457,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -10149,17 +11482,20 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction - unstructured"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding SBCv2 Liquid Water Fraction - unstructured",
+                )
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -10172,8 +11508,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -10183,10 +11522,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10198,10 +11538,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -10221,19 +11562,22 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp_elem = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction input variable."
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg="Regridding SBCv2 Liquid Water Fraction input variable.",
+                )
             try:
                 var_tmp_elem = id_tmp.variables[
                     supplemental_forcings.netcdf_var_names[0]
                 ][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp_elem = mpi_config.scatter_array(
@@ -10246,8 +11590,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp_elem / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -10259,10 +11606,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 )
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10274,10 +11622,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out_elem.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2_elem[:] = (
@@ -10298,15 +11647,19 @@ def regrid_sbcv2_liquid_water_fraction(
         var_tmp = None
         if mpi_config.rank == 0:
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    "Regridding SBCv2 Liquid Water Fraction - hydrofabric"
+                err_handler.log_msg(
+                    config_options,
+                    mpi_config,
+                    msg="Regridding SBCv2 Liquid Water Fraction - hydrofabric",
                 )
-                err_handler.log_msg(config_options, mpi_config)
             try:
                 var_tmp = id_tmp.variables[supplemental_forcings.netcdf_var_names[0]][:]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract Liquid Water Fraction from SBCv2 file: {supplemental_forcings.file_in1} ({err})",
+                )
         err_handler.check_program_status(config_options, mpi_config)
 
         var_sub_tmp = mpi_config.scatter_array(
@@ -10319,8 +11672,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 var_sub_tmp / 100.0
             )  # convert from 0-100 to 0-1.0
         except (ValueError, KeyError, AttributeError) as err:
-            config_options.errMsg = f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to place SBCv2 Liquid Water Fraction into local ESMF field: {err}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         try:
@@ -10330,10 +11686,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 supplemental_forcings.esmf_field_out,
             )
         except ValueError as ve:
-            config_options.errMsg = (
-                f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to regrid SBCv2 Liquid Water Fraction: {ve}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         # Set any missing data or pixel cells outside the input domain to a default of 100%
@@ -10345,10 +11702,11 @@ def regrid_sbcv2_liquid_water_fraction(
                 np.where(supplemental_forcings.esmf_field_out.data < 0)
             ] = 1.0
         except (ValueError, ArithmeticError) as npe:
-            config_options.errMsg = (
-                f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to run mask search on SBCv2 Liquid Water Fraction: {npe}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         err_handler.check_program_status(config_options, mpi_config)
 
         supplemental_forcings.regridded_precip2[:] = (
@@ -10369,10 +11727,11 @@ def regrid_sbcv2_liquid_water_fraction(
         try:
             id_tmp.close()
         except OSError:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {supplemental_forcings.file_in1}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to close NetCDF file: {supplemental_forcings.file_in1}",
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -10395,10 +11754,11 @@ def regrid_hourly_nbm(
     # Do we want to use NBM data at this timestep? If not, log and continue
     if not config_options.use_data_at_current_time:
         if mpi_config.rank == 0:
-            config_options.statusMsg = (
-                "Exceeded max hours for NBM data, will not use NBM in final layering."
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                msg="Exceeded max hours for NBM data, will not use NBM in final layering.",
             )
-            err_handler.log_msg(config_options, mpi_config)
         return
 
     # If the expected file is missing, this means we are allowing missing files, simply
@@ -10418,25 +11778,31 @@ def regrid_hourly_nbm(
 
     if mpi_config.rank == 0:
         if os.path.isfile(nbm_tmp_nc):
-            config_options.statusMsg = (
-                f"Found old temporary file: {nbm_tmp_nc} - Removing....."
+            err_handler.log_warning(
+                config_options,
+                mpi_config,
+                msg=f"Found old temporary file: {nbm_tmp_nc} - Removing.....",
             )
-            err_handler.log_warning(config_options, mpi_config)
             try:
                 os_utils.os_remove_retry(nbm_tmp_nc)
             except OSError:
-                config_options.errMsg = f"Unable to remove file: {nbm_tmp_nc}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to remove file: {nbm_tmp_nc}",
+                )
     err_handler.check_program_status(config_options, mpi_config)
 
     if forcings_or_precip.grib_vars is not None:
         fields = []
         for force_count, grib_var in enumerate(forcings_or_precip.grib_vars):
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Converting NBM Variable: {grib_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Converting NBM Variable: {grib_var}",
+                )
             time_str = (
                 f"{forcings_or_precip.fcst_hour1}-{forcings_or_precip.fcst_hour2} hour acc fcst"
                 if grib_var == "APCP"
@@ -10469,13 +11835,16 @@ def regrid_hourly_nbm(
 
     err_handler.check_program_status(config_options, mpi_config)
 
-    config_options.statusMsg = "Processing NBM Variables"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(config_options, mpi_config, msg="Processing NBM Variables")
 
     for force_count, nc_var in enumerate(forcings_or_precip.netcdf_var_names):
         if mpi_config.rank == 0:
-            config_options.statusMsg = f"Processing NBM Variable: {nc_var}"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Processing NBM Variable: {nc_var}",
+            )
 
         # Check to see if we need to calculate regridding weights.
         is_supp = forcings_or_precip.grib_vars is None
@@ -10503,12 +11872,12 @@ def regrid_hourly_nbm(
         if calc_regrid_flag:
             if is_supp:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Calculating NBM {tag} regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Calculating NBM {tag} regridding weights.",
+                    )
                 calculate_supp_pcp_weights(
                     forcings_or_precip,
                     id_tmp,
@@ -10519,12 +11888,12 @@ def regrid_hourly_nbm(
                 err_handler.check_program_status(config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Calculating NBM {tag} regridding weights."
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Calculating NBM {tag} regridding weights.",
+                    )
                 calculate_weights(
                     id_tmp,
                     force_count,
@@ -10537,15 +11906,19 @@ def regrid_hourly_nbm(
 
                 # Regrid the height variable.
                 if config_options.grid_meta is None:
-                    config_options.errMsg = (
-                        "No NBM height file supplied, downscaling will not be available"
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg="No NBM height file supplied, downscaling will not be available",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
                 else:
                     if not os.path.exists(config_options.grid_meta):
-                        config_options.errMsg = 'NBM height file "{config_options.grid_meta}" does not exist'
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg='NBM height file "{config_options.grid_meta}" does not exist',
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                     terrain_tmp = os.path.join(
@@ -10575,17 +11948,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -10595,8 +11971,11 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -10605,10 +11984,11 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on NBM elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -10616,8 +11996,11 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -10637,17 +12020,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -10657,8 +12043,11 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -10667,10 +12056,11 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on NBM elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -10678,8 +12068,11 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -10699,17 +12092,20 @@ def regrid_hourly_nbm(
                         try:
                             forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = (
-                                "Regridding NBM elevation data to the WRF-Hydro domain."
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the WRF-Hydro domain.",
+                            )
                         try:
                             forcings_or_precip.esmf_field_out = (
                                 esmf_regridobj_call_retry_partial(
@@ -10719,8 +12115,11 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid NBM elevation data to the WRF-Hydro domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -10729,10 +12128,11 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = (
-                                f"Unable to compute mask on NBM elevation data: {npe}"
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute mask on NBM elevation data: {npe}",
                             )
-                            err_handler.log_critical(config_options, mpi_config)
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -10740,8 +12140,11 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -10760,15 +12163,20 @@ def regrid_hourly_nbm(
                                 var_sub_tmp_elem
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to place NBM elevation data into the ESMF field object: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to place NBM elevation data into the ESMF field object: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
-                            config_options.statusMsg = "Regridding NBM elevation data to the unstructured domain."
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg="Regridding NBM elevation data to the unstructured domain.",
+                            )
                         try:
                             forcings_or_precip.esmf_field_out_elem = (
                                 esmf_regridobj_call_retry_partial(
@@ -10778,8 +12186,11 @@ def regrid_hourly_nbm(
                                 )
                             )
                         except ValueError as ve:
-                            config_options.errMsg = f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to regrid NBM elevation data to the unstructured domain using ESMF: {ve}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         # Set any pixel cells outside the input domain to the global missing value.
@@ -10788,8 +12199,11 @@ def regrid_hourly_nbm(
                                 np.where(forcings_or_precip.regridded_mask_elem == 0)
                             ] = config_options.globalNdv
                         except (ValueError, ArithmeticError) as npe:
-                            config_options.errMsg = f"Unable to compute element mask on NBM elevation data: {npe}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to compute element mask on NBM elevation data: {npe}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         try:
@@ -10797,8 +12211,11 @@ def regrid_hourly_nbm(
                                 forcings_or_precip.esmf_field_out_elem.data
                             )
                         except (ValueError, KeyError, AttributeError) as err:
-                            config_options.errMsg = f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract ESMF regridded NBM elevation data to a local array: {err}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                         if mpi_config.rank == 0:
@@ -10808,15 +12225,20 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -10827,10 +12249,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -10840,8 +12263,9 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options, mpi_config, msg=f"Unable to regrid NBM {tag}: {ve}"
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value.
@@ -10850,8 +12274,11 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -10885,10 +12312,11 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -10900,15 +12328,20 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -10919,10 +12352,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -10932,8 +12366,9 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options, mpi_config, msg=f"Unable to regrid NBM {tag}: {ve}"
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -10941,8 +12376,11 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -10976,10 +12414,11 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -10991,15 +12430,20 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
+                )
                 try:
                     var_tmp = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11010,10 +12454,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in.data[:, :] = var_sub_tmp
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11023,8 +12468,9 @@ def regrid_hourly_nbm(
                     forcings_or_precip.esmf_field_out,
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options, mpi_config, msg=f"Unable to regrid NBM {tag}: {ve}"
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -11032,8 +12478,11 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1 = (
@@ -11067,10 +12516,11 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11082,15 +12532,20 @@ def regrid_hourly_nbm(
             # Regrid the input variables.
             var_tmp_elem = None
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Regridding NBM {nc_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Regridding NBM {nc_var}",
+                )
                 try:
                     var_tmp_elem = id_tmp.variables[nc_var][0, :, :]
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract data from NBM file: {forcings_or_precip.file_in1} ({err})",
+                    )
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp_elem = mpi_config.scatter_array(
@@ -11101,10 +12556,11 @@ def regrid_hourly_nbm(
             try:
                 forcings_or_precip.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place NBM {tag} into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place NBM {tag} into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11116,8 +12572,9 @@ def regrid_hourly_nbm(
                     )
                 )
             except ValueError as ve:
-                config_options.errMsg = f"Unable to regrid NBM {tag}: {ve}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options, mpi_config, msg=f"Unable to regrid NBM {tag}: {ve}"
+                )
             err_handler.check_program_status(config_options, mpi_config)
             # Set any pixel cells outside the input domain to the global missing value.
             try:
@@ -11125,8 +12582,11 @@ def regrid_hourly_nbm(
                     np.where(forcings_or_precip.regridded_mask_elem == 0)
                 ] = config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to run mask search on NBM supplemental precipitation: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to run mask search on NBM supplemental precipitation: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             destination1_elem = (
@@ -11164,10 +12624,11 @@ def regrid_hourly_nbm(
                         )  # uniform disaggregation for 6-hourly nbm data
                     del ind_valid_elem
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NBM precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NBM precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             # If we are on the first timestep, set the previous regridded field to be
@@ -11181,19 +12642,19 @@ def regrid_hourly_nbm(
         try:
             id_tmp.close()
         except Exception as e:
-            config_options.errMsg = (
-                f"Unable to close NetCDF file: {nbm_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to close NetCDF file: {nbm_tmp_nc} - {e}\n{traceback.format_exc()}",
             )
-            err_handler.log_critical(config_options, mpi_config)
         try:
             os_utils.os_remove_retry(nbm_tmp_nc)
         except Exception as e:
-            config_options.errMsg = (
-                f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc} - {e}\n"
-                f"{traceback.format_exc()}"
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to remove temporary NBM NetCDF file: {nbm_tmp_nc} - {e}\n{traceback.format_exc()}",
             )
-            err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -11209,12 +12670,15 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
     # inputs have already been regridded and we can move on.
     if input_forcings.regridComplete:
         if mpi_config.rank == 0:
-            config_options.statusMsg = "No NDFD regridding required for this timestep."
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg="No NDFD regridding required for this timestep.",
+            )
         return
 
-    config_options.statusMsg = "Regrid NDFD"
-    err_handler.log_msg(config_options, mpi_config)
+    err_handler.log_msg(config_options, mpi_config, msg="Regrid NDFD")
 
     hour = input_forcings.fcst_hour2
     current_cycle = config_options.current_fcst_cycle
@@ -11240,41 +12704,45 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
         # Temp file may exist. If it does, and we don't need it again, remove it.....
         if not reuse_prev_file and mpi_config.rank == 0:
             if os.path.isfile(tmp_file):
-                config_options.statusMsg = f"Deleting old temporary file: {tmp_file}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Deleting old temporary file: {tmp_file}",
+                )
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except OSError:
-                    config_options.errMsg = f"Unable to remove file: {tmp_file}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove file: {tmp_file}",
+                    )
         err_handler.check_program_status(config_options, mpi_config)
 
         id_tmp = None
         try:
             if reuse_prev_file:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Cycle unchanged, reusing temporary file: {tmp_file}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Cycle unchanged, reusing temporary file: {tmp_file}",
+                    )
                 id_tmp = ioMod.open_netcdf_forcing(tmp_file, config_options, mpi_config)
             else:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}"
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"New forecast cycle, creating temporary file from: {grb_file}, cycle hour {current_cycle.hour}",
+                    )
                 if not WGRIB2_env:
                     cmd = [f":d={current_cycle.strftime('%Y%m%d%H')}:"]
                 else:
-                    cmd = (
-                        f"$WGRIB2 -match :d={current_cycle.strftime('%Y%m%d%H')}: -vt {grb_file} | "
-                        f"sort -t = -k 2 | $WGRIB2 -i -netcdf {tmp_file} {grb_file}"
-                    )
+                    cmd = f"$WGRIB2 -match :d={current_cycle.strftime('%Y%m%d%H')}: -vt {grb_file} | sort -t = -k 2 | $WGRIB2 -i -netcdf {tmp_file} {grb_file}"
                 id_tmp = ioMod.open_grib2(
                     grb_file,
                     tmp_file,
@@ -11291,44 +12759,50 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 times = [datetime.utcfromtimestamp(t) for t in id_tmp["time"][:]]
                 if ndfd_var != "qpf":
                     if forecast_time > times[-1] + timedelta(hours=3):
-                        config_options.statusMsg = (
-                            "Forecast time beyond NDFD range, skipping"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Forecast time beyond NDFD range, skipping",
+                        )
                         skip_file = 1
                     elif forecast_time in times:
                         time_index = times.index(forecast_time)
-                        config_options.statusMsg = f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Found exact time {forecast_time} in NDFD file at index {time_index} for variable {ndfd_var}",
+                        )
                     else:
                         time_index = min(
                             range(len(times)),
                             key=lambda i: abs(times[i] - forecast_time),
                         )
-                        config_options.statusMsg = f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Exact time {forecast_time} not found in NDFD file, using closest time at {times[time_index]}",
+                        )
                 else:
                     # TODO: qpf special handling
                     if forecast_time > times[-1] - timedelta(hours=6):
-                        config_options.statusMsg = (
-                            "Forecast time beyond NDFD precip range, skipping"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg="Forecast time beyond NDFD precip range, skipping",
+                        )
                         skip_file = 1
                     else:
                         time_index = int(hour // 6)
-                        config_options.statusMsg = f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}"
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Forecast hour {forecast_time} will use precip from {times[time_index] - timedelta(hours=6)} to {times[time_index]}",
+                        )
 
             skip_file = mpi_config.broadcast_parameter(
                 skip_file, config_options, param_type=np.ubyte
@@ -11354,10 +12828,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 continue
 
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Processing NDFD variable: {ndfd_var}"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing NDFD variable: {ndfd_var}",
+                )
 
             calc_regrid_flag = check_regrid_status(
                 id_tmp,
@@ -11371,10 +12847,12 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
 
             if calc_regrid_flag:
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = "Calculating NDFD regridding weights."
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg="Calculating NDFD regridding weights.",
+                    )
                 calculate_weights(
                     id_tmp,
                     i,
@@ -11400,11 +12878,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         ][time_index, :, :]
                         var_tmp_elem = var_tmp_elem.filled(config_options.globalNdv)
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} "
-                        f"from: {input_forcings.tmpFile} ({err})"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to extract NDFD variable: {input_forcings.netcdf_var_names[i]} from: {input_forcings.tmpFile} ({err})",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             var_sub_tmp = mpi_config.scatter_array(
@@ -11427,10 +12905,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     input_forcings.esmf_field_in_elem.data[:] = var_sub_tmp_elem
                 # DEBUG if mpi_config.rank == 1: LOG.debug(f"esmf_file_in has type: {type(input_forcings.esmf_field_in.data)}, var_sub_tmp has type: {type(var_sub_tmp)}")
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local array into local ESMF field: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local array into local ESMF field: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11448,10 +12927,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     )
             except ValueError as ve:
-                config_options.errMsg = (
-                    f"Unable to regrid input NDFD forcing variable using ESMF: {ve}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to regrid input NDFD forcing variable using ESMF: {ve}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
             # Set any pixel cells outside the input domain to the global missing value, and fix missings that were interpolated
@@ -11466,8 +12946,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 # input_forcings.esmf_field_out.data[np.where((input_forcings.esmf_field_out.data/config_options.globalNdv) > 0.75)] = \
                 #     config_options.globalNdv
             except (ValueError, ArithmeticError) as npe:
-                config_options.errMsg = f"Unable to calculate mask from input NDFD regridded forcings: {npe}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to calculate mask from input NDFD regridded forcings: {npe}",
+                )
             err_handler.check_program_status(config_options, mpi_config)
 
             # If processing wind speed, calculate final U2 / V2 fields
@@ -11518,8 +13001,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                     AttributeError,
                     KeyError,
                 ) as npe:
-                    config_options.errMsg = f"Unable to convert NDFD wind speed/dir to U/V components: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to convert NDFD wind speed/dir to U/V components: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
             # Convert the hourly precipitation total to a rate of mm/s
@@ -11541,10 +13027,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         )
                     del ind_valid
                 except (ValueError, ArithmeticError, AttributeError, KeyError) as npe:
-                    config_options.errMsg = (
-                        f"Unable to run NDV search on NDFD QPF precipitation: {npe}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to run NDV search on NDFD QPF precipitation: {npe}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
             try:
@@ -11564,10 +13051,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                         input_forcings.input_map_output[i], :
                     ] = input_forcings.esmf_field_out_elem.data
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = (
-                    f"Unable to place local ESMF regridded data into local array: {err}"
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to place local ESMF regridded data into local array: {err}",
                 )
-                err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
         finally:
             # always close the NetCDF handle
@@ -11575,10 +13063,11 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     id_tmp.close()
                 except OSError as e:
-                    config_options.errMsg = (
-                        f"Unable to close NDFD temp file {tmp_file}: {e}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to close NDFD temp file {tmp_file}: {e}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
 
             # only remove the scratch file if this was a new‐cycle run
             if (
@@ -11589,17 +13078,18 @@ def regrid_ndfd(input_forcings, config_options, wrf_hydro_geo_meta, mpi_config):
                 try:
                     os_utils.os_remove_retry(tmp_file)
                 except FileNotFoundError:
-                    config_options.statusMsg = (
-                        f"NetCDF file not found, continuing: {input_forcings.tmpFile}"
+                    err_handler.log_warning(
+                        config_options,
+                        mpi_config,
+                        msg=f"NetCDF file not found, continuing: {input_forcings.tmpFile}",
                     )
-                    err_handler.log_warning(config_options, mpi_config)
 
                 except Exception as e:
-                    config_options.errMsg = (
-                        f"Unable to remove scratch file {tmp_file}: {e}\n"
-                        f"{traceback.format_exc()}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to remove scratch file {tmp_file}: {e}\n{traceback.format_exc()}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
             err_handler.check_program_status(config_options, mpi_config)
 
 
@@ -11623,18 +13113,22 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
         mpi_config.comm.barrier()
         id_tmp = config_options.aws_obj
 
-        config_options.statusMsg = "Processing Custom NetCDF Forcing Variables"
-        err_handler.log_msg(config_options, mpi_config, True)
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg="Processing Custom NetCDF Forcing Variables",
+        )
 
     with timing_block(f"regrid step 2 | {mpi_config.rank}: loop over variables"):
         for force_count, nc_var in enumerate(input_forcings.netcdf_var_names):
             if mpi_config.rank == 0:
-                config_options.statusMsg = (
-                    f"Processing Custom NetCDF Forcing Variable: {nc_var}"
-                )
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Processing Custom NetCDF Forcing Variable: {nc_var}",
+                )
             with timing_block(
                 f"regrid step 2.1 | {mpi_config.rank}: check regrid status"
             ):
@@ -11680,23 +13174,26 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -11707,10 +13204,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11720,8 +13218,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -11730,8 +13231,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -11749,8 +13253,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11758,8 +13265,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :, :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -11779,23 +13289,26 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp = mpi_config.scatter_array(
@@ -11806,10 +13319,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11819,8 +13333,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.esmf_field_out,
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -11829,8 +13346,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -11847,8 +13367,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11856,8 +13379,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -11876,23 +13402,26 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     input_forcings.grib_vars[force_count], config_options.globalNdv
                 )
                 if mpi_config.rank == 0:
-                    config_options.statusMsg = (
-                        f"Regridding Custom netCDF input variable: {nc_var}"
-                    )
                     err_handler.log_msg(
-                        config_options, mpi_config, True
-                    )  # log at debug level
+                        config_options,
+                        mpi_config,
+                        debug=True,
+                        msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                    )
                     try:
-                        config_options.statusMsg = (
-                            f"Using {fill} to replace missing values in input"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Using {fill} to replace missing values in input",
+                        )
                         var_tmp_elem = id_tmp[nc_var].to_masked_array().filled(fill)
                     except Exception as err:
-                        config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({err})",
+                        )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 var_sub_tmp_elem = mpi_config.scatter_array(
@@ -11903,10 +13432,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                 try:
                     input_forcings.esmf_field_in_elem.data[:, :] = var_sub_tmp_elem
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = (
-                        f"Unable to place local array into local ESMF field: {err}"
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local array into local ESMF field: {err}",
                     )
-                    err_handler.log_critical(config_options, mpi_config)
                 err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11918,8 +13448,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         )
                     )
                 except ValueError as ve:
-                    config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Set any pixel cells outside the input domain to the global missing value.
@@ -11928,8 +13461,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         np.where(input_forcings.regridded_mask_elem == 0)
                     ] = fill
                 except (ValueError, ArithmeticError) as npe:
-                    config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # Convert the hourly precipitation total to a rate of mm/s
@@ -11949,8 +13485,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         AttributeError,
                         KeyError,
                     ) as npe:
-                        config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 try:
@@ -11958,8 +13497,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         input_forcings.input_map_output[force_count], :
                     ] = input_forcings.esmf_field_out_elem.data
                 except (ValueError, KeyError, AttributeError) as err:
-                    config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                    err_handler.log_critical(config_options, mpi_config)
+                    err_handler.log_critical(
+                        config_options,
+                        mpi_config,
+                        msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                    )
                 err_handler.check_program_status(config_options, mpi_config)
 
                 # If we are on the first timestep, set the previous regridded field to be
@@ -11986,22 +13528,22 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     with timing_block(
                         f"regrid step 2.5.1 | {mpi_config.rank}: regrid messages"
                     ):
-                        config_options.statusMsg = (
-                            f"Regridding Custom netCDF input variable: {nc_var}"
-                        )
                         err_handler.log_msg(
-                            config_options, mpi_config, True
-                        )  # log at debug level
+                            config_options,
+                            mpi_config,
+                            debug=True,
+                            msg=f"Regridding Custom netCDF input variable: {nc_var}",
+                        )
                     try:
                         with timing_block(
                             f"regrid step 2.5.2 | {mpi_config.rank}: messages2"
                         ):
-                            config_options.statusMsg = (
-                                f"Using {fill} to replace missing values in input"
-                            )
                             err_handler.log_msg(
-                                config_options, mpi_config, True
-                            )  # log at debug level
+                                config_options,
+                                mpi_config,
+                                debug=True,
+                                msg=f"Using {fill} to replace missing values in input",
+                            )
                         with timing_block(
                             f"regrid step 2.5.3 | {mpi_config.rank}: fill missing"
                         ):
@@ -12011,8 +13553,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                         with timing_block(
                             f"regrid step 2.5.4 | {mpi_config.rank}: extract error"
                         ):
-                            config_options.errMsg = f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to extract {nc_var} from: {input_forcings.file_in2} ({str(err)})",
+                            )
 
                 with timing_block(
                     f"regrid step 2.5.5 | {mpi_config.rank}: check program status"
@@ -12032,10 +13577,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                     try:
                         input_forcings.esmf_field_in.data[:, :] = var_sub_tmp
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = (
-                            f"Unable to place local array into local ESMF field: {err}"
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place local array into local ESMF field: {err}",
                         )
-                        err_handler.log_critical(config_options, mpi_config)
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -12050,8 +13596,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             )
                         )
                     except ValueError as ve:
-                        config_options.errMsg = f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to regrid input Custom netCDF forcing variables using ESMF: {ve}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -12063,8 +13612,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             np.where(input_forcings.regridded_mask == 0)
                         ] = fill
                     except (ValueError, ArithmeticError) as npe:
-                        config_options.errMsg = f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to calculate mask from input Custom netCDF regridded forcings: {npe}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -12090,8 +13642,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             AttributeError,
                             KeyError,
                         ) as npe:
-                            config_options.errMsg = f"Unable to run NDV search on Custom netCDF precipitation: {npe}"
-                            err_handler.log_critical(config_options, mpi_config)
+                            err_handler.log_critical(
+                                config_options,
+                                mpi_config,
+                                msg=f"Unable to run NDV search on Custom netCDF precipitation: {npe}",
+                            )
                         err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -12102,8 +13657,11 @@ def regrid_aorc_aws(input_forcings, config_options, wrf_hydro_geo_meta, mpi_conf
                             input_forcings.input_map_output[force_count], :
                         ] = input_forcings.esmf_field_out.data
                     except (ValueError, KeyError, AttributeError) as err:
-                        config_options.errMsg = f"Unable to place local ESMF regridded data into local array: {err}"
-                        err_handler.log_critical(config_options, mpi_config)
+                        err_handler.log_critical(
+                            config_options,
+                            mpi_config,
+                            msg=f"Unable to place local ESMF regridded data into local array: {err}",
+                        )
                     err_handler.check_program_status(config_options, mpi_config)
 
                 with timing_block(
@@ -12148,8 +13706,11 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field object: {esmf_error}",
+                )
 
         elif config_options.grid_type == "unstructured":
             try:
@@ -12159,8 +13720,11 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field node mesh object: {esmf_error}",
+                )
             try:
                 input_forcings.esmf_field_out_elem = esmf_field_retry_partial(
                     wrf_hydro_geo_meta.esmf_grid,
@@ -12168,8 +13732,11 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
+                )
         elif config_options.grid_type == "hydrofabric":
             try:
                 input_forcings.esmf_field_out = esmf_field_retry_partial(
@@ -12178,8 +13745,11 @@ def check_regrid_status(
                     name=f"{input_forcings.product_name}FORCING_REGRIDDED",
                 )
             except ESMF.ESMPyException as esmf_error:
-                config_options.errMsg = f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to create {input_forcings.product_name} destination ESMF field element mesh object: {esmf_error}",
+                )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12529,8 +14099,12 @@ def load_weight_file(
         field_out = input_forcings.esmf_field_out_elem
         target_object_attr_name = "regridObj_elem"
 
-    config_options.statusMsg = f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}"
-    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.log_msg(
+        config_options,
+        mpi_config,
+        debug=True,
+        msg=f"RANK: {mpi_config.rank}: Loading cached ESMF{msg_augment}weight object for {input_forcings.product_name} from {weight_file}",
+    )
 
     err_handler.check_program_status(config_options, mpi_config)
     try:
@@ -12541,13 +14115,18 @@ def load_weight_file(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (IOError, ValueError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = (
-            f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error}"
+        err_handler.log_warning(
+            config_options,
+            mpi_config,
+            msg=f"Unable to load cached ESMF{msg_augment}weight file: {esmf_error}",
         )
-        err_handler.log_warning(config_options, mpi_config)
     else:
-        config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds"
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(
+            config_options,
+            mpi_config,
+            debug=True,
+            msg=f"RANK: {mpi_config.rank}: Finished loading{msg_augment}weight object with ESMF, took {end - begin} seconds",
+        )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12581,8 +14160,7 @@ def make_regrid(
 
     start_msg = f"RANK: {mpi_config.rank}: Creating{msg_augment}weight object from ESMF. weight_file={weight_file}"
     if mpi_config.rank == 0:
-        config_options.statusMsg = start_msg
-        err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+        err_handler.log_msg(config_options, mpi_config, debug=True, msg=start_msg)
 
     extrap_method = ESMF.ExtrapMethod.CREEP_FILL if fill else ESMF.ExtrapMethod.NONE
     regrid_method = (ESMF.RegridMethod.BILINEAR, ESMF.RegridMethod.NEAREST_STOD)[
@@ -12607,14 +14185,21 @@ def make_regrid(
         setattr(input_forcings, target_object_attr_name, regrid)
         end = monotonic()
     except (RuntimeError, ImportError, ESMF.ESMPyException) as esmf_error:
-        config_options.errMsg = f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error}"
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"RANK: {mpi_config.rank}: Failed: {start_msg}. Unable to regrid input data from ESMF: {esmf_error}",
+        )
         etype, value, tb = sys.exc_info()
         traceback.print_exception(etype, value, tb)
     else:
         if mpi_config.rank == 0:
-            config_options.statusMsg = f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"RANK: {mpi_config.rank}: Finished: {start_msg}, took {end - begin} seconds",
+            )
 
     err_handler.check_program_status(config_options, mpi_config)
 
@@ -12647,14 +14232,19 @@ def execute_regrid(
             input_forcings, target_object_attr_name, regrid_object(field_in, field_out)
         )
     except ValueError as ve:
-        config_options.errMsg = (
-            f"Unable to extract regridded data from ESMF regridded field: {ve}"
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to extract regridded data from ESMF regridded field: {ve}",
         )
-        err_handler.log_critical(config_options, mpi_config)
         # delete bad cached file if it exists
         if weight_file is not None:
-            config_options.statusMsg = f"Deleting if exists: {weight_file}"
-            err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+            err_handler.log_msg(
+                config_options,
+                mpi_config,
+                debug=True,
+                msg=f"Deleting if exists: {weight_file}",
+            )
             try:
                 os_utils.os_remove_retry(weight_file)
             except FileNotFoundError:
@@ -12693,8 +14283,7 @@ def calculate_weights(
         esmf_grid_retry, mpi_config, config_options, err_handler
     )
 
-    config_options.statusMsg = "Calculate Weights"
-    err_handler.log_msg(config_options, mpi_config, True)  # log at debug level
+    err_handler.log_msg(config_options, mpi_config, debug=True, msg="Calculate Weights")
 
     if mpi_config.rank == 0:
         if config_options.aws:
@@ -12703,30 +14292,42 @@ def calculate_weights(
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[0]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
+                )
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from aws object",
+                )
         else:
             try:
                 input_forcings.ny_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[1]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract Y shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                )
             try:
                 input_forcings.nx_global = id_tmp.variables[
                     input_forcings.netcdf_var_names[force_count]
                 ].shape[2]
             except (ValueError, KeyError, AttributeError) as err:
-                config_options.errMsg = f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})"
-                err_handler.log_critical(config_options, mpi_config)
+                err_handler.log_critical(
+                    config_options,
+                    mpi_config,
+                    msg=f"Unable to extract X shape size from: {input_forcings.netcdf_var_names[force_count]} from: {input_forcings.tmpFile} ({err})",
+                )
     err_handler.check_program_status(config_options, mpi_config)
 
     # Broadcast the forcing nx/ny values
@@ -12747,8 +14348,11 @@ def calculate_weights(
             coord_sys=ESMF.CoordSys.SPH_DEG,
         )
     except ESMF.ESMPyException as esmf_error:
-        config_options.errMsg = f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})"
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to create source ESMF grid from temporary file: {input_forcings.tmpFile} ({esmf_error})",
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
@@ -12771,15 +14375,21 @@ def calculate_weights(
             input_forcings.y_upper_bound - input_forcings.y_lower_bound
         )
     except (ValueError, KeyError, AttributeError) as err:
-        config_options.errMsg = f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})"
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to extract local X/Y boundaries from global grid from temporary file: {input_forcings.tmpFile} ({err})",
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if input_forcings.nx_local < 2 or input_forcings.ny_local < 2:
-        config_options.errMsg = f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2."
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"You have either specified too many cores for: {input_forcings.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     # check if we're doing border trimming and set up mask
@@ -12790,10 +14400,12 @@ def calculate_weights(
                 ESMF.GridItem.MASK, ESMF.StaggerLoc.CENTER
             )
             if mpi_config.rank == 0:
-                config_options.statusMsg = f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells"
                 err_handler.log_msg(
-                    config_options, mpi_config, True
-                )  # log at debug level
+                    config_options,
+                    mpi_config,
+                    debug=True,
+                    msg=f"Trimming input forcing `{input_forcings.product_name}` by {border} grid cells",
+                )
 
             gmask = np.ones([input_forcings.ny_global, input_forcings.nx_global])
             gmask[:+border, :] = 0.0  # top edge
@@ -12902,19 +14514,21 @@ def calculate_weights(
     try:
         input_forcings.esmf_lats = input_forcings.esmf_grid_in.get_coords(1)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            f"Unable to locate latitude coordinate object within input ESMF grid: {ge}"
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to locate latitude coordinate object within input ESMF grid: {ge}",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     try:
         input_forcings.esmf_lons = input_forcings.esmf_grid_in.get_coords(0)
     except ESMF.GridException as ge:
-        config_options.errMsg = (
-            f"Unable to locate longitude coordinate object within input ESMF grid: {ge}"
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"Unable to locate longitude coordinate object within input ESMF grid: {ge}",
         )
-        err_handler.log_critical(config_options, mpi_config)
     err_handler.check_program_status(config_options, mpi_config)
 
     input_forcings.esmf_lats[:, :] = var_sub_lat_tmp
@@ -12932,8 +14546,11 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to create ESMF field object: {esmf_error}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
     if config_options.grid_type == "unstructured":
@@ -12944,8 +14561,11 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to create ESMF field object: {esmf_error}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
         # Create a ESMF field to hold the incoming data.
@@ -12955,8 +14575,11 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE_ELEMENT",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to create ESMF field object: {esmf_error}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
     elif config_options.grid_type == "hydrofabric":
@@ -12967,8 +14590,11 @@ def calculate_weights(
                 name=f"{input_forcings.product_name}_NATIVE",
             )
         except ESMF.ESMPyException as esmf_error:
-            config_options.errMsg = f"Unable to create ESMF field object: {esmf_error}"
-            err_handler.log_critical(config_options, mpi_config)
+            err_handler.log_critical(
+                config_options,
+                mpi_config,
+                msg=f"Unable to create ESMF field object: {esmf_error}",
+            )
         err_handler.check_program_status(config_options, mpi_config)
 
     # Scatter global grid to processors..
@@ -13175,8 +14801,11 @@ def calculate_supp_pcp_weights(
     # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
     # to have a size of at least 2.
     if supplemental_precip.nx_local < 2 or supplemental_precip.ny_local < 2:
-        config_options.errMsg = f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2."
-        err_handler.log_critical(config_options, mpi_config)
+        err_handler.log_critical(
+            config_options,
+            mpi_config,
+            msg=f"You have either specified too many cores for: {supplemental_precip.product_name}, or  your input forcing grid is too small to process. Local grid must have x/y dimension size of 2.",
+        )
     err_handler.check_program_status(config_options, mpi_config)
 
     lat_tmp = lon_tmp = None


### PR DESCRIPTION
Closing earlier PR, https://github.com/NGWPC/ngen-forcing/pull/83, in favor of this one.

The next PR will introduce partials to remove many of the calls that break across multiple lines.

Steps taken for this PR:

1. Ran flynt to standardize string composition

```
flynt -tc -ll 9999 ~/ngwpc/ngen-forcing/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
```

2. Removed extra `!s` phrases introduced by flynt.

3. Applied regex to replace msg sets with direct log calls:

```
### Bare

## Find
^(\s+)config_options\.(status|err)Msg = (.+)\n\1err_handler\.log_(error|critical|warning|msg)\(config_options, mpi_config\)

## Replace with
$1err_handler.log_$4(config_options, mpi_config, msg=$3)


### Debug

## Find
^(\s+)config_options\.(status|err)Msg = (.+)\n\1err_handler\.log_(error|critical|warning|msg)\(config_options, mpi_config, True\)

## Replace with
$1err_handler.log_$4(config_options, mpi_config, debug=True, msg=$3)
```

## Additions

-

## Removals

-

## Changes

String composition, msg / log calls.

## Testing

1. Ran calibrations and forecasts in RTE

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

