### PR TITLE
feat: trigger ngen downstream on successful BMI build

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -284,3 +284,26 @@ jobs:
               --all \
               "docker://${IMAGE_BASE}:${TEST_TAG}" "docker://${IMAGE_BASE}:latest"
           fi
+
+  # trigger downstream ngen CI/CD pipeline
+  trigger-ngen:
+    name: trigger-ngen
+    if: success()
+    runs-on: ubuntu-latest
+    needs:
+      - pipeline-bmi
+      - pipeline-coastal
+      - pipeline-sfincs
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PIPELINE_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Trigger ngen CI/CD
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run ngwpc-cicd.yml --repo NGWPC/ngen --ref development

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,6 +31,23 @@ on:
         description: 'EWTS_REF'
         required: false
         type: string
+      TRIGGER_DOWNSTREAM:
+        description: 'Trigger downstream repos'
+        required: false
+        default: false
+        type: boolean
+      NGEN_REF:
+        description: 'NGEN_REF'
+        required: false
+        type: string
+      NWM_CAL_MGR_REF:
+        description: 'NWM_CAL_MGR_REF'
+        required: false
+        type: string
+      NWM_FCST_MGR_REF:
+        description: 'NWM_FCST_MGR_REF'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -181,7 +198,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Log in to registry
         uses: docker/login-action@v3
         with:
@@ -190,7 +207,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build & push BMI Forcing
         id: build_bmi_image # set ID to capture output from this step to use outputs like digest, imageid, and metadata
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           load: false
           platforms: linux/amd64
@@ -285,23 +302,36 @@ jobs:
               "docker://${IMAGE_BASE}:${TEST_TAG}" "docker://${IMAGE_BASE}:latest"
           fi
 
-  # trigger downstream ngen CI/CD pipeline
+  # trigger downstream repo ngen
+  # always passes TRIGGER_DOWNSTREAM=true to ngen so the chain propagates to nwm-cal-mgr and nwm-fcst-mgr
   trigger-ngen:
     name: trigger-ngen
-    if: needs.pipeline-bmi.result == 'success'
+    if: |
+      success() && (
+        (github.event_name == 'push' && github.ref_name == 'development') ||
+        (github.event_name == 'workflow_dispatch' && inputs.TRIGGER_DOWNSTREAM)
+      )
     runs-on: ubuntu-latest
     needs:
       - pipeline-bmi
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.PIPELINE_APP_ID }}
+          client-id: ${{ secrets.PIPELINE_APP_ID }}
           private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
       - name: Trigger ngen CI/CD
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NGEN_REF: ${{ inputs.NGEN_REF || 'development' }}
+          NWM_CAL_MGR_REF: ${{ inputs.NWM_CAL_MGR_REF || 'development' }}
+          NWM_FCST_MGR_REF: ${{ inputs.NWM_FCST_MGR_REF || 'development' }}
         run: |
-          gh workflow run ngwpc-cicd.yml --repo NGWPC/ngen --ref development
+          gh workflow run ngwpc-cicd.yml \
+            --repo ${{ github.repository_owner }}/ngen \
+            --ref "$NGEN_REF" \
+            -f TRIGGER_DOWNSTREAM=true \
+            -f NWM_CAL_MGR_REF="$NWM_CAL_MGR_REF" \
+            -f NWM_FCST_MGR_REF="$NWM_FCST_MGR_REF"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -288,12 +288,10 @@ jobs:
   # trigger downstream ngen CI/CD pipeline
   trigger-ngen:
     name: trigger-ngen
-    if: success()
+    if: needs.pipeline-bmi.result == 'success'
     runs-on: ubuntu-latest
     needs:
       - pipeline-bmi
-      - pipeline-coastal
-      - pipeline-sfincs
     steps:
       - name: Generate GitHub App token
         id: app-token

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v4
       - name: Log in to registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,6 +23,10 @@ on:
         description: 'BMI_BASE_TAG'
         required: false
         type: string
+      GHCR_ORG:
+        description: 'GHCR_ORG'
+        required: false
+        type: string
       EWTS_ORG:
         description: 'EWTS_ORG'
         required: false
@@ -46,6 +50,14 @@ on:
         type: string
       NWM_FCST_MGR_REF:
         description: 'NWM_FCST_MGR_REF'
+        required: false
+        type: string
+      MSW_MGR_ORG:
+        description: 'MSW_MGR_ORG'
+        required: false
+        type: string
+      MSW_MGR_REF:
+        description: 'MSW_MGR_REF'
         required: false
         type: string
 
