### PR TITLE
Exclude or include or EWTS

### DIFF
--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -253,6 +253,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
     USE_EWTS_NORMALIZED="$(echo "${USE_EWTS}" | tr '[:lower:]' '[:upper:]')" && \
     if [[ "${USE_EWTS_NORMALIZED}" =~ ^(ON|YES|TRUE|1)$ ]]; then \
         echo "Installing EWTS Python package"; \
+        rm -rf /tmp/nwm-ewts && \
         (git clone --depth 1 -b "${EWTS_REF}" \
             "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts \
          || (git clone "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts && \

--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -30,7 +30,7 @@ FROM ${BMI_BASE_REPO}:${BMI_BASE_TAG}
 # Re-expose args after FROM for the remaining build stage.
 ARG GH_ORG
 ARG IMAGE_NAMESPACE
-ARG USE_EWTS
+ARG USE_EWTS=ON
 ARG EWTS_ORG
 ARG EWTS_REF
 ARG ESMF_VERSION
@@ -239,13 +239,17 @@ SHELL ["/bin/bash", "-c"]
 # ngen-bmi-forcing only needs the EWTS Python package, not the C/C++/Fortran
 # libraries or ngen bridge that the full ngen image requires.
 #
+# Ensures an unset or empty USE_EWTS defaults to ON
+#
 # USE_EWTS accepted ON values:
 #   ON, YES, TRUE, 1
 #
 # Everything else is treated as OFF.
+#
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    echo "USE_EWTS=${USE_EWTS}; EWTS org: ${EWTS_ORG}; ref: ${EWTS_REF}; cache bust: ${EWTS_CACHE_BUST}" && \
     set -eux && \
+    USE_EWTS="${USE_EWTS:-ON}" && \
+    echo "USE_EWTS=${USE_EWTS}; EWTS org: ${EWTS_ORG}; ref: ${EWTS_REF}; cache bust: ${EWTS_CACHE_BUST}" && \
     USE_EWTS_NORMALIZED="$(echo "${USE_EWTS}" | tr '[:lower:]' '[:upper:]')" && \
     if [[ "${USE_EWTS_NORMALIZED}" =~ ^(ON|YES|TRUE|1)$ ]]; then \
         echo "Installing EWTS Python package"; \

--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -9,6 +9,7 @@ ARG GH_ORG=NGWPC
 ARG IMAGE_NAMESPACE=ngwpc
 
 # External repository sources (org and ref/branch overrides)
+ARG USE_EWTS=ON
 ARG EWTS_ORG=${GH_ORG}
 ARG EWTS_REF=development
 
@@ -29,6 +30,7 @@ FROM ${BMI_BASE_REPO}:${BMI_BASE_TAG}
 # Re-expose args after FROM for the remaining build stage.
 ARG GH_ORG
 ARG IMAGE_NAMESPACE
+ARG USE_EWTS
 ARG EWTS_ORG
 ARG EWTS_REF
 ARG ESMF_VERSION
@@ -228,7 +230,7 @@ ENV OMPI_MCA_pml=ob1
 ENV OMPI_MCA_btl_base_warn_component_unused=0
 
 ############################################################################
-# EWTS Python package - changes rarely
+# Optional EWTS Python package
 ############################################################################
 
 # Reset SHELL so we're not locked into the gcc-10 build environment.
@@ -237,36 +239,39 @@ SHELL ["/bin/bash", "-c"]
 # ngen-bmi-forcing only needs the EWTS Python package, not the C/C++/Fortran
 # libraries or ngen bridge that the full ngen image requires.
 #
-# Build args – override at build time to pin a branch, tag, or full commit SHA:
-#   docker build --build-arg EWTS_REF=v1.2.3 ...
-#   docker build --build-arg EWTS_REF=abc123def456 ...
+# USE_EWTS accepted ON values:
+#   ON, YES, TRUE, 1
 #
-# Cache bust – override only when you need to force a rebuild of this layer:
-#   docker build --build-arg EWTS_CACHE_BUST="$(date +%s)" ...
-#
-# Try shallow clone by branch/tag name first; fall back to full clone + checkout
-# for bare commit SHAs, which git clone -b does not support.
+# Everything else is treated as OFF.
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    echo "EWTS org: ${EWTS_ORG}; ref: ${EWTS_REF}; cache bust: ${EWTS_CACHE_BUST}" && \
+    echo "USE_EWTS=${USE_EWTS}; EWTS org: ${EWTS_ORG}; ref: ${EWTS_REF}; cache bust: ${EWTS_CACHE_BUST}" && \
     set -eux && \
-    (git clone --depth 1 -b "${EWTS_REF}" \
-        "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts \
-     || (git clone "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts && \
-         cd /tmp/nwm-ewts && git checkout "${EWTS_REF}")) && \
-    cd /tmp/nwm-ewts && \
-    jq -n \
-      --arg commit_hash "$(git rev-parse HEAD)" \
-      --arg branch "$(git branch -r --contains HEAD 2>/dev/null | grep -v '\->' | sed 's|origin/||' | head -n1 | xargs || echo "${EWTS_REF}")" \
-      --arg tags "$(git tag --points-at HEAD 2>/dev/null | tr '\n' ' ')" \
-      --arg author "$(git log -1 --pretty=format:'%an')" \
-      --arg commit_date "$(date -u -d @$(git log -1 --pretty=format:'%ct') +'%Y-%m-%d %H:%M:%S UTC')" \
-      --arg message "$(git log -1 --pretty=format:'%s' | tr '\n' ';')" \
-      --arg build_date "$(date -u +'%Y-%m-%d %H:%M:%S UTC')" \
-      '{"nwm-ewts": {commit_hash: $commit_hash, branch: $branch, tags: $tags, author: $author, commit_date: $commit_date, message: $message, build_date: $build_date}}' \
-      > /ngen-app/nwm-ewts_git_info.json && \
-    pip install /tmp/nwm-ewts/runtime/python/ewts && \
-    cd / && \
-    rm -rf /tmp/nwm-ewts
+    USE_EWTS_NORMALIZED="$(echo "${USE_EWTS}" | tr '[:lower:]' '[:upper:]')" && \
+    if [[ "${USE_EWTS_NORMALIZED}" =~ ^(ON|YES|TRUE|1)$ ]]; then \
+        echo "Installing EWTS Python package"; \
+        (git clone --depth 1 -b "${EWTS_REF}" \
+            "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts \
+         || (git clone "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts && \
+             cd /tmp/nwm-ewts && git checkout "${EWTS_REF}")) && \
+        cd /tmp/nwm-ewts && \
+        jq -n \
+          --arg commit_hash "$(git rev-parse HEAD)" \
+          --arg branch "$(git branch -r --contains HEAD 2>/dev/null | grep -v '\->' | sed 's|origin/||' | head -n1 | xargs || echo "${EWTS_REF}")" \
+          --arg tags "$(git tag --points-at HEAD 2>/dev/null | tr '\n' ' ')" \
+          --arg author "$(git log -1 --pretty=format:'%an')" \
+          --arg commit_date "$(date -u -d @$(git log -1 --pretty=format:'%ct') +'%Y-%m-%d %H:%M:%S UTC')" \
+          --arg message "$(git log -1 --pretty=format:'%s' | tr '\n' ';')" \
+          --arg build_date "$(date -u +'%Y-%m-%d %H:%M:%S UTC')" \
+          '{"nwm-ewts": {commit_hash: $commit_hash, branch: $branch, tags: $tags, author: $author, commit_date: $commit_date, message: $message, build_date: $build_date}}' \
+          > /ngen-app/nwm-ewts_git_info.json && \
+        pip install /tmp/nwm-ewts/runtime/python/ewts && \
+        cd / && \
+        rm -rf /tmp/nwm-ewts; \
+    else \
+        echo "EWTS disabled; ensuring ewts package is absent"; \
+        pip uninstall -y ewts || true; \
+        rm -f /ngen-app/nwm-ewts_git_info.json; \
+    fi
 
 ############################################################################
 # ngen-bmi-forcing - most frequently changing layer

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_grid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_grid.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 # Use the Error, Warning, and Trapping System Package for logging
-import ewts
-LOG = ewts.get_logger(ewts.FORCING_ID)
+import logging
+LOG = logging.getLogger("FORCING")
 
 _error_on_grid_type: bool = False
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -8,8 +8,8 @@ import os
 import time
 from collections import defaultdict
 from pathlib import Path
