### PR TITLE
Memory bug (release-candidate)

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -398,6 +398,8 @@ class AORCConusProcessor(BaseProcessor):
         self.x_label = "longitude"
         self.y_label = "latitude"
         self.time_label = "time"
+        self._ds: xr.Dataset = None
+        self._ds_year = None
 
     @cached_property
     def src_crs(self) -> CRS:
@@ -431,13 +433,15 @@ class AORCConusProcessor(BaseProcessor):
             return cached_data
         current_year = self.current_time.year
         try:
-            object_store = obstore.store.from_url(self.url(self.current_time.year), skip_signature=True)
-            with (
-                xr.open_zarr(ObjectStore(object_store)) as ds,
-                self.timing_block(f"Loading {self.dataset_name} data")
-            ):
+            if self._ds_year != current_year:
+                if self._ds is not None:
+                    self._ds.close()
+                object_store = obstore.store.from_url(self.url(current_year), skip_signature=True)
+                self._ds = xr.open_zarr(ObjectStore(object_store))
+                self._ds_year = current_year
+            with self.timing_block(f"Loading {self.dataset_name} data"):
                 return (
-                    self.slice_ds(ds)
+                    self.slice_ds(self._ds)
                     .rename({self.x_label: "x", self.y_label: "y"})
                     .load()
                 )

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -9,6 +9,7 @@ from functools import cached_property
 from time import perf_counter, sleep
 
 import ewts
+import gc
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
@@ -223,6 +224,7 @@ class BaseProcessor:
         self.current_time = current_time
         if self.current_time in self.start_end_datetimes.keys():
             self.computed_ds = self.compute_ds()
