### PR TITLE
Build the dependencies base image in CI and integrate it with our downstream build process

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,14 +9,6 @@ on:
       - nwm-master
       - development
       - release-candidate
-    # A change to ONLY the dependencies image must not self-trigger this forcing
-    # build. dependencies.yml builds the new base first, then dispatches this
-    # workflow against it (see its trigger-forcing job), preserving deps-before-
-    # forcing order. Without this, a deps push would race a forcing build here
-    # against the old base.
-    paths-ignore:
-      - 'Dockerfile.dependencies'
-      - '.github/workflows/dependencies.yml'
   pull_request:
     branches:
       - ngwpc-candidate
@@ -25,17 +17,31 @@ on:
       - nwm-master
       - development
       - release-candidate
-    paths-ignore:
-      - 'Dockerfile.dependencies'
-      - '.github/workflows/dependencies.yml'
   workflow_dispatch:
     inputs:
+      rebuild_deps:
+        description: 'Force a rebuild of the dependencies image before building forcing'
+        required: false
+        default: false
+        type: boolean
+      deps_base_repo:
+        description: 'Base image to compile the dependencies from (default rockylinux)'
+        required: false
+        type: string
+      deps_base_tag:
+        description: 'Dependencies base image tag (default 8)'
+        required: false
+        type: string
+      deps_base_suffix:
+        description: 'Override the published deps name suffix (default derived, e.g. rocky8)'
+        required: false
+        type: string
       BMI_BASE_REPO:
-        description: 'Base dependencies image repo (default ghcr.io/<org>/ngen-dependencies-rocky8)'
+        description: 'Deps image repo to build forcing FROM when not rebuilding deps (default ghcr.io/<org>/ngen-dependencies-rocky8)'
         required: false
         type: string
       BMI_BASE_TAG:
-        description: 'Base dependencies image tag (default latest)'
+        description: 'Deps image tag to build forcing FROM when not rebuilding deps (default latest)'
         required: false
         type: string
       GHCR_ORG:
@@ -75,6 +81,34 @@ on:
         description: 'MSW_MGR_REF'
         required: false
         type: string
+      SZIP_VERSION:
+        description: 'Deps image: SZIP version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      HDF5_VERSION:
+        description: 'Deps image: HDF5 version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      NETCDF_C_VERSION:
+        description: 'Deps image: NetCDF-C version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      NETCDF_FORTRAN_VERSION:
+        description: 'Deps image: NetCDF-Fortran version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      BOOST_VERSION:
+        description: 'Deps image: Boost version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      ESMF_VERSION:
+        description: 'Deps image: ESMF version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      GDAL_VERSION:
+        description: 'Deps image: GDAL version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -91,18 +125,13 @@ jobs:
     outputs:
       org: ${{ steps.vars.outputs.org }}
       bmi_image: ${{ steps.vars.outputs.bmi_image }}
-      bmi_base_repo: ${{ steps.vars.outputs.bmi_base_repo }}
-      bmi_base_name: ${{ steps.vars.outputs.bmi_base_name }}
-      bmi_base_tag: ${{ steps.vars.outputs.bmi_base_tag }}
-      bmi_base_digest: ${{ steps.vars.outputs.bmi_base_digest }}
-      bmi_base_revision: ${{ steps.vars.outputs.bmi_base_revision }}
-      ewts_revision: ${{ steps.vars.outputs.ewts_revision }}
       commit_sha: ${{ steps.vars.outputs.commit_sha }}
       commit_sha_short: ${{ steps.vars.outputs.commit_sha_short }}
       test_image_tag: ${{ steps.vars.outputs.test_image_tag }}
       alias_tag: ${{ steps.vars.outputs.alias_tag }}
       clean_ref: ${{ steps.vars.outputs.clean_ref }}
       default_ref: ${{ steps.vars.outputs.default_ref }}
+      ewts_revision: ${{ steps.vars.outputs.ewts_revision }}
       ewts_cache_bust: ${{ steps.vars.outputs.ewts_cache_bust }}
     steps:
       - name: Compute image vars
@@ -146,24 +175,6 @@ jobs:
           esac
           # use an explicit *_REF input if provided, else DEFAULT_REF
           ref_or_default() { [ -n "$1" ] && echo "$1" || echo "$DEFAULT_REF"; }
