### PR TITLE
Unique Scratch Directory Names

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -238,6 +238,10 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
         except Exception as e:
             err_handler.err_out_screen(self._job_meta.errMsg, e)
 
+        ### Reassign the scratch dir to a new child dir of the current scratch dir,
+        ### applying uniqueness to the final path. This must be called by all ranks, once.
+        self._job_meta.uniquefy_scratch_dir_as_child(self._mpi_meta.uid64)
+
         # LOG.debug(f"self._job_meta type: {type(self._job_meta)}")
         # Call ESMF mesh creation process
         if self._mpi_meta.rank == 0:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -150,8 +150,31 @@ class ConfigOptions:
         self.geopackage = None
 
         self.uid64 = None
-
         self.broadcast_new_64bit_uid()
+
+        self._scratch_dir_has_been_uniquefied = False
+
+    def uniquefy_scratch_dir_as_child(self, uid: str) -> None:
+        """Modify the existing scratch dir by adding the UID string available to all ranks from the MpiConfig class.
+        This may only be called once. Subsequent calls will result in an error.
+        This must be called by all ranks, once."""
+        LOG.debug(f"Uniquefying scratch dir: adding suffix {uid} to {self.scratch_dir}")
+        if not isinstance(uid, str):
+            raise TypeError(f"Expected str, got {type(uid)} for type of uid: {uid}")
+        if self.scratch_dir is None:
+            raise ValueError("This cannot be ran while scratch_dir is None")
+        if self._scratch_dir_has_been_uniquefied is True:
+            raise ValueError(
+                f"scratch_dir path has already been uniquefied: {self.scratch_dir}"
+            )
+        self.scratch_dir = os.path.join(self.scratch_dir, uid)
+        self._scratch_dir_has_been_uniquefied = True
+        self.make_scratch_dir()
+
+    def make_scratch_dir(self) -> None:
+        """Make the scratch dir and its parents."""
+        os.makedirs(self.scratch_dir, exist_ok=True)
+        LOG.debug(f"Scratch dir: {self.scratch_dir}")
 
     def broadcast_new_64bit_uid(self):
         """Broadcast a random uint64 then save the hash of that to self.uid64, which effectively broadcasts the same unique string to all ranks.
@@ -500,8 +523,8 @@ class ConfigOptions:
             err_out_screen("Unable to locate ScratchDir in the configuration file.", e)
         except configparser.NoOptionError as e:
             err_out_screen("Unable to locate ScratchDir in the configuration file.", e)
-        os.makedirs(self.scratch_dir, exist_ok=True)
-        LOG.debug(f"Scratch dir: {self.scratch_dir}")
+
+        self.make_scratch_dir()
 
         # Read in compression option
         try:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -197,10 +197,12 @@ class MpiConfig:
 
     def _cleanup_scratch_dir(self) -> None:
         """Remove contents of scratch dir.
