### PR TITLE
Gates initial geometa dimensionality check by discretization.

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -292,12 +292,20 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
             for long_name in self._var_name_units_map.keys()
         }
 
-        # Check to make sure we have enough dimensionality to run regridding. ESMF requires both grids
-        # to have a size of at least 2.
-        if self.geo_meta.nx_local < 2 or self.geo_meta.ny_local < 2:
+        # Check to make sure we have enough dimensionality to run regridding. We assume that hydrofabric discretizations are large 
+        # enough that 1x1 (single catchment) will provide enough points. For gridded and unstructured domains, we need to make sure 
+        # that the local grid size for each processor is at least 2x2 to run the regridding process.
+        # forcing_input dimensionality is checked in regrid.py. 
+
+        dimensionality = 1 if self._grid_type == "hydrofabric" else 2
+
+        if (
+            self._wrf_hydro_geo_meta.nx_local < dimensionality
+            or self._wrf_hydro_geo_meta.ny_local < dimensionality
+        ):
             self._job_meta.errMsg = (
-                "You have specified too many cores for your WRF-Hydro grid. "
-                "Local grid Must have x/y dimension size of 2."
+                f"You have specified too many cores for your WRF-Hydro grid. "
+                f"Local grid Must have x/y dimension size of {dimensionality}."
             )
             err_handler.err_out_screen_para(self._job_meta.errMsg, self._mpi_meta)
         err_handler.check_program_status(self._job_meta, self._mpi_meta)


### PR DESCRIPTION
The check for the geometa class dimensionality fails when using a single-catchment basin. This check is mostly relevant for regridding the gridded discretization.

## NOTE:

This should likely wait until pending changes are merged, and then rebased to those. 

## Changes

- Gated the dimensionality check in bmi_model.py based on discretization. 

## Testing

1. Tested simulations with single-catchment basins with and without gating logic. 
2. Ran calibration simulation during Hurricane Irene and reviewed output for sanity.
3. Tested messaging by artificially triggering failure.
4. Confirmed that forcing_input.nx_local and forcing_input.ny_local >= 2 (typically by a fair margin) even if wrf_hydro_geo_meta.nx_local and .ny_local == 1.

## Todos

- This could potentially be simplified when refactoring bmi_model.py. 
- We could confirm gridded and unstructured actually fail when wrf_hydro_geo_meta.nx_local or .ny_local < 2. 

