### PR TITLE
Update setup-trivy action to v0.2.6

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -289,7 +289,7 @@ jobs:
           docker run --rm ${{ needs.setup.outputs.bmi_image }}:${{ needs.setup.outputs.test_image_tag }} \
           echo "Running BMI Forcing Unit Tests..."
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.5
+        uses: aquasecurity/setup-trivy@v0.2.6
         with:
           cache: true
           version: v0.69.3
@@ -405,7 +405,7 @@ jobs:
           docker run --rm ${{ needs.setup.outputs.coastal_image }}:${{ needs.setup.outputs.test_image_tag }} \
           echo "Running Coastal Unit Tests..."
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.5
+        uses: aquasecurity/setup-trivy@v0.2.6
         with:
           cache: true
           version: v0.69.3
@@ -520,7 +520,7 @@ jobs:
           docker run --rm ${{ needs.setup.outputs.sfincs_image }}:${{ needs.setup.outputs.test_image_tag }} \
           echo "Running SFINCS Unit Tests..."
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.5
+        uses: aquasecurity/setup-trivy@v0.2.6
         with:
           cache: true
           version: v0.69.3


### PR DESCRIPTION
## Summary
- Updates `aquasecurity/setup-trivy` from `v0.2.5` to `v0.2.6` to fix a workflow failure
- `v0.2.5` was causing the container-scanning job to fail; `v0.2.6` resolves the issue