-        TODO: full scope of remaining scratch dir usage should be identified,
-        and changes implemented to ensure file name uniqueness in the case of
-        concurrent jobs as well as concurrent ngen workers (GWO and PSO calibrations).
-        Potentially, the scratch dir could be replaced with /tmp/.
+        TODO: Potentially, the scratch dir could be replaced with /tmp/,
+        but /tmp/ files remain in the container and are not available outside of the container.
+        So use cases such as self._output_obj.outPath in `bmi_model.py` would need to be updated
+        to use a new configuration key for specifying the output directory for (optionally) storing permanent results.
+        The process of writing to outPath could still leverage /tmp/ while the file is incomplete / in-process,
+        using a OS rename to move the file to the shared location once writing has completed and the file handle has been closed.
         """
         self.log_debug("Cleanup: starting scratch dir cleanup")
         if self.config_options is None:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -241,12 +241,7 @@ class MpiConfig:
             return
         geogrid = getattr(self.config_options, "geogrid", None)
         if geogrid is not None:
-            try:
-                self.log_debug(f"Cleanup: removing: {geogrid}")
-                os.remove(geogrid)
-            except FileNotFoundError:
-                self.log_debug(f"Cleanup: not found: {geogrid}")
-                pass
+            self.try_delete_file_no_reraise(geogrid)
         else:
             self.log_debug("Cleanup: config_options.geogrid is not set")
             return
@@ -259,7 +254,7 @@ class MpiConfig:
             contents = os.listdir(dir_path)
         except (FileNotFoundError, NotADirectoryError) as e:
             self.log_warning(
-                f"Could not list, may have already been deleted: {dir_path}: {e}"
+                f"Could not list (it may have already been deleted): {dir_path}: {e}"
             )
             return []
         else:
@@ -274,7 +269,8 @@ class MpiConfig:
             self.log_warning(
                 f"Could not delete file (it may have already been deleted): {file_path}: {e}"
             )
-        self.log_info(f"Deleted file: {file_path}")
+        else:
+            self.log_info(f"Deleted file: {file_path}")
 
     def try_remove_empty_dir_no_reraise(self, dir_path: str) -> None:
         """Try to rmdir the path, do not reraise an exception if it fails due to OSError"""
@@ -285,7 +281,8 @@ class MpiConfig:
             self.log_warning(
                 f"Could not rmdir (it may have already been deleted): {dir_path}: {e}"
             )
-        self.log_info(f"Removed directory: {dir_path}")
+        else:
+            self.log_info(f"Removed directory: {dir_path}")
 
     def __test_exit(self, mode: str, rank: int) -> None:
         """Intentionally exit in a particular way, for testing exit/cleanup behavior.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/parallel.py
@@ -44,6 +44,8 @@ class MpiConfig:
         )
         self.config_options = config_options
         self.log_debug = partial(err_handler.log_msg, self.config_options, self, True)
+        self.log_info = partial(err_handler.log_msg, self.config_options, self, False)
+        self.log_warning = partial(err_handler.log_warning, self.config_options, self)
         self.__register_exit_handlers()
 
     def initialize_comm(self, comm=None):
