### PR TITLE
fixes long_range file constructor error

### DIFF
--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem1_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem1_config.yml
@@ -4,7 +4,7 @@ NWM_VERSION: 4.0
 NWM_CONFIG: "long_range_mem1"
 InputForcings: [7] 
 InputForcingDirectories: ["{root_dir}/raw_input/CFS"]
-InputForcingTypes: ["GRIB2"]
+InputForcingTypes: ["GRIB2_CFS"]
 InputMandatory: [1]
 OutputFrequency: 360
 SubOutputHour: 0

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem2_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem2_config.yml
@@ -4,7 +4,7 @@ NWM_VERSION: 4.0
 NWM_CONFIG: "long_range_mem2"
 InputForcings: [7] 
 InputForcingDirectories: ["{root_dir}/raw_input/CFS"]
-InputForcingTypes: ["GRIB2"]
+InputForcingTypes: ["GRIB2_CFS"]
 InputMandatory: [1]
 OutputFrequency: 360
 SubOutputHour: 0

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem3_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem3_config.yml
@@ -4,7 +4,7 @@ NWM_VERSION: 4.0
 NWM_CONFIG: "long_range_mem3"
 InputForcings: [7] 
 InputForcingDirectories: ["{root_dir}/raw_input/CFS"]
-InputForcingTypes: ["GRIB2"]
+InputForcingTypes: ["GRIB2_CFS"]
 InputMandatory: [1]
 OutputFrequency: 360
 SubOutputHour: 0

--- a/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem4_config.yml
+++ b/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/long_range_mem4_config.yml
@@ -4,7 +4,7 @@ NWM_VERSION: 4.0
 NWM_CONFIG: "long_range_mem4"
 InputForcings: [7] 
 InputForcingDirectories: ["{root_dir}/raw_input/CFS"]
-InputForcingTypes: ["GRIB2"]
+InputForcingTypes: ["GRIB2_CFS"]
 InputMandatory: [1]
 OutputFrequency: 360
 SubOutputHour: 0

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -354,10 +354,11 @@ class ConfigOptions:
                     "NETCDF4",
                     "NWM",
                     "ZARR",
+                    "GRIB2_CFS",
                 ]:
                     err_out_screen(
                         f'Invalid forcing file type "{file_type}" specified. '
-                        "Only GRIB1, GRIB2, NETCDF, NWM, and ZARR are supported"
+                        "Only GRIB1, GRIB2, NETCDF, NWM, ZARR, and GRIB2_CFS are supported"
                     )
 
             # Read in the input directories for each forcing option.

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/consts.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/consts.py
@@ -936,6 +936,7 @@ FORCINGINPUTMOD = {
         "NETCDF4": ".nc4",
         "NWM": ".LDASIN_DOMAIN1",
         "ZARR": ".zarr",
+        "GRIB2_CFS": ".grb2",
     },
     "config_vars_for_mapping": [
         "input_forcings",
@@ -1878,6 +1879,7 @@ FORCINGINPUTMOD = {
         "NETCDF4": ".nc4",
         "NWM": ".LDASIN_DOMAIN1",
         "ZARR": ".zarr",
+        "GRIB2_CFS": ".grb2",
     },
     "config_vars_for_mapping": [
         "input_forcings",


### PR DESCRIPTION
Adds support for .grb2 (vs. .grib2) filename extension for CFS files, by expanding consts.py and config.py to support a GRIB2_CFS InputForcingTypes parameter.