### PR TITLE
Forecast: fetch raw forcing data only on rank 0

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -247,7 +247,21 @@ class NWMv3_Forcing_Engine_BMI_model(Bmi):
 
         # Call forcing_extraction process
         if self._job_meta.nwmConfig not in ["AORC", "NWM"]:
-            forcing_extraction.retrieve_forcing(self._job_meta)
+            if self._mpi_meta.rank == 0:
+                err_handler.log_msg(
+                    self._job_meta,
+                    self._mpi_meta,
+                    False,
+                    "About to fetch raw forcing data",
+                )
+                forcing_extraction.retrieve_forcing(self._job_meta)
+                err_handler.log_msg(
+                    self._job_meta,
+                    self._mpi_meta,
+                    False,
+                    "Finished fetching raw forcing data",
+                )
+        self._mpi_meta.comm.Barrier()
 
         # Initialize our WRF-Hydro geospatial object, which contains
         # information about the modeling domain, local processor


### PR DESCRIPTION
In support of adding multiprocessing capability to the forecast workflow, this changes the forecast forcing data fetcher to run only on MPI rank 0, since the other ranks download the same information.

This should be tested with a branch of the same name for MSWM, Fcst Mgr, and RTE, see other PRs:

https://github.com/NGWPC/nwm-msw-mgr/pull/43

https://github.com/NGWPC/nwm-fcst-mgr/pull/10

https://github.com/NGWPC/nwm-rte/pull/42


## Additions

-

## Removals

-

## Changes

- `forcing_extraction.retrieve_forcing(self._job_meta)` is called only by rank 0 now, and previously was called by all ranks (but previously the workflow was running with a single rank).

## Testing

1. I confirmed that the files downloaded by rank 0 are equivalent to those downloaded by rank 1, which confirms that this is a safe change, that multiprocessing workflows will receive the proper inputs.
2. regrid.py pytests passed for HRR and RAP.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

