### PR TITLE
Test Remove MPICommExecutor from historical_forcing.py

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -19,7 +19,7 @@ import s3fs
 import xarray as xr
 import zarr
 from dotenv import find_dotenv, load_dotenv
-from mpi4py.futures import MPICommExecutor
+# from mpi4py.futures import MPICommExecutor
 from pyproj import CRS
 from zarr.storage import ObjectStore
 
@@ -224,10 +224,13 @@ class BaseProcessor:
         """Materialize lazy dask arrays into memory."""
         ds = None
         with self.timing_block("computing dataset"):
-            with MPICommExecutor(comm=self.mpi_config.comm, root=0) as executor:
-                with dask.config.set(scheduler=executor):
-                    if self.mpi_config.rank == 0:
-                        ds = self.sliced_ds.compute().rio.write_crs(self.src_crs)
+            ### This MPICommExecutor usage is being disabled for testing on certain environments.
+            # with MPICommExecutor(comm=self.mpi_config.comm, root=0) as executor:
+            #     with dask.config.set(scheduler=executor):
+            #         if self.mpi_config.rank == 0:
+            #             ds = self.sliced_ds.compute().rio.write_crs(self.src_crs)
+            if self.mpi_config.rank == 0:
+                ds = self.sliced_ds.compute().rio.write_crs(self.src_crs)
         self.mpi_config.comm.barrier()
         ds = self.mpi_config.comm.bcast(ds, root=0)
         if self.mpi_config.rank == 0:


### PR DESCRIPTION
This removes usage of MPICommExecutor from historical_forcing.py to test behavior on certain environments.

## Additions

-

## Removals

- MPICommExecutor from historical_forcing.py (it is still used in regrid.py).

## Changes

-

## Testing

1. I ran a AORC calibration using the RTE image. Speed with -n 2 on a 4-core Workspace for a 10-day calibration using KGE + DDS was comparable, before and after the change.  Effects could differ when running longer simulations with different settings, where more instances of forcing cache file interaction may occur.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

