### PR TITLE
MPI Exit Handling

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -231,10 +231,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
             self._job_meta.nwmConfig = self.cfg_bmi["NWM_CONFIG"]
 
         # Initialize MPI communication
-        self._mpi_meta = parallel.MpiConfig()
+        self._mpi_meta = parallel.MpiConfig(self._job_meta)
         try:
             comm = MPI.Comm.f2py(self._comm) if self._comm is not None else None
-            self._mpi_meta.initialize_comm(self._job_meta, comm=comm)
+            self._mpi_meta.initialize_comm(comm=comm)
         except Exception as e:
             err_handler.err_out_screen(self._job_meta.errMsg, e)
 
@@ -1036,20 +1036,6 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         # the job, and let the workflow clean them up after the
         # process exits
         gc.collect()  # make sure objects are deleted from memory
-        if self._mpi_meta.rank == 0:
-            for filename in os.listdir(self._job_meta.scratch_dir):
-                # NFS mounts may create temporary files to facilitate read-after-delete functionality on linux systems
-                # these will be cleaned when the mount is removed but will throw an error if python tries to remove it
-                # the file name is typically ".nfs" followed by numbers, so we'll just ignore files that start with it
-                if not filename.startswith(".nfs"):
-                    file_path = os.path.join(self._job_meta.scratch_dir, filename)
-                    if (
-                        os.path.isfile(file_path)
-                        and filename[0:23] != "NextGen_Forcings_Engine"
-                    ):
-                        os.remove(file_path)
-                    elif os.path.isdir(file_path):
-                        os.rmdir(file_path)
 
     # -------------------------------------------------------------------
     # -------------------------------------------------------------------

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -1022,6 +1022,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         :return: None
 
         """
+        err_handler.log_msg(
+            self._job_meta, self._mpi_meta, True, "Starting BMI finalize()"
+        )
+
         # Force destruction of ESMF objects
         self._wrf_hydro_geo_meta = None
         self._input_forcing_mod = None

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -1,9 +1,10 @@
 import configparser
 import json
 import logging
-import os
 import re
+import os
 from datetime import datetime, timedelta, timezone
+import uuid
 
 import numpy as np
 
@@ -181,26 +182,30 @@ class ConfigOptions:
         # Ensure geogrid is set; if not, read from the configuration file
         if self.geogrid is None:
             try:
-                self.geogrid = cfg_bmi.get(
+                geogrid_base = cfg_bmi.get(
                     "GeogridIn", None
                 )  # Default to None if not found
-                if self.geogrid is None:
-                    err_out_screen(
-                        "Unable to locate GeogridIn in the configuration file."
-                    )
             except KeyError as e:
                 err_out_screen(
                     "Unable to locate GeogridIn in the configuration file.", e
                 )
+            if geogrid_base is None:
+                err_out_screen("Unable to locate GeogridIn in the configuration file.")
+                self.geogrid = None
+            else:
+                geogrid_parent = os.path.dirname(geogrid_base)
+                geogrid_filename = os.path.basename(geogrid_base)
+                self.geogrid = os.path.join(
+                    geogrid_parent, f"{uuid.uuid4().hex}_{geogrid_filename}"
+                )
             # Create directory for esmf_mesh file
-            geogrid_dir = os.path.dirname(self.geogrid)
-            if not os.path.isdir(geogrid_dir):
+            if not os.path.isdir(geogrid_parent):
                 try:
-                    os.makedirs(geogrid_dir, exist_ok=True)
-                    LOG.debug(f"Created esmf mesh directory: {geogrid_dir}")
+                    os.makedirs(geogrid_parent, exist_ok=True)
+                    LOG.debug(f"Created esmf mesh directory: {geogrid_parent}")
                 except OSError as e:
                     err_out_screen(
-                        f"Unable to create esmf_mesh directory: {geogrid_dir}. Error: {e}"
+                        f"Unable to create esmf_mesh directory: {geogrid_parent}. Error: {e}"
                     )
 
         # Read in the base input forcing options as an array of values to map.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -16,6 +16,9 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.time_handling impo
 )
 from nextgen_forcings_ewts import MODULE_NAME
 
+
+from . import mpi_utils
+
 LOG = logging.getLogger(MODULE_NAME)
 
 FORCE_COUNT = 27
@@ -146,6 +149,17 @@ class ConfigOptions:
         self.geogrid = geogrid_arg
         self.geopackage = None
 
+        self.uid64 = None
+
+        self.broadcast_new_64bit_uid()
+
+    def broadcast_new_64bit_uid(self):
+        """Broadcast a random uint64 then save the hash of that to self.uid64, which effectively broadcasts the same unique string to all ranks.
+        Should be called once to avoid confusion."""
+        if self.uid64 is not None:
+            raise RuntimeError("self.uid64 has already been initialized.")
+        self.uid64 = mpi_utils.get_new_broadcasted_uid()
+
     def validate_config(self, cfg_bmi: dict) -> None:
         """Validate in options from the configuration file and check that proper options were provided."""
         # Ensure b_date_proc is set; if not, read from the configuration file
@@ -195,8 +209,10 @@ class ConfigOptions:
             else:
                 geogrid_parent = os.path.dirname(geogrid_base)
                 geogrid_filename = os.path.basename(geogrid_base)
+                if self.uid64 is None:
+                    raise ValueError("self.uid64 cannot be None, please initialize it.")
                 self.geogrid = os.path.join(
-                    geogrid_parent, f"{uuid.uuid4().hex}_{geogrid_filename}"
+                    geogrid_parent, f"{self.uid64}_{geogrid_filename}"
                 )
             # Create directory for esmf_mesh file
             if not os.path.isdir(geogrid_parent):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -114,8 +114,7 @@ def check_program_status(
             stack = traceback.format_stack()[:-1]
             for frame in stack:
                 LOG.error(frame)
-            MpiConfig.comm.Abort(1)
-            sys.exit(1)
+            MpiConfig.abort_with_cleanup(1)
 
     # Sync up processors.
     # When this is enabled, then all ranks wait for rank 0 to evaluate the

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/mpi_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/mpi_utils.py
@@ -1,0 +1,29 @@
+import uuid
+
+import mpi4py
+
+mpi4py.rc.threads = False
+from mpi4py import MPI
+
+import numpy as np
+
+
+# def get_new_broadcasted_uid(comm: MPI.Comm) -> str:
+def get_new_broadcasted_uid() -> str:
+    """Broadcast a random uint64 then return the hash of that. Used for generating a random string shared among all ranks."""
+    # if not isinstance(comm, MPI.Comm):
+    #     raise TypeError(f"Expected comm to be type MPI.Comm, got: {type(comm)}")
+    rand_uint64 = None
+    if MPI.COMM_WORLD.rank == 0:
+        rng = np.random.default_rng()
+        rand_uint64 = rng.integers(0, 2**64, dtype=np.uint64)
+    else:
+        rand_uint64 = None
+
+    rand_uint64 = MPI.COMM_WORLD.bcast(rand_uint64, root=0)
+
+    # Since based on 64-bit int, first 16 chars are 0, final 16 chars are random
+    uid_64bit_hex = uuid.UUID(int=rand_uint64).hex
+    assert len(uid_64bit_hex) == 32
+    uid64 = uid_64bit_hex[16:]
+    return uid64

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -194,7 +194,12 @@ class MpiConfig:
             pass
 
     def _cleanup_scratch_dir(self) -> None:
-        """Remove contents of scratch dir."""
+        """Remove contents of scratch dir.
+        TODO: full scope of remaining scratch dir usage should be identified,
+        and changes implemented to ensure file name uniqueness in the case of
+        concurrent jobs as well as concurrent ngen workers (GWO and PSO calibrations).
+        Potentially, the scratch dir could be replaced with /tmp/.
+        """
         self.log_debug("Cleanup: starting scratch dir cleanup")
         try:
             self.log_debug(f"Cleanup: listing: {self.config_options.scratch_dir}")

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -14,6 +14,7 @@ from mpi4py import MPI
 
 from .config import ConfigOptions
 from . import err_handler
+from . import mpi_utils
 
 # If MPI was initialized outside of python,
 # disable initialization/finalization behavior
@@ -72,7 +73,7 @@ class MpiConfig:
             self.config_options.errMsg = "Unable to retrieve the MPI processor rank."
             raise mpi_exception
 
-        self.__broadcast_new_64bit_uid(self.config_options)
+        self.__broadcast_new_64bit_uid()
 
         wait_for_debug = os.getenv("WAIT_FOR_DEBUGPY", "")
         if wait_for_debug.lower() in ("true", "1"):
@@ -291,23 +292,9 @@ class MpiConfig:
         self.log_debug(msg)
         raise RuntimeError(msg)
 
-    def __broadcast_new_64bit_uid(self, config_options):
+    def __broadcast_new_64bit_uid(self):
         """Broadcast a random uint64 then save the hash of that to self.uid64, which effectively broadcasts the same unique string to all ranks."""
-        if self.uid64 is not None:
-            raise ValueError(f"self.uid64 already set: {repr(self.uid64)}")
-
-        rand_uint64 = None
-        if self.rank == 0:
-            rng = np.random.default_rng()
-            rand_uint64 = rng.integers(0, 2**64, dtype=np.uint64)
-        rand_uint64 = self.broadcast_parameter(
-            rand_uint64, config_options, param_type=np.uint64
-        )
-
-        # Since based on 64-bit int, first 16 chars are 0, final 16 chars are random
-        uid_64bit_hex = uuid.UUID(int=rand_uint64).hex
-        assert len(uid_64bit_hex) == 32
-        self.uid64 = uid_64bit_hex[16:]
+        self.uid64 = mpi_utils.get_new_broadcasted_uid()
 
     def wait_for_debugpy_client(self):
         """Block until the debugpy clients have attached to cppdbg/gdb.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -187,6 +187,11 @@ class MpiConfig:
         )
         self._cleanup_scratch_dir()
         self._cleanup_geogrid()