+            gc.collect()  # reclaim potentially large previous computed_ds explicitly since memory management is an ongoing issue
         if self.current_time not in self.computed_ds.time.values:
             raise IndexError(
                 f"The time provided ({self.current_time}) is not in the dataset. Please check that you have provided a time span that is valid for the given domain/dataset."
@@ -398,8 +400,6 @@ class AORCConusProcessor(BaseProcessor):
         self.x_label = "longitude"
         self.y_label = "latitude"
         self.time_label = "time"
-        self._ds: xr.Dataset = None
-        self._ds_year = None
 
     @cached_property
     def src_crs(self) -> CRS:
@@ -433,15 +433,13 @@ class AORCConusProcessor(BaseProcessor):
             return cached_data
         current_year = self.current_time.year
         try:
-            if self._ds_year != current_year:
-                if self._ds is not None:
-                    self._ds.close()
-                object_store = obstore.store.from_url(self.url(current_year), skip_signature=True)
-                self._ds = xr.open_zarr(ObjectStore(object_store))
-                self._ds_year = current_year
-            with self.timing_block(f"Loading {self.dataset_name} data"):
+            object_store = obstore.store.from_url(self.url(current_year), skip_signature=True)
+            with (
+                xr.open_dataset(ObjectStore(object_store), engine="zarr") as ds,
+                self.timing_block(f"Loading {self.dataset_name} data")
+            ):
                 return (
-                    self.slice_ds(self._ds)
+                    self.slice_ds(ds)
                     .rename({self.x_label: "x", self.y_label: "y"})
                     .load()
                 )

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -430,17 +430,14 @@ class AORCConusProcessor(BaseProcessor):
         if cached_data is not None:
             return cached_data
         current_year = self.current_time.year
-        previous_year = (self.current_time - timedelta(hours=1)).year
         try:
-            if (
-                current_year != previous_year
-                and previous_year in self.s3_lazy_ds
+            object_store = obstore.store.from_url(self.url(self.current_time.year), skip_signature=True)
+            with (
+                xr.open_zarr(ObjectStore(object_store)) as ds,
+                self.timing_block(f"Loading {self.dataset_name} data")
             ):
-                self.s3_lazy_ds[previous_year].close()
-                del self.s3_lazy_ds[previous_year]
-            with self.timing_block(f"Loading {self.dataset_name} data"):
                 return (
-                    self.slice_ds(self.s3_lazy_ds[current_year])
+                    self.slice_ds(ds)
                     .rename({self.x_label: "x", self.y_label: "y"})
                     .load()
                 )
@@ -448,15 +445,6 @@ class AORCConusProcessor(BaseProcessor):
             error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}: {e}\n"
             LOG.critical(error_message)
             raise ValueError(error_message)
-
-    @cached_property
-    def s3_lazy_ds(self) -> dict[int, xr.Dataset]:
-        """Lazy load dataset from S3."""
-        year_datasets = {}
-        for year in self.years:
-            object_store = obstore.store.from_url(self.url(year), skip_signature=True)
-            year_datasets[year] = xr.open_zarr(ObjectStore(object_store))
-        return year_datasets
 
 
 class AORCAlaskaProcessor(BaseProcessor):
@@ -609,6 +597,7 @@ class NWMV3ConusProcessor(NWMV3Processor):
         for var in self.vars:
             try:
                 with self.timing_block(f"lazy loading {self.dataset_name} data"):
+                    object_store = obstore.store.from_url(self.url(var), skip_signature=True)
                     datasets.append(self.slice_ds(self.s3_lazy_ds[var]))
             except Exception as e:
                 LOG.critical(

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -440,7 +440,10 @@ class AORCConusProcessor(BaseProcessor):
         if cached_data is not None:
             return cached_data
         try:
-            if self.current_timesteps_year != self.previous_timesteps_year:
+            if (
+                self.current_timesteps_year != self.previous_timesteps_year
+                and self.previous_timesteps_year in self.s3_lazy_ds
+            ):
                 del self.s3_lazy_ds[self.previous_timesteps_year]
             with self.timing_block(f"Loading {self.dataset_name} data"):
                 return (
@@ -773,10 +776,3 @@ class NWMV3AlaskaProcessor(NWMV3Processor):
         return ds
 
 
-import pandas as pd
-
-path1 = r"C:\Users\mdeshotel\Downloads\Import\Import\SMAPngen\gages-14166500_soil_moisture.csv"
-path2 = r"C:\Users\mdeshotel\Downloads\Import\Import\SMAPappEEARS\554ce064-5103-4a2d-9171-383ce2c377be\SMAP-SPL4-14166500-LONG-TOM-RIVER-NEAR-NOTI-OR-SPL4SMGP-008-results.csv"
-df1 = pd.read_csv(path1)
-
-df2 = pd.read_csv(path2)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -420,6 +420,16 @@ class AORCConusProcessor(BaseProcessor):
         return url
 
     @property
+    def current_timesteps_year(self):
+        """Year for the current timestep."""
+        return self.current_time.year
+
+    @property
+    def previous_timesteps_year(self):
+        """Year for the previous timestep."""
+        return (self.current_time - timedelta(hours=1)).year
+
+    @property
     def sliced_ds(self) -> xr.Dataset:
         """Sliced dataset.
 
@@ -430,14 +440,16 @@ class AORCConusProcessor(BaseProcessor):
         if cached_data is not None:
             return cached_data
         try:
+            if self.current_timesteps_year != self.previous_timesteps_year:
+                del self.s3_lazy_ds[self.previous_timesteps_year]
             with self.timing_block(f"Loading {self.dataset_name} data"):
                 return (
-                    self.slice_ds(self.s3_lazy_ds[self.current_time.year])
+                    self.slice_ds(self.s3_lazy_ds[self.current_timesteps_year])
                     .rename({self.x_label: "x", self.y_label: "y"})
                     .load()
                 )
         except Exception as e:
-            error_message = f"Error opening {self.dataset_name} data from {self.url(self.current_time.year)}: {e}\n"
+            error_message = f"Error opening {self.dataset_name} data from {self.url(self.current_timesteps_year)}: {e}\n"
             LOG.critical(error_message)
             raise ValueError(error_message)
 
@@ -759,3 +771,12 @@ class NWMV3AlaskaProcessor(NWMV3Processor):
         )
         ds.rio.write_crs(self.src_crs, inplace=True)
         return ds
+
+
+import pandas as pd
+
+path1 = r"C:\Users\mdeshotel\Downloads\Import\Import\SMAPngen\gages-14166500_soil_moisture.csv"
+path2 = r"C:\Users\mdeshotel\Downloads\Import\Import\SMAPappEEARS\554ce064-5103-4a2d-9171-383ce2c377be\SMAP-SPL4-14166500-LONG-TOM-RIVER-NEAR-NOTI-OR-SPL4SMGP-008-results.csv"
+df1 = pd.read_csv(path1)
+
+df2 = pd.read_csv(path2)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -420,16 +420,6 @@ class AORCConusProcessor(BaseProcessor):
         return url
 
     @property
-    def current_timesteps_year(self):
-        """Year for the current timestep."""
-        return self.current_time.year
-
-    @property
-    def previous_timesteps_year(self):
-        """Year for the previous timestep."""
-        return (self.current_time - timedelta(hours=1)).year
-
-    @property
     def sliced_ds(self) -> xr.Dataset:
         """Sliced dataset.
 
@@ -439,20 +429,23 @@ class AORCConusProcessor(BaseProcessor):
         cached_data = self.load_cache()
         if cached_data is not None:
             return cached_data
+        current_year = self.current_time.year
+        previous_year = (self.current_time - timedelta(hours=1)).year
         try:
             if (
-                self.current_timesteps_year != self.previous_timesteps_year
-                and self.previous_timesteps_year in self.s3_lazy_ds
+                current_year != previous_year
+                and previous_year in self.s3_lazy_ds
             ):
-                del self.s3_lazy_ds[self.previous_timesteps_year]
+                self.s3_lazy_ds[previous_year].close()
+                del self.s3_lazy_ds[previous_year]
             with self.timing_block(f"Loading {self.dataset_name} data"):
                 return (
-                    self.slice_ds(self.s3_lazy_ds[self.current_timesteps_year])
+                    self.slice_ds(self.s3_lazy_ds[current_year])
                     .rename({self.x_label: "x", self.y_label: "y"})
                     .load()
                 )
         except Exception as e:
-            error_message = f"Error opening {self.dataset_name} data from {self.url(self.current_timesteps_year)}: {e}\n"
+            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}: {e}\n"
             LOG.critical(error_message)
             raise ValueError(error_message)
 


### PR DESCRIPTION
Memory was accruing over time during an NGEN run. This change aims to remove cached data that was not being properly cleaned from memory over time.

The issue was found in `AORCConusProcessor` where it cached the xarray Dataset per year, and that prevented datasets that could no longer be accessed from letting memory be released. The change now makes the Dataset for a year load in a `with` block to ensure memory is released after the read. There is also no cache of prior years, opting to generate the data for only the current time when the data was requested.

## Additions

-

## Removals

- `s3_lazy_ds` property on `AORCConusProcessor` class

## Changes

- `sliced_ds` property on `AORCConusProcessor` will not generate the xarray Datasets for all simulation years when `compute_ds` is called.

## Testing

1. Memory usage when the simulation year rolls over shows a meaningful drop in memory when the previous Dataset is freed followed by an increase when the next year is loaded in. The total memory used after the new data is loaded is roughly the same as the total memory used before the previous Dataset is freed, unlike the previous behavior where a noticeable, permanent increase was seen.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