-
-import ewts
+from datetime import datetime, timezone
+import logging
 import netCDF4 as nc
 
 # import data_tools
@@ -62,11 +62,51 @@ except ImportError:
 
 from typing import Any
 
-# Use the Error, Warning, and Trapping System Package for logging
-import ewts
 from numpy.typing import NDArray
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
+try:
+    from ewts.helper import getenv_any
+    from ewts.logger import configure_existing_logger
+    FORCING_USE_EWTS = True
+except ImportError:
+    FORCING_USE_EWTS = False
+
+class StdoutStyleFormatter(logging.Formatter):
+
+    INFO_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s %(message)s"
+    )
+
+    DETAILED_FORMAT = (
+        "%(asctime)s %(name)-8sT%(levelname)-7s "
+        "%(message)s "
+        "[%(filename)s.%(funcName)s(L%(lineno)s)]"
+    )
+
+    def format(self, record):
+        if record.levelno == logging.INFO:
+            self._style._fmt = self.INFO_FORMAT
+        else:
+            self._style._fmt = self.DETAILED_FORMAT
+
+        return super().format(record)
+    
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "Z"
+
+
+def _configure_stdout_logging():
+    LOG.setLevel(logging.INFO)
+
+    if not LOG.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(StdoutStyleFormatter())
+        LOG.addHandler(handler)
+
+    LOG.propagate = False
 
 # If less than 0, then ESMF.__version__ is greater than 8.7.0
 if ESMF.version_compare("8.7.0", ESMF.__version__) < 0:
@@ -111,6 +151,17 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
 
         Initializes the model with default values for time, variables, and grid types.
         """
+        # This is required prior to the first log message.
+        if FORCING_USE_EWTS:
+            val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+            if val in {"1", "true", "yes", "on"}:
+                configure_existing_logger(LOG)
+            else:
+                _configure_stdout_logging()
+                LOG.warning("ewts package installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
+        else:
+            _configure_stdout_logging()
+
         super(NWMv3_Forcing_Engine_BMI_model_Base, self).__init__()
         self._values = {}
         self._start_time = 0.0
@@ -185,8 +236,6 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
         :param config_file: The path to the configuration file for model initialization.
         :raises RuntimeError: If the configuration file is invalid or missing.
         """
-        # This is required prior to the first log message.
-        LOG.bind()
 
         LOG.info("---------------------------")
         LOG.info(

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -79,7 +79,7 @@ class StdoutStyleFormatter(logging.Formatter):
     )
 
     DETAILED_FORMAT = (
-        "%(asctime)s %(name)-8sT%(levelname)-7s "
+        "%(asctime)s %(name)-8s %(levelname)-7s "
         "%(message)s "
         "[%(filename)s.%(funcName)s(L%(lineno)s)]"
     )
@@ -94,7 +94,7 @@ class StdoutStyleFormatter(logging.Formatter):
     
     def formatTime(self, record, datefmt=None):
         dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