+        # TODO: Consider if this can be gated for non-wcoss only
+        try:
+            atexit.unregister(self._cleanup)
+        except Exception:
+            pass
 
     def _cleanup_scratch_dir(self) -> None:
         """Remove contents of scratch dir."""

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -1,5 +1,9 @@
+import atexit
+from functools import partial
 import os
 import uuid
+import signal
+import sys
 
 import mpi4py
 import numpy as np
@@ -8,6 +12,7 @@ mpi4py.rc.threads = False
 
 from mpi4py import MPI
 
+from .config import ConfigOptions
 from . import err_handler
 
 # If MPI was initialized outside of python,
@@ -25,16 +30,21 @@ class MpiConfig:
     handle from mpi4py.
     """
 
-    def __init__(self):
-        """Initialize the MPI abstract class that will contain basic information and communication handles."""
+    def __init__(self, config_options: ConfigOptions):
+        """Initialize the MPI abstract class that will contain basic information and communication handles.
+        NOTE: this class overrides the system excepthook so that
+        cleanup steps and MPI abort can be triggered on unhandled exceptions.
+        """
         self.comm = None
         self.rank = None
         self.size = None
         self.uid64: str | None = (
             None  # broadcasted random 16 chars based on random uint64
         )
+        self.config_options = config_options
+        self.__register_exit_handlers()
 
-    def initialize_comm(self, config_options, comm=None):
+    def initialize_comm(self, comm=None):
         """Initialize MPI communication.
 
         Initial function to initialize MPI.
