### PR TITLE
Fix optional usage of log_error and log_critical

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -173,7 +173,7 @@ def log_error(ConfigOptions, MpiConfig, msg: str = None):
             raise TypeError(
                 f"Expected type str or NoneType for msg, got type: {type(msg)}"
             )
-        ConfigOptions.statusMsg = msg
+        ConfigOptions.errMsg = msg
 
     try:
         LOG.error("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)
@@ -200,7 +200,7 @@ def log_critical(ConfigOptions, MpiConfig, msg: str = None):
             raise TypeError(
                 f"Expected type str or NoneType for msg, got type: {type(msg)}"
             )
-        ConfigOptions.statusMsg = msg
+        ConfigOptions.errMsg = msg
 
     try:
         LOG.critical("RANK: " + str(MpiConfig.rank) + " - " + ConfigOptions.errMsg)


### PR DESCRIPTION
When optional `msg` was added to functions `err_handler.log_error` and `err_handler.log_critical`, they were originally setting `.errMsg`, but are currently setting `.statusMsg`. This reverts to the `.errMsg` behavior.

## Additions

-

## Removals

-

## Changes

-

## Testing

1. `log_error` and `log_critical` set `.errMsg` instead of `.statusMsg`.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

