### PR TITLE
remove ewts from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ requires = ["setuptools >= 61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-where = ["NextGen_Forcings_Engine_BMI", "nextgen_forcings_ewts/src", "."]
+where = ["NextGen_Forcings_Engine_BMI","."]
 include = ["NextGen_Forcings_Engine*", 
     "Forcing_Extraction_Scripts*", 
     "ESMF_Mesh_Domain_Configuration_Production*"]


### PR DESCRIPTION
This PR removes `nwm-ewts` from the `pyproject.toml`.

`nwm-ewts` is now installed separately. [See this PR from RTE for an example](https://github.com/NGWPC/nwm-rte/pull/49). 
## Additions

-

## Removals

-Removed `ewts` from the `pyproject.toml`.

## Changes

-

## Testing

1. Ran RTE "run_suite.sh"

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