@@ -44,26 +54,238 @@ class MpiConfig:
             self.comm = comm if comm is not None else MPI.COMM_WORLD
             self.comm.Set_errhandler(MPI.ERRORS_ARE_FATAL)
         except AttributeError as ae:
-            config_options.errMsg = "Unable to initialize the MPI Communicator object"
+            self.config_options.errMsg = (
+                "Unable to initialize the MPI Communicator object"
+            )
             raise ae
 
         try:
             self.size = self.comm.Get_size()
         except MPI.Exception as mpi_exception:
-            config_options.errMsg = "Unable to retrieve the MPI size."
+            self.config_options.errMsg = "Unable to retrieve the MPI size."
             raise mpi_exception
 
         try:
             self.rank = self.comm.Get_rank()
         except MPI.Exception as mpi_exception:
-            config_options.errMsg = "Unable to retrieve the MPI processor rank."
+            self.config_options.errMsg = "Unable to retrieve the MPI processor rank."
             raise mpi_exception
 
-        self.__broadcast_new_64bit_uid(config_options)
+        self.__broadcast_new_64bit_uid(self.config_options)
 
         wait_for_debug = os.getenv("WAIT_FOR_DEBUGPY", "")
         if wait_for_debug.lower() in ("true", "1"):
             self.wait_for_debugpy_client()