@@ -201,12 +203,17 @@ class MpiConfig:
         Potentially, the scratch dir could be replaced with /tmp/.
         """
         self.log_debug("Cleanup: starting scratch dir cleanup")
-        try:
-            self.log_debug(f"Cleanup: listing: {self.config_options.scratch_dir}")
-            contents = os.listdir(self.config_options.scratch_dir)
-        except FileNotFoundError:
-            self.log_debug(f"Cleanup: not found: {self.config_options.scratch_dir}")
+        if self.config_options is None:
+            self.log_debug("Cleanup: config_options is not set")
             return
+        if not self.config_options.scratch_dir:
+            self.log_debug("Cleanup: scratch dir is not set")
+            return
+
+        self.log_debug(
+            f"Cleanup: listing scratch dir: {self.config_options.scratch_dir}"
+        )
+        contents = self.try_list_dir_no_reraise(self.config_options.scratch_dir)
         # NFS mounts may create temporary files to facilitate read-after-delete functionality on linux systems
         # these will be cleaned when the mount is removed but will throw an error if python tries to remove it
         # the file name is typically ".nfs" followed by numbers, so we'll just ignore files that start with it
@@ -216,24 +223,19 @@ class MpiConfig:
         to_delete = [_ for _ in contents if not _.startswith(skip_starts)]
         for fn in to_delete:
             fp = os.path.join(self.config_options.scratch_dir, fn)
-            try:
-                self.log_debug(f"Cleanup: deleting: {fp}")
-                os.remove(fp)
-            except FileNotFoundError:
-                self.log_debug(f"Cleanup: not found: {fp}")
-                pass
-            except IsADirectoryError:
-                self.log_debug(f"Cleanup: is a directory, calling rmdir: {fp}")
-                try:
-                    os.rmdir(fp)
-                except FileNotFoundError:
-                    self.log_debug(f"Cleanup: not found: {fp}")
-                    pass
+            if os.path.isfile(fp):
+                self.try_delete_file_no_reraise(fp)
+            elif os.path.isdir(fp):
+                self.try_remove_empty_dir_no_reraise(fp)
+
+        if self.config_options._scratch_dir_has_been_uniquefied:
+            self.try_remove_empty_dir_no_reraise(self.config_options.scratch_dir)
 
     def _cleanup_geogrid(self) -> None:
         """Remove temporary geogrid file if it exists."""
         self.log_debug("Cleanup: starting geogrid cleanup")
         if self.config_options is None:
+            self.log_debug("Cleanup: config_options is not set")
             return
         geogrid = getattr(self.config_options, "geogrid", None)
         if geogrid is not None:
@@ -243,6 +245,45 @@ class MpiConfig:
             except FileNotFoundError:
                 self.log_debug(f"Cleanup: not found: {geogrid}")
                 pass
+        else:
+            self.log_debug("Cleanup: config_options.geogrid is not set")
+            return
+
+    def try_list_dir_no_reraise(self, dir_path: str) -> list[str]:
+        """Try to list the directory and return a list of its contents.
+        Do not reraise an exception if it fails due to FileNotFoundError or NotADirectoryError"""
+        self.log_debug(f"Trying to list directory: {dir_path}")
+        try:
+            contents = os.listdir(dir_path)
+        except (FileNotFoundError, NotADirectoryError) as e:
+            self.log_warning(
+                f"Could not list, may have already been deleted: {dir_path}: {e}"
+            )
+            return []
+        else:
+            return contents
+
+    def try_delete_file_no_reraise(self, file_path: str) -> None:
+        """Try to delete the file, do not reraise an exception if it fails due to OSError"""
+        self.log_debug(f"Trying to delete file: {file_path}")
+        try:
+            os.remove(file_path)
+        except OSError as e:
+            self.log_warning(
+                f"Could not delete file (it may have already been deleted): {file_path}: {e}"
+            )
+        self.log_info(f"Deleted file: {file_path}")
+
+    def try_remove_empty_dir_no_reraise(self, dir_path: str) -> None:
+        """Try to rmdir the path, do not reraise an exception if it fails due to OSError"""
+        self.log_debug(f"Trying to remove directory: {dir_path}")
+        try:
+            os.rmdir(dir_path)
+        except OSError as e:
+            self.log_warning(
+                f"Could not rmdir (it may have already been deleted): {dir_path}: {e}"
+            )
+        self.log_info(f"Removed directory: {dir_path}")
 
     def __test_exit(self, mode: str, rank: int) -> None:
         """Intentionally exit in a particular way, for testing exit/cleanup behavior.


### PR DESCRIPTION
This causes the provided scratch directory to be a parent of the actual scratch directory.  The actual scratch directory is now created as a child of the directory specified in the configuration file.  The name of the child directory is a random string, and it is shared among all MPI ranks.

This is to avoid file contention during concurrent execution.

The cleanup function was also changed some.

**TODO**: note that when running through `ngen`, the MPI exit handling logic does not seem to be triggering the cleanup step in cases when forcing engine crashes.

The forcing cleanup is triggering during normal exit when running through `ngen`, and is triggering under crash conditions and normal exits when running through the debugger (`run_bmi_forcing.py` with `mpirun`).

## Additions

- Scratch dir is now created as a child dir of the provided (configured) scratch dir path. The new child dir is a random string.
- New private attribute `ConfigOptions._scratch_dir_has_been_uniquefied` used for state management to ensure the uniquefication method is called no more than once.

## Removals

-

## Changes

- Scratch dir is now created as a child dir of the provided (configured) scratch dir path. The new child dir is a random string.
- Some log messages during cleanup function were altered.

## Testing

1. I ran short range forecasts and confirmed that the new randomized scratch directory is being used and cleaned up, when the program exits normally.
2. I ran the regrid.py pytests.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

