### PR TITLE
Initial Hardening of ConfigOptions

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 from datetime import datetime, timedelta, timezone
+import typing
 
 import numpy as np
 
@@ -12,6 +13,9 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.err_handler import
 )
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.time_handling import (
     calculate_lookback_window,
+)
+from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.general_utils import (
+    setter_hardener,
 )
 from nextgen_forcings_ewts import MODULE_NAME
 
@@ -57,7 +61,9 @@ class ConfigOptions:
         self.realtime_flag = None
         self.refcst_flag = None
         self.ana_flag = None
-        self.b_date_proc = b_date
+        self.b_date_proc: datetime | None = (
+            None if b_date is None else datetime.strptime(b_date, "%Y%m%d%H%M")
+        )
         self.e_date_proc = None
         self.first_fcst_cycle = None
         self.current_fcst_cycle = None
@@ -145,18 +151,138 @@ class ConfigOptions:
         self.geogrid = geogrid_arg
         self.geopackage = None
 
+    ### BEGIN hardened properties
+    # b_date_proc
+    @property
+    def b_date_proc(self):
+        return self._b_date_proc
+
+    @b_date_proc.setter
+    @setter_hardener
+    def b_date_proc(self, val: datetime | None):
+        if (val is not None) and (not isinstance(val, datetime)):
+            raise TypeError(
+                f"Expected type datetime or None for b_date_proc, but new val has type: {type(val)}"
+            )
+        self._b_date_proc = val
+
+    # fcst_freq
+    @property
+    def fcst_freq(self):
+        return self._fcst_freq
+
+    @fcst_freq.setter
+    @setter_hardener
+    def fcst_freq(self, val: typing.Any):
+        self._fcst_freq = val
+
+    # fcst_input_horizons
+    @property
+    def fcst_input_horizons(self):
+        return self._fcst_input_horizons
+
+    @fcst_input_horizons.setter
+    @setter_hardener
+    def fcst_input_horizons(self, val: typing.Any):
+        self._fcst_input_horizons = val
+
+    # aorc_conus_source
+    @property
+    def aorc_conus_source(self):
+        return self._aorc_conus_source
+
+    @aorc_conus_source.setter
+    @setter_hardener
+    def aorc_conus_source(self, val: typing.Any):
+        self._aorc_conus_source = val
+
+    # aorc_conus_year_url
+    @property
+    def aorc_conus_year_url(self):
+        return self._aorc_conus_year_url
+
+    @aorc_conus_year_url.setter
+    @setter_hardener
+    def aorc_conus_year_url(self, val: typing.Any):
+        self._aorc_conus_year_url = val
+
+    # aorc_alaska_source
+    @property
+    def aorc_alaska_source(self):
+        return self._aorc_alaska_source
+
+    @aorc_alaska_source.setter
+    @setter_hardener
+    def aorc_alaska_source(self, val: typing.Any):
+        self._aorc_alaska_source = val
+
+    # aorc_alaska_url
+    @property
+    def aorc_alaska_url(self):
+        return self._aorc_alaska_url
+
+    @aorc_alaska_url.setter
+    @setter_hardener
+    def aorc_alaska_url(self, val: typing.Any):
+        self._aorc_alaska_url = val
+
+    # nwm_source
+    @property
+    def nwm_source(self):
+        return self._nwm_source
+
+    @nwm_source.setter
+    @setter_hardener
+    def nwm_source(self, val: typing.Any):
+        self._nwm_source = val
+
+    # nwm_geogrid
+    @property
+    def nwm_geogrid(self):
+        return self._nwm_geogrid
+
+    @nwm_geogrid.setter
+    @setter_hardener
+    def nwm_geogrid(self, val: typing.Any):
+        self._nwm_geogrid = val
+
+    # geogrid
+    @property
+    def geogrid(self):
+        return self._geogrid
+
+    @geogrid.setter
+    @setter_hardener
+    def geogrid(self, val: typing.Any):
+        self._geogrid = val
+
+    # geopackage
+    @property
+    def geopackage(self):
+        return self._geopackage
+
+    @geopackage.setter
+    @setter_hardener
+    def geopackage(self, val: typing.Any):
+        self._geopackage = val
+
+    ### END hardened properties
+
     def validate_config(self, cfg_bmi: dict) -> None:
         """Validate in options from the configuration file and check that proper options were provided."""
         # Ensure b_date_proc is set; if not, read from the configuration file
         if self.b_date_proc is None:
             try:
-                self.b_date_proc = cfg_bmi.get(
-                    "RefcstBDateProc", None
-                )  # Default to None if not found
-                if self.b_date_proc is None:
+                # Default to None if not found
+                b_date_proc_from_cfg_bmi = cfg_bmi.get("RefcstBDateProc", None)
+                if b_date_proc_from_cfg_bmi is None:
                     err_out_screen(
                         "Unable to locate RefcstBDateProc under Logistics section in configuration file."
                     )
+                self.b_date_proc = datetime.strptime(
+                    b_date_proc_from_cfg_bmi, "%Y%m%d%H%M"
+                )
+
             except KeyError as e:
                 err_out_screen(
                     "Unable to locate RefcstBDateProc under Logistics section in configuration file.",
@@ -606,8 +732,15 @@ class ConfigOptions:
                     e,
                 )
             try:
-                self.b_date_proc = datetime.strptime(beg_date_tmp, "%Y%m%d%H%M")
-            except ValueError as e:
+                if isinstance(beg_date_tmp, datetime):
+                    self.b_date_proc = beg_date_tmp
+                elif isinstance(beg_date_tmp, str):
+                    self.b_date_proc = datetime.strptime(beg_date_tmp, "%Y%m%d%H%M")
+                else:
+                    raise TypeError(
+                        f"Expected datetime.datetime or str for beg_date_tmp, but got: {type(self.b_date_proc)}"
+                    )
+            except Exception as e:
                 err_out_screen(
                     "Improper RefcstBDateProc value entered into the configuration file. Please check your entry.",
                     e,

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -22,6 +22,7 @@ from nextgen_forcings_ewts import MODULE_NAME
 LOG = logging.getLogger(MODULE_NAME)
 
 FORCE_COUNT = 27
+DATETIME_FORMAT = "%Y%m%d%H%M"
 
 
 class ConfigOptions:
@@ -62,7 +63,7 @@ class ConfigOptions:
         self.refcst_flag = None
         self.ana_flag = None
         self.b_date_proc: datetime | None = (
-            None if b_date is None else datetime.strptime(b_date, "%Y%m%d%H%M")
+            None if b_date is None else datetime.strptime(b_date, DATETIME_FORMAT)
         )
         self.e_date_proc = None
         self.first_fcst_cycle = None
@@ -280,7 +281,7 @@ class ConfigOptions:
                         "Unable to locate RefcstBDateProc under Logistics section in configuration file."
                     )
                 self.b_date_proc = datetime.strptime(
-                    b_date_proc_from_cfg_bmi, "%Y%m%d%H%M"
+                    b_date_proc_from_cfg_bmi, DATETIME_FORMAT
                 )
 
             except KeyError as e:
@@ -735,7 +736,7 @@ class ConfigOptions:
                 if isinstance(beg_date_tmp, datetime):
                     self.b_date_proc = beg_date_tmp
                 elif isinstance(beg_date_tmp, str):