+
+        # self._test_exit()
+
+    # ------------------------------------------------------
+    # Exit handling, exception handling, cleanup, and abort.
+    # ------------------------------------------------------
+
+    def _test_exit(self) -> None:
+        """Various methods for testing potential exit conditions"""
+        self.__test_exit("exception", 0)
+        # self.__test_exit("exception", 1)
+        # self.__test_exit("signal", 0)
+        ### Signal on rank 1 causes a deadlock iff abort_with_cleanup only allows rank 0 to abort, so all ranks need to be able to abort.
+        # self.__test_exit("signal", 1)
+        # self.__test_exit("sysexit1", 0)
+        # self.__test_exit("sysexit1", 1)
+        # self.__test_exit("check_program_status", 0)
+        # self.__test_exit("check_program_status", 1)
+        # self.__test_exit("err_out_screen", 0)
+        # self.__test_exit("err_out_screen", 1)
+        # self.__test_exit("err_out_screen_para", 0)
+        # self.__test_exit("err_out_screen_para", 1)
+
+    def abort_with_cleanup(self, errorcode: int) -> None:
+        """Call cleanup methods, before calling MPI Abort.
+        Do not make direct calls to MPI Abort without this method.
+        Use this method for all MPI abort needs."""
+        comm = getattr(self, "comm", None)
+        if comm is None:
+            raise RuntimeError("comm is not initialized")
+        # if self.rank == 0:
+        if True:
+            self._cleanup()
+            err_handler.log_msg(
+                self.config_options, self, debug=True, msg="About to MPI Abort"
+            )
+            comm.Abort(errorcode)
+        comm.Barrier()  # For testing case of only rank 0 aborting.
+        raise RuntimeError("At bottom of abort_with_cleanup, should not get here.")
+
+    def __signals_handled(self) -> tuple[int]:
+        """Return a tuple of signals to be handled by cleanup routine."""
+        ### signal.valid_signals() contains many that are unrelated to stoppage / interruption / error.
+        # sigs = [s for s in signal.valid_signals() if s not in (signal.SIGKILL, signal.SIGSTOP)]
+        sigs = (
+            signal.SIGINT,
+            signal.SIGTERM,
+            signal.SIGHUP,
+            signal.SIGQUIT,
+            signal.SIGSEGV,
+            signal.SIGABRT,
+            signal.SIGFPE,
+            signal.SIGBUS,
+            signal.SIGILL,
+        )
+        return sigs
+
+    def __register_exit_handlers(self) -> None:
+        """Register exit handlers for unhandled exceptions, signals, and regular exits.
+        TODO: consider WCOSS gating.
+        TODO: note that when non-0 ranks call Abort directly, the rank 0 exit handler is still invoked, at least in some cases,
+        so there may be opportunities to streamline this further to have only rank 0 perform the cleanup. Would need to test
+        against potential deadlock conditions to be sure (would need to confirm that a non-0 rank initiating an abort would cause
+        rank 0 break out of a collective call if it happens to be waiting at one)."""
+        # Exceptions
+        sys.exepthook = self.__excepthook
+        # Regular exits
+        atexit.register(self._cleanup)
+        # Signals
+        for sig in self.__signals_handled():
+            signal.signal(sig, self.__signal_handler)
+
+    def __excepthook(self, ex_type, value, tb) -> None:
+        """Custom excepthook which follows these steps:
+        1. Call Python's built-in excepthook.
+        2. Log .errMsg as CRITICAL (unless it is None).
+        3. Cleanup.
+        4. MPI Abort.
+
+        To apply, set `sys.excepthook` to this method."""
+        sys.__excepthook__(ex_type, value, tb)
+        if self.config_options.errMsg is not None:
+            err_handler.log_critical(
+                self.config_options,
+                self,
+                msg=f"In excepthook, found errMsg = {repr(self.config_options.errMsg)}",
+            )
+        self.abort_with_cleanup(1)
+
+    def __signal_handler(self, signum, frame) -> None:
+        """Handle termination signals by cleaning up before exit."""
+        ### Unregister the signal handler
+        for s in self.__signals_handled():
+            signal.signal(s, signal.SIG_DFL)
+        ### Cleanup and re-send the original signal to itself
+        # self._cleanup()
+        # os.kill(os.getpid(), signum)
+        ### Cleanup and abort directly
+        self.abort_with_cleanup(signum)
+
+    def _cleanup(self) -> None:
+        """High-level cleanup routine called by exit handlers."""
+        # if self.rank != 0:
+        #     return
+        err_handler.log_msg(
+            self.config_options, self, debug=True, msg="About to clean up"
+        )
+        self._cleanup_scratch_dir()
+        self._cleanup_geogrid()
+
+    def _cleanup_scratch_dir(self) -> None:
+        """Remove contents of scratch dir."""
+        try:
+            contents = os.listdir(self.config_options.scratch_dir)
+        except FileNotFoundError:
+            return
+        # NFS mounts may create temporary files to facilitate read-after-delete functionality on linux systems
+        # these will be cleaned when the mount is removed but will throw an error if python tries to remove it
+        # the file name is typically ".nfs" followed by numbers, so we'll just ignore files that start with it
+        #
+        # Only delete files that don't start with either of these
+        skip_starts = (".nfs", "NextGen_Forcings_Engine")
+        to_delete = [_ for _ in contents if not _.startswith(skip_starts)]
+        for fn in to_delete:
+            fp = os.path.join(self.config_options.scratch_dir, fn)
+            try:
+                os.remove(fp)
+            except FileNotFoundError:
+                pass
+            except IsADirectoryError:
+                try:
+                    os.rmdir(fp)
+                except FileNotFoundError:
+                    pass
+
+    def _cleanup_geogrid(self) -> None:
+        """Remove temporary geogrid file if it exists."""
+        if self.config_options is None:
+            return
+        geogrid = getattr(self.config_options, "geogrid", None)
+        if geogrid is not None:
+            try:
+                os.remove(geogrid)
+            except FileNotFoundError:
+                pass
+
+    def __test_exit(self, mode: str, rank: int) -> None:
+        """Intentionally exit in a particular way, for testing exit/cleanup behavior.
+        `mode` : str. Mode of exit. See match/case block below for accepted values.
+        `rank` : int. Rank to perform the mode of exit. Can be 0 or 1. They have different"""
+
+        log_debug_partial = partial(
+            err_handler.log_msg, self.config_options, self, True
+        )
+
+        log_debug_partial(
+            f"__test_exit(): provided: mode={repr(mode)}, rank={repr(rank)}"
+        )
+        if rank not in (0, 1):
+            raise ValueError(f"__test_exit(): unsupported value for rank: {repr(rank)}")
+
+        if self.rank == rank:
+            match mode:
+                case "exception":
+                    msg = "__test_exit(): raising intentional RuntimeError"
+                    log_debug_partial(msg)
+                    self.config_options.errMsg = "TEST"
+                    raise RuntimeError(msg)
+
+                case "signal":
+                    # msg = f"__test_exit(): sending signal.SIGHUP ({signal.SIGHUP})"
+                    msg = f"__test_exit(): sending signal.SIGTERM ({signal.SIGTERM})"
+                    log_debug_partial(msg)
+                    # os.kill(os.getpid(), signal.SIGHUP)
+                    os.kill(os.getpid(), signal.SIGTERM)
+
+                case "sysexit1":
+                    msg = "__test_exit(): calling sys.exit(1)"
+                    log_debug_partial(msg)
+                    sys.exit(1)
+
+                case "check_program_status":
+                    msg = "__test_exit(): setting critical msg before calling check_program_status()"
+                    log_debug_partial(msg)
+                    err_handler.log_critical(
+                        self.config_options, self, msg="TESTING EXIT HANDLING"
+                    )
+
+                case "err_out_screen":
+                    msg = "__test_exit(): calling err_out_screen()"
+                    log_debug_partial(msg)
+                    err_handler.err_out_screen(msg)
+
+                case "err_out_screen_para":
+                    msg = "__test_exit(): calling err_out_screen_para()"
+                    log_debug_partial(msg)
+                    err_handler.err_out_screen_para(msg, self)
+
+                case _:
+                    raise ValueError(f"Unsupported mode={repr(mode)} for __test_exit()")
+
+        log_debug_partial("__test_exit(): reaching check_program_status()")
+        err_handler.check_program_status(self.config_options, self)
+
+        log_debug_partial("__test_exit(): reaching MPI Barrier")
+        self.comm.Barrier()
+
+        msg = "__test_exit(): got past MPI Barrier (should not get here)"
+        log_debug_partial(msg)
+        raise RuntimeError(msg)
 
     def __broadcast_new_64bit_uid(self, config_options):
         """Broadcast a random uint64 then save the hash of that to self.uid64, which effectively broadcasts the same unique string to all ranks."""