-
-          # skopeo is needed to inspect the base image
-          if ! command -v skopeo >/dev/null 2>&1; then
-            sudo apt-get update -y
-            sudo apt-get install -y --no-install-recommends skopeo
-          fi
-
-          # base image = the prebuilt compiled-dependencies image that
-          # Dockerfile.bmi-forcings builds FROM (published by dependencies.yml).
-          # Both repo and tag are overridable so any base can be passed in;
-          # default is ngen-dependencies-rocky8:latest in this org's registry.
-          BMI_BASE_REPO="${{ inputs.BMI_BASE_REPO || '' }}"
-          [ -n "$BMI_BASE_REPO" ] || BMI_BASE_REPO="${REGISTRY}/${ORG}/ngen-dependencies-rocky8"
-          BMI_BASE_TAG="${{ inputs.BMI_BASE_TAG || 'latest' }}"
-          BMI_BASE_NAME="${BMI_BASE_REPO}:${BMI_BASE_TAG}"
-          BMI_BASE_INSPECT=$(skopeo inspect --override-os linux --override-arch amd64 "docker://${BMI_BASE_NAME}" 2>/dev/null || echo '{}')
-          BMI_BASE_DIGEST=$(echo "$BMI_BASE_INSPECT" | jq -r '.Digest // "unknown"')
-          BMI_BASE_REVISION=$(echo "$BMI_BASE_INSPECT" | jq -r '.Labels["org.opencontainers.image.revision"] // .Labels["io.ngwpc.image.base.revision"] // "unknown"')
 
           # resolve each source repo's ref (branch/tag/SHA) to its commit SHA for revision labels
           resolve_sha() {
@@ -216,11 +227,6 @@ jobs:
           cat >> "$GITHUB_OUTPUT" <<EOF
           org=${ORG}
           bmi_image=${IMAGE_BASE}/ngen-bmi-forcing
-          bmi_base_repo=${BMI_BASE_REPO}
-          bmi_base_name=${BMI_BASE_NAME}
-          bmi_base_tag=${BMI_BASE_TAG}
-          bmi_base_digest=${BMI_BASE_DIGEST}
-          bmi_base_revision=${BMI_BASE_REVISION}
           ewts_revision=${EWTS_REVISION}
           ewts_cache_bust=${EWTS_CACHE_BUST}
           test_image_tag=${TEST_TAG}
@@ -230,6 +236,56 @@ jobs:
           clean_ref=${CLEAN_REF}
           default_ref=${DEFAULT_REF}
           EOF
+
+  # detect whether this change touched the dependency image files, so the deps
+  # rebuild below runs only when needed (or when manually forced)
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    outputs:
+      deps: ${{ steps.filter.outputs.deps || 'false' }}
+      versions: ${{ steps.versions.outputs.set || 'false' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: filter
+        if: github.event_name != 'workflow_dispatch'
+        with:
+          filters: |
+            deps:
+              - 'Dockerfile.dependencies'
+              - '.github/workflows/dependencies.yml'
+      - name: Detect dependency version overrides
+        id: versions
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          # if any dependency version input was provided, force a deps rebuild so
+          # the override actually takes effect
+          if [ -n "${{ inputs.SZIP_VERSION }}${{ inputs.HDF5_VERSION }}${{ inputs.NETCDF_C_VERSION }}${{ inputs.NETCDF_FORTRAN_VERSION }}${{ inputs.BOOST_VERSION }}${{ inputs.ESMF_VERSION }}${{ inputs.GDAL_VERSION }}" ]; then
+            echo "set=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # rebuild the compiled-dependencies base image, ONLY when the deps files
+  # changed or a rebuild is forced. pipeline-bmi `needs` this, so forcing always
+  # builds AFTER the new base exists. This is the reusable workflow dependencies.yml.
+  dependencies:
+    name: dependencies
+    needs: changes
+    if: ${{ needs.changes.outputs.deps == 'true' || inputs.rebuild_deps || needs.changes.outputs.versions == 'true' }}
+    uses: ./.github/workflows/dependencies.yml
+    with:
+      deps_base_repo: ${{ inputs.deps_base_repo }}
+      deps_base_tag: ${{ inputs.deps_base_tag }}
+      deps_base_suffix: ${{ inputs.deps_base_suffix }}
+      ghcr_org: ${{ inputs.GHCR_ORG }}
+      szip_version: ${{ inputs.SZIP_VERSION }}
+      hdf5_version: ${{ inputs.HDF5_VERSION }}
+      netcdf_c_version: ${{ inputs.NETCDF_C_VERSION }}
+      netcdf_fortran_version: ${{ inputs.NETCDF_FORTRAN_VERSION }}
+      boost_version: ${{ inputs.BOOST_VERSION }}
+      esmf_version: ${{ inputs.ESMF_VERSION }}
+      gdal_version: ${{ inputs.GDAL_VERSION }}
 
   # CodeQL scan
   codeql-scan:
@@ -264,12 +320,14 @@ jobs:
   # build ngen-bmi-forcing Docker image
   pipeline-bmi:
     name: pipeline-bmi
-    if: |
-      (github.event_name == 'pull_request') ||
-      (github.event_name == 'push') ||
-      (github.event_name == 'workflow_dispatch')
+    # run whether the deps rebuild happened or was skipped, but not if anything
+    # upstream failed or was cancelled
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
-    needs: setup
+    needs:
+      - setup
+      - changes
+      - dependencies
     outputs:
       bmi_digest: ${{ steps.build_bmi_image.outputs.digest }}
     steps:
@@ -282,6 +340,36 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve base (deps) image
+        id: base
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # if the dependencies job rebuilt the image this run, build FROM exactly
+          # that; otherwise use the override inputs, else this org's deps :latest
+          REPO="${{ needs.dependencies.outputs.image }}"
+          TAG="${{ needs.dependencies.outputs.tag }}"
+          [ -n "$REPO" ] || REPO="${{ inputs.BMI_BASE_REPO }}"
+          [ -n "$REPO" ] || REPO="${REGISTRY}/${{ needs.setup.outputs.org }}/ngen-dependencies-rocky8"
+          [ -n "$TAG" ] || TAG="${{ inputs.BMI_BASE_TAG }}"
+          [ -n "$TAG" ] || TAG="latest"
+
+          # inspect the base for the OCI base.* labels on the forcing image
+          if ! command -v skopeo >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends skopeo
+          fi
+          INSPECT=$(skopeo inspect --override-os linux --override-arch amd64 "docker://${REPO}:${TAG}" 2>/dev/null || echo '{}')
+          DIGEST=$(echo "$INSPECT" | jq -r '.Digest // "unknown"')
+          REVISION=$(echo "$INSPECT" | jq -r '.Labels["org.opencontainers.image.revision"] // .Labels["io.ngwpc.image.base.revision"] // "unknown"')
+
+          cat >> "$GITHUB_OUTPUT" <<EOF
+          repo=${REPO}
+          tag=${TAG}
+          digest=${DIGEST}
+          revision=${REVISION}
+          EOF
       - name: Build & push BMI Forcing
         id: build_bmi_image # set ID to capture output from this step to use outputs like digest, imageid, and metadata
         uses: docker/build-push-action@v7
@@ -295,10 +383,10 @@ jobs:
           push: true
           tags: ${{ needs.setup.outputs.bmi_image }}:${{ needs.setup.outputs.test_image_tag }}
           build-args: |
-            BMI_BASE_REPO=${{ needs.setup.outputs.bmi_base_repo }}
-            BMI_BASE_TAG=${{ needs.setup.outputs.bmi_base_tag }}
-            BMI_BASE_DIGEST=${{ needs.setup.outputs.bmi_base_digest }}
-            BMI_BASE_REVISION=${{ needs.setup.outputs.bmi_base_revision }}
+            BMI_BASE_REPO=${{ steps.base.outputs.repo }}
+            BMI_BASE_TAG=${{ steps.base.outputs.tag }}
+            BMI_BASE_DIGEST=${{ steps.base.outputs.digest }}
+            BMI_BASE_REVISION=${{ steps.base.outputs.revision }}
             EWTS_ORG=${{ inputs.EWTS_ORG || github.repository_owner }}
             EWTS_REF=${{ inputs.EWTS_REF || needs.setup.outputs.default_ref }}
             EWTS_REVISION=${{ needs.setup.outputs.ewts_revision }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,14 @@ on:
       - nwm-master
       - development
       - release-candidate
+    # A change to ONLY the dependencies image must not self-trigger this forcing
+    # build. dependencies.yml builds the new base first, then dispatches this
+    # workflow against it (see its trigger-forcing job), preserving deps-before-
+    # forcing order. Without this, a deps push would race a forcing build here
+    # against the old base.
+    paths-ignore:
+      - 'Dockerfile.dependencies'
+      - '.github/workflows/dependencies.yml'
   pull_request:
     branches:
       - ngwpc-candidate
@@ -17,10 +25,17 @@ on:
       - nwm-master
       - development
       - release-candidate
+    paths-ignore:
+      - 'Dockerfile.dependencies'
+      - '.github/workflows/dependencies.yml'
   workflow_dispatch:
     inputs:
+      BMI_BASE_REPO:
+        description: 'Base dependencies image repo (default ghcr.io/<org>/ngen-dependencies-rocky8)'
+        required: false
+        type: string
       BMI_BASE_TAG:
-        description: 'BMI_BASE_TAG'
+        description: 'Base dependencies image tag (default latest)'
         required: false
         type: string
       GHCR_ORG:
@@ -68,7 +83,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  BMI_BASE_REPO: rockylinux
 
 jobs:
   # set variables for use in other jobs
@@ -77,6 +91,7 @@ jobs:
     outputs:
       org: ${{ steps.vars.outputs.org }}
       bmi_image: ${{ steps.vars.outputs.bmi_image }}
+      bmi_base_repo: ${{ steps.vars.outputs.bmi_base_repo }}
       bmi_base_name: ${{ steps.vars.outputs.bmi_base_name }}
       bmi_base_tag: ${{ steps.vars.outputs.bmi_base_tag }}
       bmi_base_digest: ${{ steps.vars.outputs.bmi_base_digest }}
@@ -138,15 +153,15 @@ jobs:
             sudo apt-get install -y --no-install-recommends skopeo
           fi
 
-          # base image metadata for BMI Dockerfile labels
-          BMI_BASE_TAG_INPUT="${{ github.event.inputs.BMI_BASE_TAG || '' }}"
-          if [ -n "$BMI_BASE_TAG_INPUT" ]; then
-            BMI_BASE_TAG="$BMI_BASE_TAG_INPUT"
-          else
-            BMI_BASE_TAG="8"
-          fi
+          # base image = the prebuilt compiled-dependencies image that
+          # Dockerfile.bmi-forcings builds FROM (published by dependencies.yml).
+          # Both repo and tag are overridable so any base can be passed in;
+          # default is ngen-dependencies-rocky8:latest in this org's registry.
+          BMI_BASE_REPO="${{ inputs.BMI_BASE_REPO || '' }}"
+          [ -n "$BMI_BASE_REPO" ] || BMI_BASE_REPO="${REGISTRY}/${ORG}/ngen-dependencies-rocky8"
+          BMI_BASE_TAG="${{ inputs.BMI_BASE_TAG || 'latest' }}"
           BMI_BASE_NAME="${BMI_BASE_REPO}:${BMI_BASE_TAG}"
-          BMI_BASE_INSPECT=$(skopeo inspect --override-os linux --override-arch amd64 "docker://${BMI_BASE_NAME}")
+          BMI_BASE_INSPECT=$(skopeo inspect --override-os linux --override-arch amd64 "docker://${BMI_BASE_NAME}" 2>/dev/null || echo '{}')
           BMI_BASE_DIGEST=$(echo "$BMI_BASE_INSPECT" | jq -r '.Digest // "unknown"')
           BMI_BASE_REVISION=$(echo "$BMI_BASE_INSPECT" | jq -r '.Labels["org.opencontainers.image.revision"] // .Labels["io.ngwpc.image.base.revision"] // "unknown"')
 
@@ -201,6 +216,7 @@ jobs:
           cat >> "$GITHUB_OUTPUT" <<EOF
           org=${ORG}
           bmi_image=${IMAGE_BASE}/ngen-bmi-forcing
+          bmi_base_repo=${BMI_BASE_REPO}
           bmi_base_name=${BMI_BASE_NAME}
           bmi_base_tag=${BMI_BASE_TAG}
           bmi_base_digest=${BMI_BASE_DIGEST}
@@ -279,6 +295,7 @@ jobs:
           push: true
           tags: ${{ needs.setup.outputs.bmi_image }}:${{ needs.setup.outputs.test_image_tag }}
           build-args: |
+            BMI_BASE_REPO=${{ needs.setup.outputs.bmi_base_repo }}
             BMI_BASE_TAG=${{ needs.setup.outputs.bmi_base_tag }}
             BMI_BASE_DIGEST=${{ needs.setup.outputs.bmi_base_digest }}
             BMI_BASE_REVISION=${{ needs.setup.outputs.bmi_base_revision }}

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,59 +1,87 @@
 name: Dependencies Image
 
-# Builds and publishes the slow-moving compiled dependency base image
-# (ngen-dependencies-<base>) that Dockerfile.bmi-forcings builds FROM. This is
-# deliberately kept out of cicd.yml so a normal ngen-bmi-forcing build never
-# rebuilds the heavy compiled stack (WGRIB2, ESMF, SZIP, HDF5, NetCDF, Boost,
-# GDAL) and stays fast.
+# Reusable workflow (called by cicd.yml, it does not run on its own). Builds and
+# publishes the compiled-dependency base image (ngen-dependencies-<base>) that
+# Dockerfile.bmi-forcings builds FROM. Because cicd.yml calls this as a job, the
+# forcing build can order itself after a base rebuild with `needs`, and the base
+# is only rebuilt when the dependency files change.
 #
-# Runs only when the dependencies actually change:
-#   - manually (workflow_dispatch), where the base image is customizable, and
-#   - automatically when Dockerfile.dependencies (or this workflow) changes.
+# The published image name follows the base image, so rockylinux:8 publishes
+# ngen-dependencies-rocky8. Change deps_base_repo / deps_base_tag to move off
+# Rocky and the name follows; set deps_base_suffix to force a specific name.
 #
-# The published package name reflects the base image, e.g. rockylinux:8 ->
-# ngen-dependencies-rocky8. Change DEPS_BASE_REPO/DEPS_BASE_TAG to move off Rocky
-# and the name follows; override DEPS_BASE_SUFFIX if you want a specific name.
+# Outputs the published repo and tag so the caller can build FROM exactly what
+# was just built.
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      DEPS_BASE_REPO:
+      deps_base_repo:
         description: 'Base image to compile the dependencies from (default rockylinux)'
         required: false
         type: string
-      DEPS_BASE_TAG:
+        default: ''
+      deps_base_tag:
         description: 'Base image tag (default 8)'
         required: false
         type: string
-      DEPS_BASE_SUFFIX:
+        default: ''
+      deps_base_suffix:
         description: 'Override the published name suffix (default derived from the base, e.g. rocky8)'
         required: false
         type: string
-      GHCR_ORG:
-        description: 'GHCR_ORG'
+        default: ''
+      ghcr_org:
+        description: 'GHCR org (default repo owner, lowercased)'
         required: false
         type: string
-  push:
-    branches:
-      - development
-      - ngwpc-candidate
-      - ngwpc-release
-    paths:
-      - 'Dockerfile.dependencies'
-      - '.github/workflows/dependencies.yml'
-  pull_request:
-    branches:
-      - development
-      - ngwpc-candidate
-      - ngwpc-release
-    paths:
-      - 'Dockerfile.dependencies'
-      - '.github/workflows/dependencies.yml'
+        default: ''
+      szip_version:
+        description: 'SZIP version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      hdf5_version:
+        description: 'HDF5 version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      netcdf_c_version:
+        description: 'NetCDF-C version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      netcdf_fortran_version:
+        description: 'NetCDF-Fortran version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      boost_version:
+        description: 'Boost version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      esmf_version:
+        description: 'ESMF version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      gdal_version:
+        description: 'GDAL version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      image:
+        description: 'Published deps image repo (no tag)'
+        value: ${{ jobs.setup.outputs.deps_image }}
+      tag:
+        description: 'Tag of the deps image just built'
+        value: ${{ jobs.setup.outputs.test_image_tag }}
 
 permissions:
   contents: read
   packages: write
-  security-events: write
 
 env:
   REGISTRY: ghcr.io
@@ -65,11 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       deps_image: ${{ steps.vars.outputs.deps_image }}
-      base_suffix: ${{ steps.vars.outputs.base_suffix }}
-      deps_base_repo: ${{ steps.vars.outputs.deps_base_repo }}
-      deps_base_tag: ${{ steps.vars.outputs.deps_base_tag }}
       test_image_tag: ${{ steps.vars.outputs.test_image_tag }}
       alias_tag: ${{ steps.vars.outputs.alias_tag }}
+      build_args: ${{ steps.vars.outputs.build_args }}
     steps:
       - name: Compute image vars
         id: vars
@@ -77,8 +103,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # org (lowercased for GHCR); GHCR_ORG input overrides the repo owner
-          ORG="$(echo "${{ inputs.GHCR_ORG || github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          # org (lowercased for GHCR); ghcr_org input overrides the repo owner
+          ORG="$(echo "${{ inputs.ghcr_org || github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
 
           # one datetime for all time variables
           NOW=$(date -u +'%Y-%m-%d %H:%M:%S')
@@ -95,9 +121,12 @@ jobs:
           CLEAN_REF=$(echo "$REAL_REF" | tr '[:upper:]' '[:lower:]' | sed 's/\//-/g')
           SHORT_SHA="${REAL_SHA:0:7}"
 
-          # base image the dependencies are compiled FROM (customizable)
-          DEPS_BASE_REPO="${{ inputs.DEPS_BASE_REPO || 'rockylinux' }}"
-          DEPS_BASE_TAG="${{ inputs.DEPS_BASE_TAG || '8' }}"
+          # base image the dependencies are compiled FROM. inputs may arrive empty
+          # (the caller passes them through on every event), so fall back here.
+          DEPS_BASE_REPO="${{ inputs.deps_base_repo }}"
+          [ -n "$DEPS_BASE_REPO" ] || DEPS_BASE_REPO="rockylinux"
+          DEPS_BASE_TAG="${{ inputs.deps_base_tag }}"
+          [ -n "$DEPS_BASE_TAG" ] || DEPS_BASE_TAG="8"
 
           # derive the published name suffix from the base image (unless overridden)
           # so the package name reflects its base (rockylinux:8 -> rocky8):
@@ -105,7 +134,7 @@ jobs:
           #   - drop the literal "linux" (rockylinux -> rocky)
           #   - append the tag reduced to alphanumerics (8 -> 8, 24.04 -> 2404)
           #   - lowercase
-          SUFFIX_INPUT="${{ inputs.DEPS_BASE_SUFFIX || '' }}"
+          SUFFIX_INPUT="${{ inputs.deps_base_suffix }}"
           if [ -n "$SUFFIX_INPUT" ]; then
             BASE_SUFFIX="$SUFFIX_INPUT"
           else
@@ -117,8 +146,9 @@ jobs:
 
           DEPS_IMAGE="${REGISTRY}/${ORG}/ngen-dependencies-${BASE_SUFFIX}"
 
-          # test_image_tag (commit short sha): used for the build/scan
-          # alias_tag: applied on success (timestamp-branch, or pr-<n>-build)
+          # test_image_tag (commit short sha): always pushed, so the caller can
+          # build FROM it. alias_tag: promoted on success (timestamp-branch, or
+          # pr-<n>-build).
           TEST_TAG="${SHORT_SHA}"
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             ALIAS="pr-${{ github.event.pull_request.number }}-build"
@@ -126,15 +156,48 @@ jobs:
             ALIAS="${TIMESTAMP}-${CLEAN_REF}"
           fi
 
-          # save outputs
-          cat >> "$GITHUB_OUTPUT" <<EOF
-          deps_image=${DEPS_IMAGE}
-          base_suffix=${BASE_SUFFIX}
-          deps_base_repo=${DEPS_BASE_REPO}
-          deps_base_tag=${DEPS_BASE_TAG}
-          test_image_tag=${TEST_TAG}
-          alias_tag=${ALIAS}
-          EOF
+          # Build the list of docker build-args for the dependencies image. Start
+          # with the base image, then append each library version ONLY if the
+          # caller provided it. Empty values are skipped so that version stays at
+          # the default baked into Dockerfile.dependencies (single source of truth
+          # for versions; the workflow only overrides when asked).
+          ARGS=( "DEPS_BASE_REPO=${DEPS_BASE_REPO}" "DEPS_BASE_TAG=${DEPS_BASE_TAG}" )
+          # add NAME VALUE -> appends "NAME=VALUE" to ARGS when VALUE is non-empty
+          # (the "|| true" keeps the skipped case from tripping "set -e").
+          add() { [ -n "$2" ] && ARGS+=("$1=$2") || true; }
+          add SZIP_VERSION "${{ inputs.szip_version }}"
+          add HDF5_VERSION "${{ inputs.hdf5_version }}"
+          add NETCDF_C_VERSION "${{ inputs.netcdf_c_version }}"
+          add NETCDF_FORTRAN_VERSION "${{ inputs.netcdf_fortran_version }}"
+          add BOOST_VERSION "${{ inputs.boost_version }}"
+          add ESMF_VERSION "${{ inputs.esmf_version }}"
+          add GDAL_VERSION "${{ inputs.gdal_version }}"
+
+          # Publish step outputs. $GITHUB_OUTPUT is a FILE the runner provides;
+          # every line appended to it becomes ${{ steps.vars.outputs.<name> }},
+          # which the setup job re-exports as a job output so other jobs can read
+          # it via needs.setup.outputs.<name>.
+          #
+          # Most outputs are one line: "name=value". But build_args holds MANY
+          # lines (one docker build-arg each), which "name=value" can't represent.
+          # GitHub's multi-line output syntax handles that:
+          #     name<<MARKER
+          #     ...value lines...
+          #     MARKER
+          # Everything between the opening "build_args<<BUILDARGS_EOF" line and the
+          # closing "BUILDARGS_EOF" line becomes the value of build_args. printf
+          # writes each ARGS element on its own line in between. BUILDARGS_EOF is
+          # just an arbitrary end marker (any unique word works). Downstream,
+          # build-dependencies passes needs.setup.outputs.build_args straight to
+          # docker/build-push-action, which splits it into one --build-arg per line.
+          {
+            echo "deps_image=${DEPS_IMAGE}"
+            echo "test_image_tag=${TEST_TAG}"
+            echo "alias_tag=${ALIAS}"
+            echo "build_args<<BUILDARGS_EOF"
+            printf '%s\n' "${ARGS[@]}"
+            echo "BUILDARGS_EOF"
+          } >> "$GITHUB_OUTPUT"
 
   # build the compiled-dependencies base image
   build-dependencies:
@@ -162,7 +225,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       # No GHA layer cache here: this image is built from scratch by design when
       # it runs (rare), and its layers are multi-GB. The published image is the
-      # reuse mechanism for downstream builds (Dockerfile.bmi-forcings FROM it).
+      # reuse mechanism for the forcing build (it builds FROM this image).
       - name: Build & push dependencies image
         uses: docker/build-push-action@v7
         with:
@@ -170,19 +233,18 @@ jobs:
           platforms: linux/amd64
           context: .
           file: Dockerfile.dependencies
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ needs.setup.outputs.deps_image }}:${{ needs.setup.outputs.test_image_tag }}
-          build-args: |
-            DEPS_BASE_REPO=${{ needs.setup.outputs.deps_base_repo }}
-            DEPS_BASE_TAG=${{ needs.setup.outputs.deps_base_tag }}
+          # multi-line string (one NAME=VALUE per line) assembled in the setup
+          # job; see the build_args output there. build-push-action turns each
+          # line into a --build-arg.
+          build-args: ${{ needs.setup.outputs.build_args }}
       - name: Install Trivy
-        if: github.event_name != 'pull_request'
         uses: aquasecurity/setup-trivy@v0.2.6
         with:
           cache: true
           version: v0.69.3
       - name: Trivy scan (dependencies)
-        if: github.event_name != 'pull_request'
         env:
           TMPDIR: /mnt/trivy-temp
         run: |
@@ -198,7 +260,7 @@ jobs:
             --timeout 45m \
             ${{ needs.setup.outputs.deps_image }}:${{ needs.setup.outputs.test_image_tag }}
       - name: Promote Tags
-        if: success() && github.event_name != 'pull_request'
+        if: success()
         shell: bash
         run: |
           set -euo pipefail
@@ -228,44 +290,3 @@ jobs:
               --all \
               "docker://${IMAGE_BASE}:${TEST_TAG}" "docker://${IMAGE_BASE}:latest"
           fi
-
-  # rebuild ngen-bmi-forcing against the deps image we just published so a
-  # dependency update always flows into the forcing image (and on down the
-  # chain). Rebuilding deps without rebuilding what consumes it is never useful,
-  # so this is not optional.
-  #
-  # This is also what guarantees order: it `needs` build-dependencies and runs
-  # only on success, so the deps image is fully built and promoted BEFORE the
-  # forcing build is dispatched. It pins the exact image just built (repo +
-  # alias), so forcing never races against the old base.
-  trigger-forcing:
-    name: trigger-forcing
-    if: |
-      success() && (
-        (github.event_name == 'push' && (github.ref_name == 'development' || github.ref_name == 'ngwpc-candidate' || github.ref_name == 'ngwpc-release')) ||
-        (github.event_name == 'workflow_dispatch')
-      )
-    runs-on: ubuntu-latest
-    needs:
-      - setup
-      - build-dependencies
-    steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.PIPELINE_APP_ID }}
-          private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-      - name: Trigger ngen-forcing CI/CD on the new dependencies image
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          DEPS_IMAGE: ${{ needs.setup.outputs.deps_image }}
-          DEPS_TAG: ${{ needs.setup.outputs.alias_tag }}
-        run: |
-          gh workflow run cicd.yml \
-            --repo ${{ github.repository_owner }}/ngen-forcing \
-            --ref "${{ github.ref_name }}" \
-            -f TRIGGER_DOWNSTREAM=true \
-            -f BMI_BASE_REPO="$DEPS_IMAGE" \
-            -f BMI_BASE_TAG="$DEPS_TAG"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -156,7 +156,7 @@ jobs:
             BASE_SUFFIX="$(echo "${base_name}${tag_clean}" | tr '[:upper:]' '[:lower:]')"
           fi
 
-          DEPS_IMAGE="${REGISTRY}/${ORG}/ngen-forcing/ngen-dependencies-${BASE_SUFFIX}"
+          DEPS_IMAGE="${REGISTRY}/${ORG}/ngen-dependencies-${BASE_SUFFIX}"
 
           # test_image_tag (commit short sha): always pushed, so the caller can
           # build FROM it. alias_tag: promoted on success (timestamp-branch, or

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -174,7 +174,7 @@ jobs:
           add GDAL_VERSION "${{ inputs.gdal_version }}"
 
           # Publish step outputs. $GITHUB_OUTPUT is a FILE the runner provides;
-          # every line appended to it becomes ${{ steps.vars.outputs.<name> }},
+          # every line appended to it becomes `steps.vars.outputs.<name>`,
           # which the setup job re-exports as a job output so other jobs can read
           # it via needs.setup.outputs.<name>.
           #

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -156,7 +156,7 @@ jobs:
             BASE_SUFFIX="$(echo "${base_name}${tag_clean}" | tr '[:upper:]' '[:lower:]')"
           fi
 
-          DEPS_IMAGE="${REGISTRY}/${ORG}/ngen-dependencies-${BASE_SUFFIX}"
+          DEPS_IMAGE="${REGISTRY}/${ORG}/ngen-forcing/ngen-dependencies-${BASE_SUFFIX}"
 
           # test_image_tag (commit short sha): always pushed, so the caller can
           # build FROM it. alias_tag: promoted on success (timestamp-branch, or
@@ -175,6 +175,7 @@ jobs:
           # Dockerfile.dependencies (single source of truth for versions; the
           # workflow only overrides when asked).
           ARGS=(
+            "IMAGE_SOURCE=https://github.com/${{ github.repository }}"
             "DEPS_BASE_REPO=${DEPS_BASE_REPO}"
             "DEPS_BASE_TAG=${DEPS_BASE_TAG}"
             "DEPS_BASE_DIGEST=${DEPS_BASE_DIGEST}"

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -128,6 +128,18 @@ jobs:
           DEPS_BASE_TAG="${{ inputs.deps_base_tag }}"
           [ -n "$DEPS_BASE_TAG" ] || DEPS_BASE_TAG="8"
 
+          # resolve the base image's manifest digest for the OCI base.digest
+          # label (passed through as the DEPS_BASE_DIGEST build-arg below). skopeo
+          # inspect reads the manifest without pulling; --override-os/--override-arch
+          # pin the amd64 digest (the platform this image builds for) so the value
+          # does not vary with the runner's own architecture.
+          if ! command -v skopeo >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends skopeo
+          fi
+          DEPS_BASE_INSPECT=$(skopeo inspect --override-os linux --override-arch amd64 "docker://${DEPS_BASE_REPO}:${DEPS_BASE_TAG}" 2>/dev/null || echo '{}')
+          DEPS_BASE_DIGEST=$(echo "$DEPS_BASE_INSPECT" | jq -r '.Digest // "unknown"')
+
           # derive the published name suffix from the base image (unless overridden)
           # so the package name reflects its base (rockylinux:8 -> rocky8):
           #   - keep only the last path segment (drop any registry/namespace)
@@ -157,11 +169,16 @@ jobs:
           fi
 
           # Build the list of docker build-args for the dependencies image. Start
-          # with the base image, then append each library version ONLY if the
-          # caller provided it. Empty values are skipped so that version stays at
-          # the default baked into Dockerfile.dependencies (single source of truth
-          # for versions; the workflow only overrides when asked).
-          ARGS=( "DEPS_BASE_REPO=${DEPS_BASE_REPO}" "DEPS_BASE_TAG=${DEPS_BASE_TAG}" )
+          # with the base image identity (repo, tag, resolved digest), then append
+          # each library version ONLY if the caller provided it. Empty values are
+          # skipped so that version stays at the default baked into
+          # Dockerfile.dependencies (single source of truth for versions; the
+          # workflow only overrides when asked).
+          ARGS=(
+            "DEPS_BASE_REPO=${DEPS_BASE_REPO}"
+            "DEPS_BASE_TAG=${DEPS_BASE_TAG}"
+            "DEPS_BASE_DIGEST=${DEPS_BASE_DIGEST}"
+          )
           # add NAME VALUE -> appends "NAME=VALUE" to ARGS when VALUE is non-empty
           # (the "|| true" keeps the skipped case from tripping "set -e").
           add() { [ -n "$2" ] && ARGS+=("$1=$2") || true; }

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,271 @@
+name: Dependencies Image
+
+# Builds and publishes the slow-moving compiled dependency base image
+# (ngen-dependencies-<base>) that Dockerfile.bmi-forcings builds FROM. This is
+# deliberately kept out of cicd.yml so a normal ngen-bmi-forcing build never
+# rebuilds the heavy compiled stack (WGRIB2, ESMF, SZIP, HDF5, NetCDF, Boost,
+# GDAL) and stays fast.
+#
+# Runs only when the dependencies actually change:
+#   - manually (workflow_dispatch), where the base image is customizable, and
+#   - automatically when Dockerfile.dependencies (or this workflow) changes.
+#
+# The published package name reflects the base image, e.g. rockylinux:8 ->
+# ngen-dependencies-rocky8. Change DEPS_BASE_REPO/DEPS_BASE_TAG to move off Rocky
+# and the name follows; override DEPS_BASE_SUFFIX if you want a specific name.
+
+on:
+  workflow_dispatch:
+    inputs:
+      DEPS_BASE_REPO:
+        description: 'Base image to compile the dependencies from (default rockylinux)'
+        required: false
+        type: string
+      DEPS_BASE_TAG:
+        description: 'Base image tag (default 8)'
+        required: false
+        type: string
+      DEPS_BASE_SUFFIX:
+        description: 'Override the published name suffix (default derived from the base, e.g. rocky8)'
+        required: false
+        type: string
+      GHCR_ORG:
+        description: 'GHCR_ORG'
+        required: false
+        type: string
+  push:
+    branches:
+      - development
+      - ngwpc-candidate
+      - ngwpc-release
+    paths:
+      - 'Dockerfile.dependencies'
+      - '.github/workflows/dependencies.yml'
+  pull_request:
+    branches:
+      - development
+      - ngwpc-candidate
+      - ngwpc-release
+    paths:
+      - 'Dockerfile.dependencies'
+      - '.github/workflows/dependencies.yml'
+
+permissions:
+  contents: read
+  packages: write
+  security-events: write
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # set variables for use in other jobs
+  setup:
+    name: setup
+    runs-on: ubuntu-latest
+    outputs:
+      deps_image: ${{ steps.vars.outputs.deps_image }}
+      base_suffix: ${{ steps.vars.outputs.base_suffix }}
+      deps_base_repo: ${{ steps.vars.outputs.deps_base_repo }}
+      deps_base_tag: ${{ steps.vars.outputs.deps_base_tag }}
+      test_image_tag: ${{ steps.vars.outputs.test_image_tag }}
+      alias_tag: ${{ steps.vars.outputs.alias_tag }}
+    steps:
+      - name: Compute image vars
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # org (lowercased for GHCR); GHCR_ORG input overrides the repo owner
+          ORG="$(echo "${{ inputs.GHCR_ORG || github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+
+          # one datetime for all time variables
+          NOW=$(date -u +'%Y-%m-%d %H:%M:%S')
+          TIMESTAMP=$(date -u -d "$NOW" +'%Y%m%d%H%M%SZ')
+
+          # real branch name and commit SHA (handle pull_request head)
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            REAL_REF="${{ github.head_ref }}"
+            REAL_SHA="${{ github.event.pull_request.head.sha }}"
+          else
+            REAL_REF="${{ github.ref_name }}"
+            REAL_SHA="${GITHUB_SHA}"
+          fi
+          CLEAN_REF=$(echo "$REAL_REF" | tr '[:upper:]' '[:lower:]' | sed 's/\//-/g')
+          SHORT_SHA="${REAL_SHA:0:7}"
+
+          # base image the dependencies are compiled FROM (customizable)
+          DEPS_BASE_REPO="${{ inputs.DEPS_BASE_REPO || 'rockylinux' }}"
+          DEPS_BASE_TAG="${{ inputs.DEPS_BASE_TAG || '8' }}"
+
+          # derive the published name suffix from the base image (unless overridden)
+          # so the package name reflects its base (rockylinux:8 -> rocky8):
+          #   - keep only the last path segment (drop any registry/namespace)
+          #   - drop the literal "linux" (rockylinux -> rocky)
+          #   - append the tag reduced to alphanumerics (8 -> 8, 24.04 -> 2404)
+          #   - lowercase
+          SUFFIX_INPUT="${{ inputs.DEPS_BASE_SUFFIX || '' }}"
+          if [ -n "$SUFFIX_INPUT" ]; then
+            BASE_SUFFIX="$SUFFIX_INPUT"
+          else
+            base_name="${DEPS_BASE_REPO##*/}"
+            base_name="${base_name//linux/}"
+            tag_clean="$(echo "$DEPS_BASE_TAG" | tr -cd '[:alnum:]')"
+            BASE_SUFFIX="$(echo "${base_name}${tag_clean}" | tr '[:upper:]' '[:lower:]')"
+          fi
+
+          DEPS_IMAGE="${REGISTRY}/${ORG}/ngen-dependencies-${BASE_SUFFIX}"
+
+          # test_image_tag (commit short sha): used for the build/scan
+          # alias_tag: applied on success (timestamp-branch, or pr-<n>-build)
+          TEST_TAG="${SHORT_SHA}"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            ALIAS="pr-${{ github.event.pull_request.number }}-build"
+          else
+            ALIAS="${TIMESTAMP}-${CLEAN_REF}"
+          fi
+
+          # save outputs
+          cat >> "$GITHUB_OUTPUT" <<EOF
+          deps_image=${DEPS_IMAGE}
+          base_suffix=${BASE_SUFFIX}
+          deps_base_repo=${DEPS_BASE_REPO}
+          deps_base_tag=${DEPS_BASE_TAG}
+          test_image_tag=${TEST_TAG}
+          alias_tag=${ALIAS}
+          EOF
+
+  # build the compiled-dependencies base image
+  build-dependencies:
+    name: build-dependencies
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v6
+      - name: Free disk space
+        run: |
+          # the compiled dependency stack (ESMF/GDAL/Boost/NetCDF) is large;
+          # reclaim runner space before building
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # No GHA layer cache here: this image is built from scratch by design when
+      # it runs (rare), and its layers are multi-GB. The published image is the
+      # reuse mechanism for downstream builds (Dockerfile.bmi-forcings FROM it).
+      - name: Build & push dependencies image
+        uses: docker/build-push-action@v7
+        with:
+          load: false
+          platforms: linux/amd64
+          context: .
+          file: Dockerfile.dependencies
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ needs.setup.outputs.deps_image }}:${{ needs.setup.outputs.test_image_tag }}
+          build-args: |
+            DEPS_BASE_REPO=${{ needs.setup.outputs.deps_base_repo }}
+            DEPS_BASE_TAG=${{ needs.setup.outputs.deps_base_tag }}
+      - name: Install Trivy
+        if: github.event_name != 'pull_request'
+        uses: aquasecurity/setup-trivy@v0.2.6
+        with:
+          cache: true
+          version: v0.69.3
+      - name: Trivy scan (dependencies)
+        if: github.event_name != 'pull_request'
+        env:
+          TMPDIR: /mnt/trivy-temp
+        run: |
+          sudo mkdir -p $TMPDIR
+          sudo chown -R $USER:$USER $TMPDIR
+
+          trivy image \
+            --format sarif \
+            --output trivy-results-dependencies.sarif \
+            --severity CRITICAL,HIGH \
+            --scanners vuln \
+            --ignore-unfixed \
+            --timeout 45m \
+            ${{ needs.setup.outputs.deps_image }}:${{ needs.setup.outputs.test_image_tag }}
+      - name: Promote Tags
+        if: success() && github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ensure skopeo is available for promotion
+          if ! command -v skopeo >/dev/null 2>&1; then
+            sudo apt-get update -y
+            sudo apt-get install -y --no-install-recommends skopeo
+          fi
+
+          IMAGE_BASE="${{ needs.setup.outputs.deps_image }}"
+          TEST_TAG="${{ needs.setup.outputs.test_image_tag }}"
+          ALIAS_TAG="${{ needs.setup.outputs.alias_tag }}"
+
+          # apply the primary alias (timestamp-branch)
+          skopeo copy \
+            --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            --all \
+            "docker://${IMAGE_BASE}:${TEST_TAG}" "docker://${IMAGE_BASE}:${ALIAS_TAG}"
+
+          # consumers pull :latest by default; promote it on development
+          if [ "$GITHUB_REF_NAME" = "development" ]; then
+            skopeo copy \
+              --src-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+              --dest-creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+              --all \
+              "docker://${IMAGE_BASE}:${TEST_TAG}" "docker://${IMAGE_BASE}:latest"
+          fi
+
+  # rebuild ngen-bmi-forcing against the deps image we just published so a
+  # dependency update always flows into the forcing image (and on down the
+  # chain). Rebuilding deps without rebuilding what consumes it is never useful,
+  # so this is not optional.
+  #
+  # This is also what guarantees order: it `needs` build-dependencies and runs
+  # only on success, so the deps image is fully built and promoted BEFORE the
+  # forcing build is dispatched. It pins the exact image just built (repo +
+  # alias), so forcing never races against the old base.
+  trigger-forcing:
+    name: trigger-forcing
+    if: |
+      success() && (
+        (github.event_name == 'push' && (github.ref_name == 'development' || github.ref_name == 'ngwpc-candidate' || github.ref_name == 'ngwpc-release')) ||
+        (github.event_name == 'workflow_dispatch')
+      )
+    runs-on: ubuntu-latest
+    needs:
+      - setup
+      - build-dependencies
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.PIPELINE_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Trigger ngen-forcing CI/CD on the new dependencies image
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEPS_IMAGE: ${{ needs.setup.outputs.deps_image }}
+          DEPS_TAG: ${{ needs.setup.outputs.alias_tag }}
+        run: |
+          gh workflow run cicd.yml \
+            --repo ${{ github.repository_owner }}/ngen-forcing \
+            --ref "${{ github.ref_name }}" \
+            -f TRIGGER_DOWNSTREAM=true \
+            -f BMI_BASE_REPO="$DEPS_IMAGE" \
+            -f BMI_BASE_TAG="$DEPS_TAG"

--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -13,19 +13,20 @@ ARG USE_EWTS=ON
 ARG EWTS_ORG=${GH_ORG}
 ARG EWTS_REF=development
 
-# External dependency versions
-ARG ESMF_VERSION=8.8.0
-ARG GDAL_VERSION=3.7.3
-
 ############################################################################
 # Image selection
 ############################################################################
-## TODO: replace with base image created under NGWPC-3223 ##
-## see: https://jira.nextgenwaterprediction.com/browse/NGWPC-3223
-ARG BMI_BASE_REPO=rockylinux
-ARG BMI_BASE_TAG=8
+
+# Use the compiled dependencies image. This already includes the slow-moving
+# Rocky-based FOSS/compiled stack: WGRIB2, ESMF, SZIP, HDF5, NetCDF-C,
+# NetCDF-Fortran, Boost, and GDAL.
+ARG BMI_BASE_REPO=ghcr.io/ngwpc/ngen-dependencies-rocky8
+ARG BMI_BASE_TAG=latest
 
 FROM ${BMI_BASE_REPO}:${BMI_BASE_TAG}
+
+# Uncomment when building locally
+# FROM ngen-dependencies-rocky8
 
 # Re-expose args after FROM for the remaining build stage.
 ARG GH_ORG
@@ -33,15 +34,11 @@ ARG IMAGE_NAMESPACE
 ARG USE_EWTS=ON
 ARG EWTS_ORG
 ARG EWTS_REF
-ARG ESMF_VERSION
-ARG GDAL_VERSION
 
 # Optional cache-bust args.
-# Leave these at 0 for normal builds. Override only when you intentionally want
-# that dependency layer rebuilt even though the Dockerfile inputs did not change.
-ARG ESMF_CACHE_BUST=0
+# Leave this at 0 for normal builds. Override only when you intentionally want
+# the EWTS layer rebuilt even though the Dockerfile inputs did not change.
 ARG EWTS_CACHE_BUST=0
-ARG WGRIB2_CACHE_BUST=0
 
 # OCI Metadata Arguments
 ARG BMI_BASE_REPO
@@ -69,184 +66,34 @@ LABEL org.opencontainers.image.base.name="${BMI_BASE_NAME}" \
     io.${IMAGE_NAMESPACE}.ewts.ref="${EWTS_REF}" \
     io.${IMAGE_NAMESPACE}.ewts.revision="${EWTS_REVISION}"
 
-# Ensure local python is preferred over distribution python.
-ENV PATH="/usr/local/bin:$PATH"
-
-# Cannot remove LANG even though https://bugs.python.org/issue19846 is fixed.
-# Last attempted removal of LANG broke many users:
-# https://github.com/docker-library/python/pull/570
-ENV LANG="C.UTF-8"
-
 ############################################################################
-# System/FOSS dependencies
+# Python environment inherited from dependencies image
 ############################################################################
 
-## FIXME: Replace installation and build of FOSS dependencies with a base image. ##
-
-RUN set -eux; \
-    dnf install -y dnf-plugins-core; \
-    dnf install -y epel-release; \
-    dnf config-manager --set-enabled powertools; \
-    dnf install -y \
-        proj proj-devel \
-        sqlite sqlite-devel \
-        autoconf \
-        automake \
-        bzip2 bzip2-devel \
-        cmake \
-        curl curl-devel \
-        file \
-        findutils \
-        git \
-        jq \
-        gcc-toolset-10 \
-        gcc-toolset-10-libasan-devel \
-        gcc-toolset-10-gcc-gfortran \
-        jasper-libs jasper-devel \
-        libaec libaec-devel \
-        libasan6 \
-        libffi libffi-devel \
-        libpng libpng-devel \
-        m4 \
-        openmpi openmpi-devel \
-        openssl openssl-devel \
-        python3.11 \
-        python3.11-devel \
-        python3.11-pip \
-        python3.11-pyyaml \
-        rsync \
-        uuid uuid-devel \
-        which \
-        zlib zlib-devel \
-        hdf5-devel \
-        netcdf-devel \
-        netcdf-fortran-devel \
-    ; \
-    dnf clean all
-
-## FIXME: replace GNU compilers with Intel compiler ##
-SHELL [ "/usr/bin/scl", "enable", "gcc-toolset-10"]
-
-## FIXME: replace openmpi with Intel MPI libraries ##
-ENV PATH="${PATH}:/usr/lib64/openmpi/bin/"
-
-############################################################################
-# Rarely changing compiled dependencies
-############################################################################
-
-RUN --mount=type=cache,target=/root/.cache/build-wgrib2,id=build-wgrib2 \
-    echo "WGRIB2 cache bust: ${WGRIB2_CACHE_BUST}"; \
-    set -eux; \
-    curl --location --output wgrib2.tgz "https://ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz" ; \
-    mkdir --parents /usr/src/wgrib2 ; \
-    tar --extract --directory /usr/src/wgrib2 --strip-components=1 --file wgrib2.tgz ; \
-    rm wgrib2.tgz ; \
-    cd /usr/src/wgrib2 ; \
-    export CC=gcc ; \
-    export FC=gfortran ; \
-    make \
-        USE_IPOLATES=3 \
-        USE_PNG=1 \
-        USE_AEC=0 \
-        USE_JASPER=1 \
-        USE_OPENJPEG=0 \
-        USE_G2CLIB=0 \
-        PREFIX=/usr/local ; \
-    make lib ; \
-    cp /usr/src/wgrib2/wgrib2/wgrib2 /usr/local/bin/ ; \
-    chmod +x /usr/local/bin/wgrib2 ; \
-    rm --recursive --force /usr/src/wgrib2
-
-# Build and install ESMF.
-# Normal builds should reuse this layer. Override ESMF_CACHE_BUST only when you
-# intentionally want to force a rebuild of this layer.
-RUN --mount=type=cache,target=/root/.cache/build-esmf,id=build-esmf \
-    echo "ESMF version: ${ESMF_VERSION}; cache bust: ${ESMF_CACHE_BUST}" && \
-    set -eux; \
-    curl --location --output esmf-${ESMF_VERSION}.tar.gz "https://github.com/esmf-org/esmf/archive/refs/tags/v${ESMF_VERSION}.tar.gz"; \
-    tar --extract --gzip --file esmf-${ESMF_VERSION}.tar.gz; \
-    rm esmf-${ESMF_VERSION}.tar.gz; \
-    cd esmf-${ESMF_VERSION}; \
-    export ESMF_DIR=/esmf-${ESMF_VERSION}; \
-    export ESMF_INSTALL_PREFIX=/usr/local/esmf; \
-    export ESMF_COMPILER=gfortran; \
-    export ESMF_COMM=openmpi; \
-    export ESMF_NETCDF="nc-config"; \
-    export ESMF_F90COMPILEPATHS="-I/usr/lib64/gfortran/modules"; \
-    export ESMF_BOPT=O; \
-    make all; \
-    make install; \
-    cd ..; \
-    rm -rf esmf-${ESMF_VERSION}
-
-# Build GDAL from source.
-RUN --mount=type=cache,target=/root/.cache/gdal,id=gdal-build \
-    set -eux && \
-    curl --location --output gdal.tar.gz "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz" && \
-    mkdir --parents /usr/src/gdal && \
-    tar --extract --directory /usr/src/gdal --strip-components=1 --file gdal.tar.gz && \
-    cd /usr/src/gdal && \
-    cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    cmake --build build --parallel "$(nproc)" && \
-    cmake --build build --target install && \
-    ldconfig && \
-    rm --recursive --force /usr/src/gdal gdal.tar.gz
-
-############################################################################
-# Python environment and stable Python dependencies
-############################################################################
-
-# Create a self-contained venv for ngen-forcing.
+# Re-expose the shared Python virtual environment created by the dependency
+# image. Do not recreate it here; forcing, ngen, and downstream images should
+# all install into and reuse the same venv.
 ENV VIRTUAL_ENV="/ngen-app/ngen-python"
-RUN python3.11 -m venv ${VIRTUAL_ENV}
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
-    PYTHONPATH="${VIRTUAL_ENV}/lib/python3.11/site-packages"
+    PYTHONPATH="${VIRTUAL_ENV}/lib/python3.11/site-packages:/usr/local/lib64/python3.11/site-packages:${PYTHONPATH}"
 
-# Install ESMPy against the installed ESMF.
-ENV ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.mk
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    set -eux; \
-    pip install --upgrade pip setuptools wheel; \
-    pip install setuptools-git-versioning; \
-    git clone --depth 1 --branch v${ESMF_VERSION} https://github.com/esmf-org/esmf.git; \
-    cd esmf/src/addon/esmpy; \
-    python3.11 -m pip install .; \
-    cd /; \
-    rm -rf esmf
-
-# mpi4py is a stable dependency; keep it before COPY . so source changes in
-# ngen-bmi-forcing do not force mpi4py to reinstall.
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    set -eux; \
-    pip install mpi4py
-
-ENV PATH="/usr/local/bin:${PATH}"
-ENV WGRIB2=/usr/local/bin/wgrib2
-
-# Fix OpenMPI transport for containers.
-ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
-ENV OMPI_MCA_btl=^openib,ofi
-ENV OMPI_MCA_pml=ob1
-ENV OMPI_MCA_btl_base_warn_component_unused=0
 
 ############################################################################
 # Optional EWTS Python package
 ############################################################################
 
-# Reset SHELL so we're not locked into the gcc-10 build environment.
 SHELL ["/bin/bash", "-c"]
 
 # ngen-bmi-forcing only needs the EWTS Python package, not the C/C++/Fortran
 # libraries or ngen bridge that the full ngen image requires.
 #
-# Ensures an unset or empty USE_EWTS defaults to ON
+# Ensures an unset or empty USE_EWTS defaults to ON.
 #
 # USE_EWTS accepted ON values:
 #   ON, YES, TRUE, 1
 #
 # Everything else is treated as OFF.
-#
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
     set -eux && \
     USE_EWTS="${USE_EWTS:-ON}" && \
     echo "USE_EWTS=${USE_EWTS}; EWTS org: ${EWTS_ORG}; ref: ${EWTS_REF}; cache bust: ${EWTS_CACHE_BUST}" && \
@@ -269,12 +116,12 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
           --arg build_date "$(date -u +'%Y-%m-%d %H:%M:%S UTC')" \
           '{"nwm-ewts": {commit_hash: $commit_hash, branch: $branch, tags: $tags, author: $author, commit_date: $commit_date, message: $message, build_date: $build_date}}' \
           > /ngen-app/nwm-ewts_git_info.json && \
-        pip install /tmp/nwm-ewts/runtime/python/ewts && \
+        python -m pip install /tmp/nwm-ewts/runtime/python/ewts && \
         cd / && \
         rm -rf /tmp/nwm-ewts; \
     else \
         echo "EWTS disabled; ensuring ewts package is absent"; \
-        pip uninstall -y ewts || true; \
+        python -m pip uninstall -y ewts || true; \
         rm -f /ngen-app/nwm-ewts_git_info.json; \
     fi
 
@@ -282,18 +129,15 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
 # ngen-bmi-forcing - most frequently changing layer
 ############################################################################
 
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    set -eux; \
-    pip install --upgrade pip setuptools wheel
-
 # Keep COPY near the end. Source changes should invalidate only this section
-# and the git-info section below, not ESMF, GDAL, ESMPy, mpi4py, or EWTS.
+# and the git-info section below, not the inherited compiled dependencies,
+# ESMPy, mpi4py, or EWTS.
 COPY . /ngen-app/ngen-forcing/
 
 WORKDIR /ngen-app/ngen-forcing
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
     set -eux; \
-    pip install .
+    python -m pip install .
 
 ARG CI_COMMIT_REF_NAME
 
@@ -320,7 +164,5 @@ RUN set -eux; \
     fi
 
 WORKDIR /
-
-ENV LD_LIBRARY_PATH="/usr/lib64/openmpi/lib/"
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -27,6 +27,7 @@ ARG DEPS_BASE_REPO
 ARG DEPS_BASE_TAG
 ARG DEPS_BASE_NAME="${DEPS_BASE_REPO}:${DEPS_BASE_TAG}"
 ARG DEPS_BASE_DIGEST="unknown"
+ARG IMAGE_SOURCE="unknown"
 
 ARG SZIP_VERSION=2.1.1
 ARG HDF5_VERSION=1.10.11
@@ -39,14 +40,15 @@ ARG GDAL_VERSION=3.7.3
 # Image Labels: OCI-spec base annotations first, then the compiled library
 # versions baked into this image.
 LABEL org.opencontainers.image.base.name="${DEPS_BASE_NAME}" \
-      org.opencontainers.image.base.digest="${DEPS_BASE_DIGEST}" \
-      io.ngwpc.szip.version="${SZIP_VERSION}" \
-      io.ngwpc.hdf5.version="${HDF5_VERSION}" \
-      io.ngwpc.netcdf-c.version="${NETCDF_C_VERSION}" \
-      io.ngwpc.netcdf-fortran.version="${NETCDF_FORTRAN_VERSION}" \
-      io.ngwpc.boost.version="${BOOST_VERSION}" \
-      io.ngwpc.esmf.version="${ESMF_VERSION}" \
-      io.ngwpc.gdal.version="${GDAL_VERSION}"
+    org.opencontainers.image.base.digest="${DEPS_BASE_DIGEST}" \
+    org.opencontainers.image.source="${IMAGE_SOURCE}" \
+    io.ngwpc.szip.version="${SZIP_VERSION}" \
+    io.ngwpc.hdf5.version="${HDF5_VERSION}" \
+    io.ngwpc.netcdf-c.version="${NETCDF_C_VERSION}" \
+    io.ngwpc.netcdf-fortran.version="${NETCDF_FORTRAN_VERSION}" \
+    io.ngwpc.boost.version="${BOOST_VERSION}" \
+    io.ngwpc.esmf.version="${ESMF_VERSION}" \
+    io.ngwpc.gdal.version="${GDAL_VERSION}"
 
 ENV LANG="C.UTF-8"
 ENV PATH="/usr/local/bin:${PATH}"

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -19,6 +19,15 @@ ARG DEPS_BASE_TAG=8
 
 FROM ${DEPS_BASE_REPO}:${DEPS_BASE_TAG}
 
+# Re-expose the base args after FROM (an ARG declared before FROM is only in
+# scope for the FROM line) so they can populate the OCI base.* image labels.
+# DEPS_BASE_NAME is composed here; DEPS_BASE_DIGEST defaults to "unknown" and is
+# overridden by the build-arg dependencies.yml resolves with skopeo at build time.
+ARG DEPS_BASE_REPO
+ARG DEPS_BASE_TAG
+ARG DEPS_BASE_NAME="${DEPS_BASE_REPO}:${DEPS_BASE_TAG}"
+ARG DEPS_BASE_DIGEST="unknown"
+
 ARG SZIP_VERSION=2.1.1
 ARG HDF5_VERSION=1.10.11
 ARG NETCDF_C_VERSION=4.7.4
@@ -27,7 +36,11 @@ ARG BOOST_VERSION=1.86.0
 ARG ESMF_VERSION=8.8.0
 ARG GDAL_VERSION=3.7.3
 
-LABEL io.ngwpc.szip.version="${SZIP_VERSION}" \
+# Image Labels: OCI-spec base annotations first, then the compiled library
+# versions baked into this image.
+LABEL org.opencontainers.image.base.name="${DEPS_BASE_NAME}" \
+      org.opencontainers.image.base.digest="${DEPS_BASE_DIGEST}" \
+      io.ngwpc.szip.version="${SZIP_VERSION}" \
       io.ngwpc.hdf5.version="${HDF5_VERSION}" \
       io.ngwpc.netcdf-c.version="${NETCDF_C_VERSION}" \
       io.ngwpc.netcdf-fortran.version="${NETCDF_FORTRAN_VERSION}" \

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -14,10 +14,10 @@
 #   - GDAL
 ############################################################################
 
-ARG BMI_BASE_REPO=rockylinux
-ARG BMI_BASE_TAG=8
+ARG DEPS_BASE_REPO=rockylinux
+ARG DEPS_BASE_TAG=8
 
-FROM ${BMI_BASE_REPO}:${BMI_BASE_TAG}
+FROM ${DEPS_BASE_REPO}:${DEPS_BASE_TAG}
 
 ARG SZIP_VERSION=2.1.1
 ARG HDF5_VERSION=1.10.11

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -1,0 +1,323 @@
+# syntax=docker/dockerfile:1.4
+
+############################################################################
+# Rocky compiled dependency base image for ngen-bmi-forcing / ngen
+#
+# Contains slow-moving compiled dependencies:
+#   - WGRIB2
+#   - ESMF
+#   - SZIP
+#   - HDF5
+#   - NetCDF-C
+#   - NetCDF-Fortran
+#   - Boost
+#   - GDAL
+############################################################################
+
+ARG BMI_BASE_REPO=rockylinux
+ARG BMI_BASE_TAG=8
+
+FROM ${BMI_BASE_REPO}:${BMI_BASE_TAG}
+
+ARG SZIP_VERSION=2.1.1
+ARG HDF5_VERSION=1.10.11
+ARG NETCDF_C_VERSION=4.7.4
+ARG NETCDF_FORTRAN_VERSION=4.5.4
+ARG BOOST_VERSION=1.86.0
+ARG ESMF_VERSION=8.8.0
+ARG GDAL_VERSION=3.7.3
+
+LABEL io.ngwpc.szip.version="${SZIP_VERSION}" \
+      io.ngwpc.hdf5.version="${HDF5_VERSION}" \
+      io.ngwpc.netcdf-c.version="${NETCDF_C_VERSION}" \
+      io.ngwpc.netcdf-fortran.version="${NETCDF_FORTRAN_VERSION}" \
+      io.ngwpc.boost.version="${BOOST_VERSION}" \
+      io.ngwpc.esmf.version="${ESMF_VERSION}" \
+      io.ngwpc.gdal.version="${GDAL_VERSION}"
+
+ENV LANG="C.UTF-8"
+ENV PATH="/usr/local/bin:${PATH}"
+
+############################################################################
+# System/FOSS dependencies
+############################################################################
+
+RUN set -eux; \
+    dnf install -y dnf-plugins-core; \
+    dnf install -y epel-release; \
+    dnf config-manager --set-enabled powertools; \
+    dnf install -y \
+        proj proj-devel \
+        sqlite sqlite-devel \
+        autoconf \
+        automake \
+        bzip2 bzip2-devel \
+        cmake \
+        curl curl-devel \
+        file \
+        findutils \
+        git \
+        jq \
+        gcc-toolset-10 \
+        gcc-toolset-10-libasan-devel \
+        gcc-toolset-10-gcc-gfortran \
+        jasper-libs jasper-devel \
+        libaec libaec-devel \
+        libasan6 \
+        libffi libffi-devel \
+        libpng libpng-devel \
+        m4 \
+        openmpi openmpi-devel \
+        openssl openssl-devel \
+        python3.11 \
+        python3.11-devel \
+        python3.11-pip \
+        python3.11-pyyaml \
+        rsync \
+        uuid uuid-devel \
+        which \
+        xz xz-devel \
+        zlib zlib-devel \
+        hdf5-devel \
+        netcdf-devel \
+        netcdf-fortran-devel \
+    ; \
+    dnf clean all; \
+    rm -rf /var/cache/dnf
+
+SHELL ["/usr/bin/scl", "enable", "gcc-toolset-10"]
+
+ENV PATH="${PATH}:/usr/lib64/openmpi/bin/"
+
+# Create the shared Python virtual environment early so any Python packages
+# built by compiled dependencies, including ESMPy, install into the same venv
+# reused later by forcing, ngen, and cal-mgr.
+ENV VIRTUAL_ENV="/ngen-app/ngen-python"
+ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/bin:${PATH}"
+ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.11/site-packages:/usr/local/lib64/python3.11/site-packages"
+
+RUN set -eux; \
+    mkdir -p /ngen-app; \
+    python3.11 -m venv --system-site-packages "${VIRTUAL_ENV}"; \
+    ln -sf "${VIRTUAL_ENV}/bin/python" /usr/local/bin/python; \
+    python --version; \
+    python -c "import sys; print(sys.executable)"
+
+############################################################################
+# WGRIB2
+#
+# Unlike the other compiled dependencies, WGRIB2 is not currently version-pinned.
+# It is built from NOAA's current wgrib2.tgz distribution when this image is rebuilt.
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-wgrib2; \
+    cd /tmp/build-wgrib2; \
+    curl --location --output wgrib2.tgz \
+        "https://ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz"; \
+    mkdir wgrib2; \
+    tar --extract --directory wgrib2 --strip-components=1 --file wgrib2.tgz; \
+    cd wgrib2; \
+    export CC=gcc; \
+    export FC=gfortran; \
+    make \
+        USE_IPOLATES=3 \
+        USE_PNG=1 \
+        USE_AEC=0 \
+        USE_JASPER=1 \
+        USE_OPENJPEG=0 \
+        USE_G2CLIB=0 \
+        PREFIX=/usr/local; \
+    make lib; \
+    cp wgrib2/wgrib2 /usr/local/bin/; \
+    chmod +x /usr/local/bin/wgrib2; \
+    rm -rf /tmp/build-wgrib2
+
+ENV WGRIB2=/usr/local/bin/wgrib2
+
+
+############################################################################
+# ESMF
+#
+# ESMF is built before the source-built SZIP/HDF5/NetCDF stack below so it uses
+# the Rocky-provided hdf5/netcdf/netcdf-fortran packages. This matches the
+# original ngen-bmi-forcing Dockerfile behavior and avoids ESMF linking against
+# the later /usr/local NetCDF install.
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-esmf; \
+    cd /tmp/build-esmf; \
+    curl --location --output "esmf-${ESMF_VERSION}.tar.gz" \
+        "https://github.com/esmf-org/esmf/archive/refs/tags/v${ESMF_VERSION}.tar.gz"; \
+    tar --extract --gzip --file "esmf-${ESMF_VERSION}.tar.gz"; \
+    cd "esmf-${ESMF_VERSION}"; \
+    export ESMF_DIR="$(pwd)"; \
+    export ESMF_INSTALL_PREFIX=/usr/local/esmf; \
+    export ESMF_COMPILER=gfortran; \
+    export ESMF_COMM=openmpi; \
+    export ESMF_NETCDF="nc-config"; \
+    export ESMF_F90COMPILEPATHS="-I/usr/lib64/gfortran/modules"; \
+    export ESMF_BOPT=O; \
+    make all; \
+    make install
+
+ENV ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.mk
+
+############################################################################
+# ESMPy install
+############################################################################
+
+RUN set -eux; \
+    cd "/tmp/build-esmf/esmf-${ESMF_VERSION}"; \
+    export ESMF_DIR="$(pwd)"; \
+    export ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.mk; \
+    cd src/addon/esmpy; \
+    python -m pip install .
+
+RUN rm -rf /tmp/build-esmf
+
+
+############################################################################
+# SZIP / HDF5 / NetCDF-C / NetCDF-Fortran
+#
+# These are source-built after ESMF for compatibility with the original ngen
+# dependency image, where ngen and several submodules expected the compiled
+# dependency stack under /usr/local.
+############################################################################
+
+############################################################################
+# SZIP
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-szip; \
+    cd /tmp/build-szip; \
+    curl --location --output szip.tar.gz \
+        "https://docs.hdfgroup.org/archive/support/ftp/lib-external/szip/${SZIP_VERSION%%[a-z]*}/src/szip-${SZIP_VERSION}.tar.gz"; \
+    mkdir szip; \
+    tar --extract --directory szip --strip-components=1 --file szip.tar.gz; \
+    cd szip; \
+    ./configure --prefix=/usr/local/; \
+    make -j "$(nproc)"; \
+    make install; \
+    strip --strip-debug /usr/local/lib/libsz*.so.* || true; \
+    rm -rf /tmp/build-szip
+
+############################################################################
+# HDF5
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-hdf5; \
+    cd /tmp/build-hdf5; \
+    curl --location --output hdf5.tar.gz \
+        "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-${HDF5_VERSION//./_}.tar.gz"; \
+    mkdir hdf5; \
+    tar --extract --directory hdf5 --strip-components=1 --file hdf5.tar.gz; \
+    cd hdf5; \
+    ./configure --prefix=/usr/local/ --with-szlib=/usr/local/; \
+    make -j "$(nproc)"; \
+    make install; \
+    strip --strip-debug /usr/local/lib/libhdf5*.so.* || true; \
+    rm -f /usr/local/lib/libhdf5*.a; \
+    rm -rf /tmp/build-hdf5
+
+############################################################################
+# NetCDF-C
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-netcdf-c; \
+    cd /tmp/build-netcdf-c; \
+    curl --location --output netcdf-c.tar.gz \
+        "https://github.com/Unidata/netcdf-c/archive/refs/tags/v${NETCDF_C_VERSION%%[a-z]*}.tar.gz"; \
+    mkdir netcdf-c; \
+    tar --extract --directory netcdf-c --strip-components=1 --file netcdf-c.tar.gz; \
+    cd netcdf-c; \
+    cmake -B cmake_build -S . \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DENABLE_TESTS=OFF; \
+    cmake --build cmake_build --parallel "$(nproc)"; \
+    cmake --build cmake_build --target install; \
+    ldconfig; \
+    rm -rf /tmp/build-netcdf-c
+
+############################################################################
+# NetCDF-Fortran
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-netcdf-fortran; \
+    cd /tmp/build-netcdf-fortran; \
+    curl --location --output netcdf-fortran.tar.gz \
+        "https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v${NETCDF_FORTRAN_VERSION%%[a-z]*}.tar.gz"; \
+    mkdir netcdf-fortran; \
+    tar --extract --directory netcdf-fortran --strip-components=1 --file netcdf-fortran.tar.gz; \
+    cd netcdf-fortran; \
+    cmake -B cmake_build -S . \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=ON \
+        -DENABLE_TESTS=OFF \
+        -DCMAKE_Fortran_COMPILER=/opt/rh/gcc-toolset-10/root/usr/bin/gfortran; \
+    cmake --build cmake_build --parallel "$(nproc)"; \
+    cmake --build cmake_build --target install; \
+    ldconfig; \
+    rm -rf /tmp/build-netcdf-fortran
+
+
+############################################################################
+# Boost
+############################################################################
+
+RUN set -eux; \
+    mkdir -p /tmp/build-boost; \
+    cd /tmp/build-boost; \
+    curl --location --output boost.tar.gz \
+        "https://archives.boost.io/release/${BOOST_VERSION%%[a-z]*}/source/boost_${BOOST_VERSION//./_}.tar.gz"; \
+    mkdir boost; \
+    tar --extract --directory boost --strip-components=1 --file boost.tar.gz; \
+    cd boost; \
+    ./bootstrap.sh; \
+    ./b2 install --prefix=/usr/local --without-python; \
+    rm -rf /opt/boost; \
+    mkdir --parents /opt/boost; \
+    cp -a /tmp/build-boost/boost/. /opt/boost/; \
+    strip --strip-debug /usr/local/lib/libboost_*.so.* || true; \
+    rm -f /usr/local/lib/libboost_*.a; \
+    rm -rf /tmp/build-boost
+
+############################################################################
+# GDAL
+############################################################################
+
+RUN set -eux && \
+    mkdir -p /tmp/build-gdal && \
+    cd /tmp/build-gdal && \
+    curl --location --output gdal.tar.gz \
+        "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz" && \
+    mkdir gdal && \
+    tar --extract --directory gdal --strip-components=1 --file gdal.tar.gz && \
+    cd gdal && \
+    cmake -B build -S . \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    cmake --build build --parallel "$(nproc)" && \
+    cmake --build build --target install && \
+    ldconfig && \
+    rm -rf /tmp/build-gdal
+
+############################################################################
+# Runtime environment
+############################################################################
+
+ENV LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:/usr/local/lib:/usr/local/lib64"
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+ENV OMPI_MCA_btl=^openib,ofi
+ENV OMPI_MCA_pml=ob1
+ENV OMPI_MCA_btl_base_warn_component_unused=0
+
+WORKDIR /
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Splits the slow-moving compiled stack (WGRIB2, ESMF, HDF5, NetCDF, Boost, GDAL) into a standalone base image and builds it in CI, so normal forcing builds reuse it instead of recompiling everything.

- New `dependencies.yml` builds and publishes the deps image
  (`ngen-dependencies-rocky8`), separate from the forcing build. Runs on demand or automatically when `Dockerfile.dependencies` changes.
- `cicd.yml` now builds `ngen-bmi-forcing` FROM the prebuilt deps image instead of rockylinux, with the base repo and tag parameterized. The published name follows the base (rockylinux:8 gives ngen-dependencies-rocky8), so swapping the base later carries through.
- A deps rebuild auto-triggers the forcing build against the new image (deps is built and promoted first, so no race) and cascades down to ngen and cal/fcst.
- Renamed the deps base args to `DEPS_BASE_REPO`/`DEPS_BASE_TAG`. ngen, cal-mgr, and fcst-mgr need no workflow changes.