### PR TITLE
revert domain name in sub-directory name for mrms multisensor

### DIFF
--- a/Forcing_Extraction_Scripts/CONUS/get_conus_MRMS_MultiSensor.py
+++ b/Forcing_Extraction_Scripts/CONUS/get_conus_MRMS_MultiSensor.py
@@ -28,7 +28,9 @@ class MRMSMultiSensorConusDownloader(FixedFileDownloader, ABC):
     def get_file_specs(self, d_start):
         specs = []
         for pass_num in ["Pass1", "Pass2"]:
-            subdir = f"CONUS/MultiSensor_QPE_01H_{pass_num}_00.00/{d_start.strftime('%Y%m%d')}"
+            subdir = (
+                f"MultiSensor_QPE_01H_{pass_num}_00.00/{d_start.strftime('%Y%m%d')}"
+            )
             filename = f"MRMS_MultiSensor_QPE_01H_{pass_num}_00.00_{d_start.strftime('%Y%m%d')}-{d_start.strftime('%H')}0000.grib2.gz"
             specs.append((subdir, filename))
         return specs

--- a/Forcing_Extraction_Scripts/Hawaii/get_MRMS_MultiSensor_Hawaii.py
+++ b/Forcing_Extraction_Scripts/Hawaii/get_MRMS_MultiSensor_Hawaii.py
@@ -22,7 +22,9 @@ class MRMSMultiSensorHawaiiDownloader(FixedFileDownloader, ABC):
     def get_file_specs(self, d_start):
         specs = []
         for pass_num in ["Pass1", "Pass2"]:
-            subdir = f"Hawaii/MultiSensor_QPE_01H_{pass_num}_00.00/{d_start.strftime('%Y%m%d')}"
+            subdir = (
+                f"MultiSensor_QPE_01H_{pass_num}_00.00/{d_start.strftime('%Y%m%d')}"
+            )
             filename = f"MRMS_MultiSensor_QPE_01H_{pass_num}_00.00_{d_start.strftime('%Y%m%d')}-{d_start.strftime('%H')}0000.grib2.gz"
             specs.append((subdir, filename))
         return specs

--- a/Forcing_Extraction_Scripts/Puerto_Rico/get_MRMS_MultiSensor_Puerto_Rico.py
+++ b/Forcing_Extraction_Scripts/Puerto_Rico/get_MRMS_MultiSensor_Puerto_Rico.py
@@ -21,7 +21,9 @@ class MRMSMultiSensorPuertoRicoDownloader(FixedFileDownloader, ABC):
     def get_file_specs(self, d_start):
         specs = []
         for pass_num in ["Pass1", "Pass2"]:
-            subdir = f"CARIB/MultiSensor_QPE_01H_{pass_num}_00.00/{d_start.strftime('%Y%m%d')}"
+            subdir = (
+                f"MultiSensor_QPE_01H_{pass_num}_00.00/{d_start.strftime('%Y%m%d')}"
+            )
             filename = f"MRMS_MultiSensor_QPE_01H_{pass_num}_00.00_{d_start.strftime('%Y%m%d')}-{d_start.strftime('%H')}0000.grib2.gz"
             specs.append((subdir, filename))
         return specs


### PR DESCRIPTION
Revert domain name in sub-directory names for MRMS multi-sensor extraction scripts.

This bug was introduced in: [https://github.com/NGWPC/ngen-forcing/pull/171](url)

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