@@ -338,7 +560,11 @@ class MpiConfig:
                         + str(i)
                     )
                     err_handler.log_critical(options, self)
-                    self.comm.abort()
+                    # TODO why was there an abort here?
+                    # Switched it to a new wrapped/cleanup abort,
+                    # but would like to remove that call too if
+                    # there is no reason to keep it.
+                    self.abort_with_cleanup(1)
 
             # options.errMsg = "Checking of Rows and Columns complete"
             # err_handler.log_msg(options,self)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -42,6 +42,7 @@ class MpiConfig:
             None  # broadcasted random 16 chars based on random uint64
         )
         self.config_options = config_options
+        self.log_debug = partial(err_handler.log_msg, self.config_options, self, True)
         self.__register_exit_handlers()
 
     def initialize_comm(self, comm=None):
@@ -188,9 +189,12 @@ class MpiConfig:
 
     def _cleanup_scratch_dir(self) -> None:
         """Remove contents of scratch dir."""
+        self.log_debug("Cleanup: starting scratch dir cleanup")
         try:
+            self.log_debug(f"Cleanup: listing: {self.config_options.scratch_dir}")
             contents = os.listdir(self.config_options.scratch_dir)
         except FileNotFoundError:
+            self.log_debug(f"Cleanup: not found: {self.config_options.scratch_dir}")
             return
         # NFS mounts may create temporary files to facilitate read-after-delete functionality on linux systems
         # these will be cleaned when the mount is removed but will throw an error if python tries to remove it
