### PR TITLE
handle time key error for AORC data reads

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -4,11 +4,11 @@ import datetime
 import logging
 import os
 import re
+import typing
 from contextlib import contextmanager
 from datetime import timedelta
 from functools import lru_cache
 from time import perf_counter
-import typing
 
 import dask
 import geopandas as gpd
@@ -223,8 +223,12 @@ class BaseProcessor:
             raise IndexError(
                 f"The time provided ({self.current_time}) is not in the dataset. Please check that you have provided a time span that is valid for the given domain/dataset."
             )
-        ds = self.computed_ds.sel(time=self.current_time)
-
+        try:
+            ds = self.computed_ds.sel(time=self.current_time)
+        except KeyError:
+            raise KeyError(
+                f"The time provided ({self.current_time}) is not in the dataset. Please check that you have provided a time span that is valid for the given domain/dataset."
+            )
         # if self.mpi_config.rank == 0:
         #     self.plot_precip(ds)
         # self.write_sum_tif(self.computed_ds)
@@ -293,6 +297,14 @@ class BaseProcessor:
         :return: Sliced Dataset
         """
         with self.timing_block("slicing dataset"):
+            if self.current_time not in ds.time.values:
+                raise IndexError(
+                    f"The time provided is not in the dataset: {self.current_time}"
+                )
+            if self.end_time_datetime not in ds.time.values:
+                raise IndexError(
+                    f"The time provided is not in the dataset: {self.end_time_datetime}"
+                )
             sliced_ds = ds.sel(
                 {
                     self.x_label: slice(self.reprojected_xmin, self.reprojected_xmax),


### PR DESCRIPTION
This PR catches and better handles key errors associated with trying to access a datetime outside of the available period of record for AORC data. A more explicit message is provided including the datetime that was attempted so that the dataset can be investigated by the user. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1. Tested with success on the clusters.

## Screenshots


## Notes

-

## Todos

-Confirm all is working well once NOAA fills in the gaps in the AORC dataset.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

