### PR TITLE
Fix durations in forcing config files for medium-range lagged ensemble

### DIFF
--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem2_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem2_config.yml
@@ -18,7 +18,7 @@ LookBack : -9999
 RefcstBDateProc: "202412020000"
 ForecastFrequency: 60
 ForecastShift: 0
-ForecastInputHorizons: [12246]
+ForecastInputHorizons: [12600]
 ForecastInputOffsets: [0]
 Geopackage: "{root_dir}/gpkg/conus/{gage}.gpkg"
 GeogridIn: "{root_dir}/esmf_mesh/{gage}_ESMF_Mesh.nc"

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem3_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem3_config.yml
@@ -18,7 +18,7 @@ LookBack : -9999
 RefcstBDateProc: "202412020000"
 ForecastFrequency: 60
 ForecastShift: 0
-ForecastInputHorizons: [12252]
+ForecastInputHorizons: [12960]
 ForecastInputOffsets: [0]
 Geopackage: "{root_dir}/gpkg/conus/{gage}.gpkg"
 GeogridIn: "{root_dir}/esmf_mesh/{gage}_ESMF_Mesh.nc"

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem4_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem4_config.yml
@@ -18,7 +18,7 @@ LookBack : -9999
 RefcstBDateProc: "202412020000"
 ForecastFrequency: 60
 ForecastShift: 0
-ForecastInputHorizons: [12258]
+ForecastInputHorizons: [13320]
 ForecastInputOffsets: [0]
 Geopackage: "{root_dir}/gpkg/conus/{gage}.gpkg"
 GeogridIn: "{root_dir}/esmf_mesh/{gage}_ESMF_Mesh.nc"

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem5_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem5_config.yml
@@ -18,7 +18,7 @@ LookBack : -9999
 RefcstBDateProc: "202412020000"
 ForecastFrequency: 60
 ForecastShift: 0
-ForecastInputHorizons: [12264]
+ForecastInputHorizons: [13680]
 ForecastInputOffsets: [0]
 Geopackage: "{root_dir}/gpkg/conus/{gage}.gpkg"
 GeogridIn: "{root_dir}/esmf_mesh/{gage}_ESMF_Mesh.nc"

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem6_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/medium_range_mem6_config.yml
@@ -18,7 +18,7 @@ LookBack : -9999
 RefcstBDateProc: "202412020000"
 ForecastFrequency: 60
 ForecastShift: 0
-ForecastInputHorizons: [12270]
+ForecastInputHorizons: [14040]
 ForecastInputOffsets: [0]
 Geopackage: "{root_dir}/gpkg/conus/{gage}.gpkg"
 GeogridIn: "{root_dir}/esmf_mesh/{gage}_ESMF_Mesh.nc"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import sys
@@ -39,8 +40,13 @@ def err_out_screen(err_msg: str, exc: BaseException | None = None):
 
     if in_exception_context():
         tb = traceback.format_exc()
-        LOG.critical(f"TRACEBACK: {tb}")
-        print(tb, flush=True, file=sys.stderr)
+        tb_msg = f"TRACEBACK: {tb}"
+        print(tb_msg, flush=True, file=sys.stderr)
+        LOG.critical(tb_msg)
+
+    final_msg = f"Calling sys.exit(1) from object {repr(inspect.currentframe().f_code.co_name)}"
+    print(final_msg, flush=True, file=sys.stderr)
+    LOG.critical(final_msg)
 
     sys.exit(1)
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -12,6 +12,12 @@ import ewts
 LOG = ewts.get_logger(ewts.FORCING_ID)
 
 
+def in_exception_context() -> bool:
+    if sys.exc_info()[0] is not None:
+        return True
+    return False
+
+
 def err_out_screen(err_msg: str, exc: BaseException | None = None):
     """Print an error message to the screen and exit the program gracefully.
 
@@ -27,8 +33,15 @@ def err_out_screen(err_msg: str, exc: BaseException | None = None):
     if exc is not None:
         err_msg += f" - {exc}"
     err_msg_out = "ERROR: " + err_msg
+
     print(err_msg_out, flush=True)
-    traceback.print_exc()  # Only prints if an exception is currently being handled
+    LOG.critical(err_msg_out)
+
+    if in_exception_context():
+        tb = traceback.format_exc()
+        LOG.critical(f"TRACEBACK: {tb}")
+        print(tb, flush=True, file=sys.stderr)
+
     sys.exit(1)
 
 


### PR DESCRIPTION
For the medium-range lagged ensemble workflow, this adjusts the realization durations (parameter `ForecastInputHorizons`) that are written in the forcing configuration files, to match the intended time-windowing.

This also improves error messaging (see below for details).

This should be reviewed in conjunction with related PRs on other repositories:

https://github.com/NGWPC/nwm-rte/pull/52

https://github.com/NGWPC/nwm-msw-mgr/pull/54

https://github.com/NGWPC/nwm-fcst-mgr/pull/18


## Changes

- Updated forcing configuration files for medium-range lagged ensemble members to match intended time-windowing of those members (starting with member 2, each runs 6 hours aka 360 minutes longer than its previous member).
- Improved error messaging in `err_out_screen` to include traceback in to the LOG, in addition to sending the traceback to `stderr` as had been done before.

## Testing

1. Tested initial ensemble setup (not ran to completion) using nwm-rte with command: `docker_run python "/ngen-app/bin/bin_mounted/run_forecast.py" -n 2 -dt "2025-09-15 00:00:00" -rname "${fcst_run_name}_mr_le" -fconfig medium_range -le "" ""`

## Screenshots


## Notes

- For each member of the ensemble, the config file parameter `RefcstBDateProc` is overridden on-the-fly by `nwm-fcst-mgr`, but `ForecastInputHorizons` is taken as-is from each forcing config file.

## Todos

-