@@ -202,38 +206,38 @@ class MpiConfig:
         for fn in to_delete:
             fp = os.path.join(self.config_options.scratch_dir, fn)
             try:
+                self.log_debug(f"Cleanup: deleting: {fp}")
                 os.remove(fp)
             except FileNotFoundError:
+                self.log_debug(f"Cleanup: not found: {fp}")
                 pass
             except IsADirectoryError:
+                self.log_debug(f"Cleanup: is a directory, calling rmdir: {fp}")
                 try:
                     os.rmdir(fp)
                 except FileNotFoundError:
+                    self.log_debug(f"Cleanup: not found: {fp}")
                     pass
 
     def _cleanup_geogrid(self) -> None:
         """Remove temporary geogrid file if it exists."""
+        self.log_debug("Cleanup: starting geogrid cleanup")
         if self.config_options is None:
             return
         geogrid = getattr(self.config_options, "geogrid", None)
         if geogrid is not None:
             try:
+                self.log_debug(f"Cleanup: removing: {geogrid}")
                 os.remove(geogrid)
             except FileNotFoundError:
+                self.log_debug(f"Cleanup: not found: {geogrid}")
                 pass
 
     def __test_exit(self, mode: str, rank: int) -> None:
         """Intentionally exit in a particular way, for testing exit/cleanup behavior.
         `mode` : str. Mode of exit. See match/case block below for accepted values.
         `rank` : int. Rank to perform the mode of exit. Can be 0 or 1. They have different"""