-                    self.b_date_proc = datetime.strptime(beg_date_tmp, "%Y%m%d%H%M")
+                    self.b_date_proc = datetime.strptime(beg_date_tmp, DATETIME_FORMAT)
                 else:
                     raise TypeError(
                         f"Expected datetime.datetime or str for beg_date_tmp, but got: {type(self.b_date_proc)}"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/general_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/general_utils.py
@@ -1,0 +1,26 @@
+"""General utilities."""
+
+import functools
+
+
+def setter_hardener(func):
+    """Decorator for setters. Causes the setter to be hardened such that it
+    asserts that the new value is either replacing None, or that the new value
+    is equal to the existing value."""
+
+    @functools.wraps(func)
+    def wrapper(self, new_value):
+        # Private attr attr_public is typical pattern, with underscore prepending the public attr attr_public.
+        attr_public = func.__name__
+        attr_private = f"_{attr_public}"
+        # Current value, or None if not yet set.
+        val_existing = getattr(self, attr_private, None)
+
+        if val_existing is None or val_existing == new_value:
+            return func(self, new_value)
+        else:
+            raise ValueError(
+                f"Public attr {attr_public} (private attr {attr_private}) is hardened. It had already been set to non-None value {repr(val_existing)}, and proposed new value is {repr(new_value)}, which is not equal to the existing value."
+            )
+
+    return wrapper

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/general_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/general_utils.py
@@ -4,13 +4,19 @@ import functools
 
 
 def setter_hardener(func):
-    """Decorator for setters. Causes the setter to be hardened such that it
+    """
+    Decorator for setters. Causes the setter to be hardened such that it
     asserts that the new value is either replacing None, or that the new value
-    is equal to the existing value."""
+    is equal to the existing value.
+
+    NOTE: since `==` is used to determine if the new value is equal to the old value,
+    it is possible to change the value if the `==` check passes, for example setting 5.0 (float) to replace 5 (int)
+    would not cause an error to be raised.
+    """
 
     @functools.wraps(func)
     def wrapper(self, new_value):
-        # Private attr attr_public is typical pattern, with underscore prepending the public attr attr_public.
+        # Private attr attr_private is typical pattern, with underscore prepending the public attr attr_public.
         attr_public = func.__name__
         attr_private = f"_{attr_public}"
         # Current value, or None if not yet set.


### PR DESCRIPTION
### Note: the hardening is currently too strict for the Analysis and Assimilation ("AnA") case.

This case does modify `b_date_proc` on the fly, and therefore results in the following intentional error currently:

`ValueError: Public attr b_date_proc (private attr _b_date_proc) is hardened. It had already been set to non-None value datetime.datetime(2025, 7, 10, 9, 0), and proposed new value is datetime.datetime(2025, 7, 10, 7, 0), which is not equal to the existing value.`

The hardening needs to be relaxed for this use case, or, AnA implementation needs to be changed, before this can be merged.



## PR Description:

To follow up on the discussion surrounding `@lru_cache` from https://github.com/NGWPC/ngen-forcing/pull/107, this adds hardening to existing class ConfigOptions for the following existing attributes:

```
b_date_proc
fcst_freq
fcst_input_horizons
aorc_conus_source
aorc_conus_year_url
aorc_alaska_source
aorc_alaska_url
nwm_source
nwm_geogrid
geogrid
geopackage
```

The hardening is defined in a new setter decorator (can be applied to any setter method). Its rules are that the property can only be set to a non-None value if the current value is None, or if the new value is equal to the current value (via Python `==` comparison).

The hardening is applied via new setters for those attributes -- they are now properties.

This also adds a type check for `b_date_proc`, asserting that it is either `datetime.datetime` or `None`.  Previously, it could also be a `str` type.


## Additions

- New file `general_utils.py` with new decorator `setter_hardener`
- New setters and getters for attributes described above
- New constant variable for defining the datetime string format (DRYify)

## Removals

-

## Changes

- 11 attributes moved to properties with standard getter and "hardened" setter, ensuring that values do not change (sameness checked via `==` comparison) after the first time they are set to a non-None value.
- `b_date_proc` may only be a `datetime.datetime` or `None`, may not be a `str`.

## Testing

1. Testing via RTE's `run_suite.sh` calls is currently in progress as of 2/25/26 evening.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

