### PR TITLE
Include Forcing Config Files in Python Package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,5 +56,8 @@ include = ["NextGen_Forcings_Engine*",
     "ESMF_Mesh_Domain_Configuration_Production*"]
 namespaces = false
 
+[tool.setuptools.package-data]
+"NextGen_Forcings_Engine_BMI" = ["BMI_NextGen_Configs/**/*"]
+
 [tool.setuptools.dynamic]
 version = { attr = "NextGen_Forcings_Engine.__version__" }


### PR DESCRIPTION
Adds this block to `pyproject.toml`:

```
[tool.setuptools.package-data]
"NextGen_Forcings_Engine_BMI" = ["BMI_NextGen_Configs/**/*"]
```

So that config files are baked-in and do not need to be mounted from the repo files at runtime.

Within the ngen (and nwm-rte) image the config files end up at the following path:

`/ngen-app/ngen-python/lib/python3.11/site-packages/NextGen_Forcings_Engine_BMI/BMI_NextGen_Configs/config_templates/`


## Additions

-

## Removals

-

## Changes

- Forcing config files are now installed into the Python package's site-packages root.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