-
-        log_debug_partial = partial(
-            err_handler.log_msg, self.config_options, self, True
-        )
-
-        log_debug_partial(
-            f"__test_exit(): provided: mode={repr(mode)}, rank={repr(rank)}"
-        )
+        self.log_debug(f"__test_exit(): provided: mode={repr(mode)}, rank={repr(rank)}")
         if rank not in (0, 1):
             raise ValueError(f"__test_exit(): unsupported value for rank: {repr(rank)}")
 
@@ -241,50 +245,50 @@ class MpiConfig:
             match mode:
                 case "exception":
                     msg = "__test_exit(): raising intentional RuntimeError"
-                    log_debug_partial(msg)
+                    self.log_debug(msg)
                     self.config_options.errMsg = "TEST"
                     raise RuntimeError(msg)
 
                 case "signal":
                     # msg = f"__test_exit(): sending signal.SIGHUP ({signal.SIGHUP})"
                     msg = f"__test_exit(): sending signal.SIGTERM ({signal.SIGTERM})"
-                    log_debug_partial(msg)
+                    self.log_debug(msg)
                     # os.kill(os.getpid(), signal.SIGHUP)
                     os.kill(os.getpid(), signal.SIGTERM)
 
                 case "sysexit1":
                     msg = "__test_exit(): calling sys.exit(1)"
-                    log_debug_partial(msg)
+                    self.log_debug(msg)
                     sys.exit(1)
 
                 case "check_program_status":
                     msg = "__test_exit(): setting critical msg before calling check_program_status()"
-                    log_debug_partial(msg)
+                    self.log_debug(msg)
                     err_handler.log_critical(
                         self.config_options, self, msg="TESTING EXIT HANDLING"
                     )
 
                 case "err_out_screen":
                     msg = "__test_exit(): calling err_out_screen()"
-                    log_debug_partial(msg)
+                    self.log_debug(msg)
                     err_handler.err_out_screen(msg)
 
                 case "err_out_screen_para":
                     msg = "__test_exit(): calling err_out_screen_para()"
-                    log_debug_partial(msg)
+                    self.log_debug(msg)
                     err_handler.err_out_screen_para(msg, self)
 
                 case _:
                     raise ValueError(f"Unsupported mode={repr(mode)} for __test_exit()")
 
-        log_debug_partial("__test_exit(): reaching check_program_status()")
+        self.log_debug("__test_exit(): reaching check_program_status()")
         err_handler.check_program_status(self.config_options, self)
 
-        log_debug_partial("__test_exit(): reaching MPI Barrier")
+        self.log_debug("__test_exit(): reaching MPI Barrier")
         self.comm.Barrier()
 
         msg = "__test_exit(): got past MPI Barrier (should not get here)"
-        log_debug_partial(msg)
+        self.log_debug(msg)
         raise RuntimeError(msg)
 
     def __broadcast_new_64bit_uid(self, config_options):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/retry_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/retry_utils.py
@@ -84,7 +84,7 @@ def retry_w_mpi_context(
                             err_handler.log_critical(
                                 config_options, mpi_config, msg=msg
                             )
-                            mpi_config.comm.Abort(1)
+                            mpi_config.abort_with_cleanup(1)
                         else:
                             msg += " Reraising exception."
                             err_handler.log_critical(


### PR DESCRIPTION
This adds exit handling to the `MpiConfig` class for treating the following conditions the same way via a cleanup routine: unhandled exceptions, normal exit (and sys.exit()), and MPI aborts.  MPI aborts have a new wrapper method -- raw abort is removed and should no longer be used.

The existing BMI tmp file cleanup steps were moved into the new MPI exit handler cleanup steps.

## Additions

- MPI exit handling

## Removals

- Direct MPI abort (use the wrapped method going forward)

## Changes

- BMI tmp file cleanup steps moved out of BMI class and into `MpiConfig` class
- BMI tmp file cleanup occurs on all ranks, not only rank 0
- Uniqueness added to mesh file names

## Testing

1. Added `__test_exit()` and `_test_exit()` methods to the `MpiConfig` class for checking various exit and crash conditions -- occurring on rank 0 as well as non-0 ranks.
2. Ran calibrations and forecasts.
3. Observed log debug messages.


## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

