### PR TITLE
support using {forcing_static_dir} for NWM_Geogrid

### DIFF
--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/nwm_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/nwm_config.yml
@@ -60,4 +60,4 @@ RqiMethod: 0
 RqiThreshold: 0.9
 cfsEnsNumber: 1
 custom_input_fcst_freq: []
-NWM_Geogrid: '{static_data_dir}/esmf_mesh/NWM/domain/geo_em_{global_domain}.nc'
+NWM_Geogrid: '{forcing_static_dir}/esmf_mesh/NWM/domain/geo_em_{global_domain}.nc'

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/nwm_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/nwm_config.yml
@@ -60,4 +60,4 @@ RqiMethod: 0
 RqiThreshold: 0.9
 cfsEnsNumber: 1
 custom_input_fcst_freq: []
-NWM_Geogrid: '{root_dir}/esmf_mesh/NWM/domain/geo_em_{global_domain}.nc'
+NWM_Geogrid: '{static_data_dir}/esmf_mesh/NWM/domain/geo_em_{global_domain}.nc'


### PR DESCRIPTION
Summary of updates:
Updated nwm_config.yml to use search string {forcing_static_dir} for NWM_Geogrid (to support using different input and output directories for ngen-forcing)