@@ -222,7 +234,7 @@ jobs:
             BMI_BASE_TAG=${{ needs.setup.outputs.bmi_base_tag }}
             BMI_BASE_DIGEST=${{ needs.setup.outputs.bmi_base_digest }}
             BMI_BASE_REVISION=${{ needs.setup.outputs.bmi_base_revision }}
-            EWTS_ORG=${{ inputs.EWTS_ORG || 'NGWPC' }}
+            EWTS_ORG=${{ inputs.EWTS_ORG || github.repository_owner }}
             EWTS_REF=${{ inputs.EWTS_REF || 'development' }}
             IMAGE_SOURCE=https://github.com/${{ github.repository }}
             IMAGE_VENDOR=${{ github.repository_owner }}
@@ -313,6 +325,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     needs:
+      - setup
       - pipeline-bmi
     steps:
       - name: Generate GitHub App token
@@ -328,10 +341,20 @@ jobs:
           NGEN_REF: ${{ inputs.NGEN_REF || 'development' }}
           NWM_CAL_MGR_REF: ${{ inputs.NWM_CAL_MGR_REF || 'development' }}
           NWM_FCST_MGR_REF: ${{ inputs.NWM_FCST_MGR_REF || 'development' }}
+          EWTS_ORG: ${{ inputs.EWTS_ORG || github.repository_owner }}
+          EWTS_REF: ${{ inputs.EWTS_REF || 'development' }}
+          MSW_MGR_ORG: ${{ inputs.MSW_MGR_ORG || github.repository_owner }}
+          MSW_MGR_REF: ${{ inputs.MSW_MGR_REF || 'development' }}
+          GHCR_ORG: ${{ inputs.GHCR_ORG || needs.setup.outputs.org }}
         run: |
           gh workflow run ngwpc-cicd.yml \
             --repo ${{ github.repository_owner }}/ngen \
             --ref "$NGEN_REF" \
             -f TRIGGER_DOWNSTREAM=true \
             -f NWM_CAL_MGR_REF="$NWM_CAL_MGR_REF" \
-            -f NWM_FCST_MGR_REF="$NWM_FCST_MGR_REF"
+            -f NWM_FCST_MGR_REF="$NWM_FCST_MGR_REF" \
+            -f EWTS_ORG="$EWTS_ORG" \
+            -f EWTS_REF="$EWTS_REF" \
+            -f MSW_MGR_ORG="$MSW_MGR_ORG" \
+            -f MSW_MGR_REF="$MSW_MGR_REF" \
+            -f GHCR_ORG="$GHCR_ORG"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -304,4 +304,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh workflow run ngwpc-cicd.yml --repo NGWPC/ngen --ref feat/trigger-downstream-pipelines
+          gh workflow run ngwpc-cicd.yml --repo NGWPC/ngen --ref development

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -304,4 +304,4 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh workflow run ngwpc-cicd.yml --repo NGWPC/ngen --ref development
+          gh workflow run ngwpc-cicd.yml --repo NGWPC/ngen --ref feat/trigger-downstream-pipelines

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -346,6 +346,7 @@ jobs:
           MSW_MGR_ORG: ${{ inputs.MSW_MGR_ORG || github.repository_owner }}
           MSW_MGR_REF: ${{ inputs.MSW_MGR_REF || 'development' }}
           GHCR_ORG: ${{ inputs.GHCR_ORG || needs.setup.outputs.org }}
+          NGEN_FORCING_IMAGE_TAG: ${{ needs.setup.outputs.alias_tag }}
         run: |
           gh workflow run ngwpc-cicd.yml \
             --repo ${{ github.repository_owner }}/ngen \
@@ -357,4 +358,5 @@ jobs:
             -f EWTS_REF="$EWTS_REF" \
             -f MSW_MGR_ORG="$MSW_MGR_ORG" \
             -f MSW_MGR_REF="$MSW_MGR_REF" \
-            -f GHCR_ORG="$GHCR_ORG"
+            -f GHCR_ORG="$GHCR_ORG" \
+            -f NGEN_FORCING_IMAGE_TAG="$NGEN_FORCING_IMAGE_TAG"


### PR DESCRIPTION
## Summary
- Adds a `trigger-ngen` job to the CI/CD pipeline that fires the ngen `ngwpc-cicd.yml` workflow after a successful BMI forcing build
- `trigger-ngen` only requires `pipeline-bmi` (not coastal/sfincs) since ngen only consumes the BMI forcing image
- Uses the NGWPC Pipeline App (GitHub App token) for cross-repo workflow dispatch

## Merge order
**Merge `ngen` feat/trigger-downstream-pipelines first** so the `trigger-downstream` job exists on ngen's `development` branch before this is merged.

## Test plan
- [x] Full chain validated end-to-end: ngen-forcing → ngen → nwm-cal-mgr + nwm-fcst-mgr all completed successfully