### PR TITLE
Fix Regression: Historical Forcing Performance

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -7,7 +7,8 @@ import re
 from contextlib import contextmanager
 from datetime import timedelta
 from functools import lru_cache
-from time import time
+from time import perf_counter
+import typing
 
 import dask
 import geopandas as gpd
@@ -19,7 +20,6 @@ import s3fs
 import xarray as xr
 import zarr
 from dotenv import find_dotenv, load_dotenv
-# from mpi4py.futures import MPICommExecutor
 from pyproj import CRS
 from zarr.storage import ObjectStore
 
@@ -84,17 +84,21 @@ class BaseProcessor:
         return self.bounds[3]
 
     @contextmanager
-    def timing_block(self, step_str: str):
+    def timing_block(self, step_str: str, log_callable: typing.Callable = LOG.debug):
         """Context manager for timing code execution.
 
         Args:
             step_str: Description of the step being timed.
+            log_callable: Callable used for sending the log message. Defaults to LOG.debug.
 
         """
-        start = time()
+        start = perf_counter()
+        log_callable(f"  Starting {step_str}")
         yield
-        end = time()
-        LOG.debug(f"  Execution time for {step_str}: {round(end - start, 2)} seconds")
+        end = perf_counter()
+        log_callable(
+            f"  Execution time for {step_str}: {round(end - start, 2)} seconds"
+        )
 
     @property
     def time_min(self) -> np.datetime64:
@@ -223,13 +227,8 @@ class BaseProcessor:
     def compute_ds(self) -> xr.Dataset:
         """Materialize lazy dask arrays into memory."""
         ds = None
-        with self.timing_block("computing dataset"):
-            ### This MPICommExecutor usage is being disabled for testing on certain environments.
-            # with MPICommExecutor(comm=self.mpi_config.comm, root=0) as executor:
-            #     with dask.config.set(scheduler=executor):
-            #         if self.mpi_config.rank == 0:
-            #             ds = self.sliced_ds.compute().rio.write_crs(self.src_crs)
-            if self.mpi_config.rank == 0:
+        if self.mpi_config.rank == 0:
+            with self.timing_block("computing dataset", LOG.info):
                 ds = self.sliced_ds.compute().rio.write_crs(self.src_crs)
         self.mpi_config.comm.barrier()
         ds = self.mpi_config.comm.bcast(ds, root=0)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -183,6 +183,11 @@ class BaseProcessor:
         start and end date pairs for each year. Otherwise, it will create
         start and end date pairs based on the cache size.
          :return: Dictionary of start and end dates as pd.Timestamp
+
+         TODO for lru_cache safety, confirm or enforce that these are never mutated:
+            self.config_options.b_date_proc
+            self.config_options.fcst_input_horizons
+            self.config_options.fcst_freq
         """
         start_end_datetimes = {}
         for start, end in self.year_start_stop_dict.values():

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -175,8 +175,9 @@ class BaseProcessor:
         return start_date, end_date
 
     @property
+    @lru_cache
     def start_end_datetimes(self) -> dict[pd.Timestamp, pd.Timestamp]:
-        """Generate dictioanry of start and end dates for caching.
+        """Generate dictionary of start and end dates for caching.
 
         If the cache size exceeds the year boundary, it will create multiple
         start and end date pairs for each year. Otherwise, it will create


### PR DESCRIPTION
This fixes a performance regression introduced in https://github.com/NGWPC/ngen-forcing/pull/79, specifically https://github.com/NGWPC/ngen-forcing/pull/79/changes/84be3ed45dc8823a431bcb2b06d5365c599fe335.  As reviewer I had asked for `@lru_cache` to be removed from a class property to avoid the risk of one of the `self` attributes changing between calls, which would go unnoticed by `lru_cache`.

Discussion here: https://github.com/NGWPC/ngen-forcing/pull/79#discussion_r2779926246

However, since method call causes a performance drop that scales exponentially with the duration of the simulation (the total number of timesteps, n). This is because each call to the method is O(n), and it is called N times, resulting in O(n^2).

It cannot be parameterized away from `self` usage, since one of its input is an unhashable type, `dict`.

To get the performance back to normal on Integration, I think this should be merged, but we should confirm soon that there are no cases in which the following are mutated after init, since that would cause the result stored in `lru_cache` to be invalid.

```
self.config_options.b_date_proc
self.config_options.fcst_input_horizons
self.config_options.fcst_freq
```

Alternatively, we could protect the above attributes by making them immutable after initial set.


## Additions

- Added log INFO calls for reporting timing of historical forcing cache fetch from s3.

## Removals

-

## Changes

- Added `@lru_cache` to a O(n^2) method to fix performance issues

## Testing

1. I tested a calibration with `-n 2` on a 4-core Workspace and got drastically better performance, back on par with https://github.com/NGWPC/ngen-forcing/pull/89 which was the PR immediately prior to #79.

## Screenshots


## Notes

-

## Todos

- Confirm or enforce that certain `config_options` attributes are never mutated during the run, since that would invalidate the value stored by `lru_cache`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