-        return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] + "Z"
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
 
 def _configure_stdout_logging():

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/config.py
@@ -7,7 +7,6 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 # Use the Error, Warning, and Trapping System Package for logging
-import ewts
 import numpy as np
 
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.err_handler import (
@@ -19,7 +18,7 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.time_handling impo
 
 from . import mpi_utils
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 FORCE_COUNT = 27
 
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -10,7 +10,8 @@ import numpy as np
 from mpi4py import MPI
 from scipy import spatial
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+# Use the Error, Warning, and Trapping System Package for logging
+LOG = logging.getLogger("FORCING")
 
 
 def in_exception_context() -> bool:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/forcingInputMod.py
@@ -24,9 +24,8 @@ if TYPE_CHECKING:
     from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.parallel import (
         MpiConfig,
     )
-import ewts
-
-LOG = ewts.get_logger(ewts.FORCING_ID)
+import logging
+LOG = logging.getLogger("FORCING")
 
 
 class InputForcings:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/geoMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/geoMod.py
@@ -17,8 +17,7 @@ except ImportError:
 
 from functools import cached_property, wraps
 from typing import Any
-
-import ewts
+import logging
 import xarray as xr
 
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.config import (
@@ -30,7 +29,7 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.err_handler import
 )
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.parallel import MpiConfig
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
 
 def set_none(func) -> Any:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -13,14 +13,13 @@ import shutil
 import subprocess
 import sys
 from typing import Optional
-
-import ewts
+import logging
 import numpy as np
 from netCDF4 import Dataset
 
 from . import err_handler
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
 
 if "WGRIB2" not in os.environ:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/regrid.py
@@ -57,9 +57,7 @@ if TYPE_CHECKING:
     from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.parallel import (
         MpiConfig,
     )
-
-import ewts
-
+import logging
 from ..esmf_utils import (
     esmf_field_retry,
     esmf_grid_retry,
@@ -69,7 +67,7 @@ from ..esmf_utils import (
     esmf_regridobj_call_retry,
 )
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
 
 if "WGRIB2" not in os.environ:

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/time_handling.py
@@ -7,8 +7,7 @@ import glob
 import math
 import os
 from typing import TYPE_CHECKING
-
-import ewts
+import logging
 import numpy as np
 import pandas as pd
 
@@ -27,10 +26,8 @@ if TYPE_CHECKING:
     from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.suppPrecipMod import (
         supplemental_precip as SupplementalPrecip,
     )
-# Use the Error, Warning, and Trapping System Package for logging
-import ewts
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
 
 NETCDF = "NETCDF"

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -8,8 +8,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 from functools import cached_property
 from time import perf_counter, sleep
-
-import ewts
+import logging
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,7 +27,7 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.config import (
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.parallel import MpiConfig
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.general_utils import rand_str
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
 zarr.config.set({"async.concurrency": 100})
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -2,8 +2,7 @@ import datetime
 import os
 from contextlib import contextmanager
 from time import time
-
-import ewts
+import logging
 import numpy as np
 import pandas as pd
 from ewts import Payload as Pld
@@ -33,7 +32,7 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.historical_forcing impo
     NWMV3OConusProcessor,
 )
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
 MODNM = ModuleKey.FORCING.value
 


### PR DESCRIPTION
Update to reconfigure a native Python logger to an EWTS logger when the ewts package is installed and the `EWTS_USE_NGEN_BRIDGE` environment variable set by ngen indicating to use ewts for logging.

## Additions

- Call to `configure_existing_logger` when ewts is present and `EWTS_USE_NGEN_BRIDGE` is true
- Logs to stdout follow same format pattern currently used by ewts, <timestamp> <module> <log level> <message>. If log level above INFO, the filename, method name and line number also appended to the log message.

## Removals

- Importing ewts in all modules that log

## Changes

- Change setting `LOG` from the ewts named logger to an Python logger named `FORCING` 

## Testing

1. Tested with docker build command build argument `USE_EWTS` set `ON` 
2. Tested with docker build command build argument `USE_EWTS` set `OFF`
3. Tested with docker build command build argument `USE_EWTS` not set, which defaults to `ON`