### PR TITLE
removing an mpi barrier and a file existence check

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -122,7 +122,7 @@ def check_program_status(
     # collected error flags and call Abort() as appropriate, before continuing.
     # When this is not enabled, then non-0 ranks may continue execution after sending
     # their error flag, since non-0 ranks do not block on reduce().
-    MpiConfig.comm.barrier()
+    # MpiConfig.comm.barrier()
 
 
 def init_log(ConfigOptions, MpiConfig):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
@@ -925,9 +925,10 @@ class InputForcings:
         LOG.debug(
             f"keyValue: {self.keyValue}, {self.find_neighbor_files_map[self.keyValue].__name__}"
         )
-        self.find_neighbor_files_map[self.keyValue](
-            self, config_options, dcurrent, mpi_config
-        )
+        if config_options.input_forcings[0] not in [12, 21]:
+            self.find_neighbor_files_map[self.keyValue](
+                self, config_options, dcurrent, mpi_config
+            )
 
     @property
     def regrid_map(self):


### PR DESCRIPTION
Debugging/profiling and testing have identified two processes that can be cleaned up in ngen-forcing. These are somewhat low-hanging fruit. The first was a file existence check that was repeatedly failing. The second was an mpi barrier that was being called repeatedly. 

## Additions

-

## Removals

-

## Changes

- Minor changes to forcingInputMod.py and err_handler.py

## Testing

1. Tested changes many times locally and on a PW node. Needs to be tested on dev2. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

