### PR TITLE
Alaska NWM Forcing: Update Path for Spatial Metadata for CRS

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -735,11 +735,24 @@ class NWMV3AlaskaProcessor(NWMV3Processor):
         return self.geo_grid["crs"].attrs["spatial_ref"]
 
     @property
+    def geogrid_ldasout_spatial_metadata_path(self) -> str:
+        """Path to geogrid spatial metadata file for assigning CRS.
+
+        Currently assumed to exist as a sibling file to the nwm_geogrid file.
+        TODO consider using forcing config attribute SpatialMetaIn, see: https://github.com/NGWPC/ngen-forcing/blob/0992b43391ba141717b7a80f10ef38478cef2eee/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/README.md?plain=1#L136-L138
+        """
+        basename = "GEOGRID_LDASOUT_Spatial_Metadata_AK.nc"
+        parent_dir = os.path.dirname(self.config_options.nwm_geogrid)
+        p = os.path.join(parent_dir, basename)
+        LOG.warning(
+            f"For Alaska NWM forcing, not using SpatialMetaIn. Using this instead to define the mesh CRS (this path assumed to be sibling of NWM_Geogrid): {p}"
+        )
+        return p
+
+    @property
     def geo_grid(self) -> xr.Dataset:
         """Load geogrid metadata."""
-        geo_grid = xr.open_dataset(
-            "/ngen-app/data/GEOGRID_LDASOUT_Spatial_Metadata_AK.nc"
-        )
+        geo_grid = xr.open_dataset(self.geogrid_ldasout_spatial_metadata_path)
         return geo_grid
 
     @cached_property

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -601,6 +601,7 @@ class NWMV3ConusProcessor(NWMV3Processor):
         for var in self.vars:
             try:
                 with self.timing_block(f"lazy loading {self.dataset_name} data"):
+                    # TODO this object_store var is not used
                     object_store = obstore.store.from_url(
                         self.url(var), skip_signature=True
                     )

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -433,10 +433,12 @@ class AORCConusProcessor(BaseProcessor):
             return cached_data
         current_year = self.current_time.year
         try:
-            object_store = obstore.store.from_url(self.url(current_year), skip_signature=True)
+            object_store = obstore.store.from_url(
+                self.url(current_year), skip_signature=True
+            )
             with (
                 xr.open_dataset(ObjectStore(object_store), engine="zarr") as ds,
-                self.timing_block(f"Loading {self.dataset_name} data")
+                self.timing_block(f"Loading {self.dataset_name} data"),
             ):
                 return (
                     self.slice_ds(ds)
@@ -599,7 +601,9 @@ class NWMV3ConusProcessor(NWMV3Processor):
         for var in self.vars:
             try:
                 with self.timing_block(f"lazy loading {self.dataset_name} data"):
-                    object_store = obstore.store.from_url(self.url(var), skip_signature=True)
+                    object_store = obstore.store.from_url(
+                        self.url(var), skip_signature=True
+                    )
                     datasets.append(self.slice_ds(self.s3_lazy_ds[var]))
             except Exception as e:
                 LOG.critical(
@@ -771,5 +775,3 @@ class NWMV3AlaskaProcessor(NWMV3Processor):
         )
         ds.rio.write_crs(self.src_crs, inplace=True)
         return ds
-
-


### PR DESCRIPTION
This updates the assumed path for the Alaska NWM forcing file that contains the spatial metadata (CRS) for Alaska NWM forcing.  It is assumed to be a sibling of the `NWM_Geogrid` configuration attribute. Note that it is not using the `SpatialMetaIn` configuration attribute.

There is a `nwm-rte` branch of the same name to download this file from s3 into the appropriate location on disk (before running ngen).

## Additions

-

## Removals

-

## Changes

- See description.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

