### PR TITLE
Fixes grib_var handling in forcingInputMod, and a bug in bmi_model

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -300,8 +300,8 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
         dimensionality = 1 if self._grid_type == "hydrofabric" else 2
 
         if (
-            self._wrf_hydro_geo_meta.nx_local < dimensionality
-            or self._wrf_hydro_geo_meta.ny_local < dimensionality
+            self.geo_meta.nx_local < dimensionality
+            or self.geo_meta.ny_local < dimensionality
         ):
             self._job_meta.errMsg = (
                 f"You have specified too many cores for your WRF-Hydro grid. "

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
@@ -175,12 +175,13 @@ class InputForcings:
             # First call to getter, initialize
             self._grib_vars = FORCINGINPUTMOD["GRIB_VARS"][self.keyValue]
         if self.force_count == 8 and 8 in self.input_map_output:
-            # TODO: this assumes that LQFRAC (8) is always the last grib var
+            # TODO: we need to dig into LQFRAC and other non-liquid precip variables more
+            # to understand how non-LQFRAC variables (ie: FROZR, CPOFP) are being or can be used
             if (self._grib_vars is None) or (
                 not self._grib_vars[-1].startswith("LQFRAC")
             ):
-                raise ValueError(
-                    f"Expected LQFRAC to be the 8th variable; recieved: {self.grib_vars[-1]}"
+                LOG.warning(
+                    f"Expected LQFRAC to be the 8th variable; recieved: {self._grib_vars[-1]}"
                 )
             return self._grib_vars[:-1]
         else:


### PR DESCRIPTION
grib_vars was missing an underscore, causing a recursion error. Fixing that revealed that the ValueError was too tight - a warning is more suitable if the 8th variable is not LQFRAC. That just means LQFRAC won't be used, which should not be a fail condition. I updated the TODO to better understand LQFRAC and other non-liquid precip variables, to make sure we are using the models optimally. Note however that HRRR and RAP will be deprecated when RRFS comes online, so really, we need to understand what RRFS has available, and how to best utilize it.  


