### PR TITLE
Dynamic Typing for CAT-ID

### DIFF
--- a/ESMF_Mesh_Domain_Configuration_Production/NextGen_hyfab_to_ESMF_Mesh.py
+++ b/ESMF_Mesh_Domain_Configuration_Production/NextGen_hyfab_to_ESMF_Mesh.py
@@ -40,7 +40,7 @@ def convert_hyfab_to_esmf(hyfab_gpkg: pathlib.Path, esmf_mesh_output: pathlib.Pa
 
     # Eventually, we'll add code to slice catchment ids
     # but for now just use feature ids
-    element_ids = np.array(hyfab.div_id.values, dtype=int)
+    element_ids = np.array(hyfab.div_id.values, dtype=np.int64)
     hyfab_coords = np.empty((len(element_ids), 2), dtype=float)
     hyfab_coords[:, 0] = element_ids
     hyfab_coords[:, 1] = element_ids
@@ -206,7 +206,7 @@ def convert_hyfab_to_esmf(hyfab_gpkg: pathlib.Path, esmf_mesh_output: pathlib.Pa
     node_count_dim = nc.createDimension("coordDim", 2)
     node_coords_var = nc.createVariable("nodeCoords", 'f8', ("nodeCount", "coordDim"))
     node_coords_var.units = "degrees"
-    elem_id = nc.createVariable("element_id", "i", "elementCount")
+    elem_id = nc.createVariable("element_id", "i8", "elementCount")
     elem_id.long_name = "Catchment ID for hydrofabric"
     elem_conn_var = nc.createVariable("elementConn", "i4", ("connectionCount"))
     elem_conn_var.long_name = "Node Indices that define the element connectivity"

--- a/ESMF_Mesh_Domain_Configuration_Production/NextGen_hyfab_to_ESMF_Mesh.py
+++ b/ESMF_Mesh_Domain_Configuration_Production/NextGen_hyfab_to_ESMF_Mesh.py
@@ -40,18 +40,19 @@ def convert_hyfab_to_esmf(hyfab_gpkg: pathlib.Path, esmf_mesh_output: pathlib.Pa
 
     # Eventually, we'll add code to slice catchment ids
     # but for now just use feature ids
-    element_ids = np.array(hyfab.div_id.values, dtype=np.int64)
+    # just use the default dtype for the values instead of trying to specify in the code
+    element_ids = np.array(hyfab.div_id.values, copy=True)
+    # generate 32-bit false IDs that are required for ESMF meshes
+    # access to the IDs should be through indexes into the return of this function,
+    # so it doesn't matter what these IDs are as long as they're int32
+    false_ids = np.arange(len(element_ids), dtype=np.int32)
     hyfab_coords = np.empty((len(element_ids), 2), dtype=float)
-    hyfab_coords[:, 0] = element_ids
-    hyfab_coords[:, 1] = element_ids
+    hyfab_coords[:, 0] = false_ids
+    hyfab_coords[:, 1] = false_ids
 
     # Sort data by feature id and reset index
-    hyfab['element_id'] = element_ids
-    hyfab_cart['element_id'] = element_ids
-    hyfab = hyfab.sort_values(by=['element_id'])
-    hyfab_cart = hyfab_cart.sort_values(by=['element_id'])
-    hyfab = hyfab.reset_index()
-    hyfab_cart = hyfab_cart.reset_index()
+    hyfab['element_id'] = false_ids
+    hyfab_cart['element_id'] = false_ids
 
     # Get element count
     element_count = len(hyfab.element_id)
@@ -206,8 +207,8 @@ def convert_hyfab_to_esmf(hyfab_gpkg: pathlib.Path, esmf_mesh_output: pathlib.Pa
     node_count_dim = nc.createDimension("coordDim", 2)
     node_coords_var = nc.createVariable("nodeCoords", 'f8', ("nodeCount", "coordDim"))
     node_coords_var.units = "degrees"
-    elem_id = nc.createVariable("element_id", "i8", "elementCount")
-    elem_id.long_name = "Catchment ID for hydrofabric"
+    elem_id = nc.createVariable("element_id", "i4", "elementCount")
+    elem_id.long_name = "False 32-bit catchment IDs use for ESMF mesh generation"
     elem_conn_var = nc.createVariable("elementConn", "i4", ("connectionCount"))
     elem_conn_var.long_name = "Node Indices that define the element connectivity"
     num_elem_conn_var = nc.createVariable("numElementConn", "i", "elementCount")
@@ -251,6 +252,7 @@ def convert_hyfab_to_esmf(hyfab_gpkg: pathlib.Path, esmf_mesh_output: pathlib.Pa
     except FileExistsError:
         # Another process already published the file.
         os.remove(temp_path)
+    return element_ids
 
 
 def get_options():

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -305,8 +305,15 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
         # LOG.debug(f"self._job_meta type: {type(self._job_meta)}")
         # Call ESMF mesh creation process
         if self._mpi_meta.rank == 0:
-            esmf_creation.create_mesh(self._job_meta)
-        self._mpi_meta.comm.Barrier()
+            cat_ids = esmf_creation.create_mesh(self._job_meta)
+        cat_count = np.array([
+            len(cat_ids) if self._mpi_meta.rank == 0 else 0
+        ], dtype=np.intc)
+        self._mpi_meta.comm.Bcast(cat_count, root=0)
+        if self._mpi_meta.rank != 0:
+            cat_ids = np.empty(cat_count[0], dtype=np.int64)
+        self._mpi_meta.comm.Bcast(cat_ids, root=0)
+        self._values["CAT-ID"] = cat_ids
 
         # Call forcing_extraction process
         if self._job_meta.nwmConfig not in ["AORC", "NWM"]:
@@ -406,10 +413,6 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
         # Initialize the Forcings Engine model
         self._model = NWMv3ForcingEngineModel()
 
-        # Set catchment ids if using hydrofabric
-        if self._grid_type == "hydrofabric":
-            self._values["CAT-ID"] = self.geo_meta.element_ids_global
-
         self._configure_output_path(output_path)
 
         LOG.info(f"BMI Forcing Engine initialized{Pld(St.INITTED, modnm=MODNM)}")
@@ -482,7 +485,7 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
                 )
 
             self._output_obj.init_forcing_file(
-                self._job_meta, self.geo_meta, self._mpi_meta
+                self._job_meta, self.geo_meta, self._mpi_meta, self._values["CAT-ID"]
             )
             self._output_configured = True
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -313,7 +313,6 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
         if self._mpi_meta.rank != 0:
             cat_ids = np.empty(cat_count[0], dtype=np.int64)
         self._mpi_meta.comm.Bcast(cat_ids, root=0)
-        self._values["CAT-ID"] = cat_ids
 
         # Call forcing_extraction process
         if self._job_meta.nwmConfig not in ["AORC", "NWM"]:
@@ -406,9 +405,10 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
         # for model_input in self.get_input_var_names():
         #    self._values[model_input] = np.zeros(self._varsize, dtype=float)
 
-        # Set initial time and step
+        # Set initial time, step, and true catchment IDs
         self._values["current_model_time"] = self.cfg_bmi["initial_time"]
         self._values["time_step_size"] = self.cfg_bmi["time_step_seconds"]
+        self._values["CAT-ID"] = cat_ids
 
         # Initialize the Forcings Engine model
         self._model = NWMv3ForcingEngineModel()
@@ -782,7 +782,7 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
 
         # Ensure dtype is float64 (C double), except for CAT-ID
         if var_name == "CAT-ID":
-            pass # allow CAT-ID to pass on whatever the dtype is based on the input data
+            return arr # allow CAT-ID to pass on whatever the dtype is based on the input data
         elif arr.dtype != np.float64:
             LOG.warning(
                 f"[BMI] Array for '{var_name}' has dtype {arr.dtype}, expected float64; converting."

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/bmi_model.py
@@ -779,10 +779,7 @@ class NWMv3_Forcing_Engine_BMI_model_Base(Bmi):
 
         # Ensure dtype is float64 (C double), except for CAT-ID
         if var_name == "CAT-ID":
-            if arr.dtype != np.int32:
-                msg = f"[BMI] Array for '{var_name}' has dtype {arr.dtype}, expected int32"
-                LOG.critical(msg)
-                raise RuntimeError(msg)
+            pass # allow CAT-ID to pass on whatever the dtype is based on the input data
         elif arr.dtype != np.float64:
             LOG.warning(
                 f"[BMI] Array for '{var_name}' has dtype {arr.dtype}, expected float64; converting."

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/ioMod.py
@@ -56,7 +56,7 @@ class OutputObj:
             self.output_global = np.empty([9, GeoMetaWrfHydro.ny_global])
         # self.output_local[:,:,:] = self.out_ndv
 
-    def init_forcing_file(self, ConfigOptions, geoMetaWrfHydro, MpiConfig):
+    def init_forcing_file(self, ConfigOptions, geoMetaWrfHydro, MpiConfig, cat_ids: np.ndarray):
         """Initialize the forcing file output for the WRF-Hydro model.
 
         Initializes the forcing file output for the WRF-Hydro model. This function assumes that all necessary
@@ -233,7 +233,7 @@ class OutputObj:
                 elif ConfigOptions.grid_type == "hydrofabric":
                     try:
                         self.idOut.createDimension(
-                            "catchment-id", len(geoMetaWrfHydro.element_ids_global)
+                            "catchment-id", len(cat_ids)
                         )  # Catchment ID dimension
                     except Exception as e:
                         ConfigOptions.errMsg = f"Unable to create catchment id dimension in: {self.outPath} - {e}"
@@ -625,14 +625,9 @@ class OutputObj:
                             err_handler.log_critical(ConfigOptions, MpiConfig)
                             break
                         try:
-                            self.idOut.variables["ids"][:] = np.array(
-                                [
-                                    "cat-" + str(x)
-                                    for x in np.array(
-                                        geoMetaWrfHydro.element_ids_global, dtype=int
-                                    )
-                                ]
-                            )
+                            self.idOut.variables["ids"][:] = np.array([
+                                "cat-" + str(x) for x in cat_ids
+                            ])
                         except Exception as e:
                             ConfigOptions.errMsg = f"Unable to place catchment id string values into output variable for output file: {self.outPath} - {e}"
                             err_handler.log_critical(ConfigOptions, MpiConfig)

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/model.py
@@ -805,7 +805,6 @@ class NWMv3ForcingEngineModel:
                 model[variable + "_ELEMENT"] = output_obj.output_global[
                     count, :
                 ].flatten()
-                model["CAT-ID"] = wrf_hydro_geo_meta.element_ids_global
 
         return (
             model,

--- a/NextGen_Forcings_Engine_BMI/esmf_creation.py
+++ b/NextGen_Forcings_Engine_BMI/esmf_creation.py
@@ -1,5 +1,5 @@
 import argparse
-import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import yaml
@@ -19,13 +19,13 @@ def create_mesh(cfg: ConfigOptions):
     """
     # Set the mesh file name based on the hydrofabric file
     hyfab_name = cfg.geopackage
-    mesh_outPath = cfg.geogrid
+    mesh_out_path = Path(cfg.geogrid)
 
-    # Check if the mesh file already exists and skip conversion if it does
-    if not os.path.exists(mesh_outPath):
-        convert_hyfab_to_esmf(hyfab_gpkg=hyfab_name, esmf_mesh_output=mesh_outPath)
-    else:
-        print(f"ESMF mesh file already exists at {mesh_outPath}, skipping conversion.")
+    # Check if the mesh file already exists and remake if it does.
+    # The remake is necessary to ensure the same true catchment IDs will be generated.
+    if mesh_out_path.is_file():
+        mesh_out_path.unlink()
+    return convert_hyfab_to_esmf(hyfab_gpkg=hyfab_name, esmf_mesh_output=mesh_out_path)
 
 
 def main():

--- a/NextGen_Forcings_Engine_BMI/run_bmi_model.py
+++ b/NextGen_Forcings_Engine_BMI/run_bmi_model.py
@@ -70,7 +70,7 @@ def print_post_update(model, start_time) -> None:
         if model._job_meta.include_lqfrac == 1:
             LQFRAC = np.zeros(varsize, dtype=float)
         if model._grid_type == "hydrofabric":
-            CAT_IDS = np.zeros(varsize, dtype=int)
+            CAT_IDS = np.zeros(varsize, dtype=np.int64)
 
     elif model._grid_type == "unstructured":
         # Unstructured grid (element + node)


### PR DESCRIPTION
Allow forcing engine to work with 64-bit catchment IDs that will be present in NHF v1.2.

When forcing engine generates a netCDF file that can be read by ESMF, the underlying ESMF Fortran model _requires_ the ID field to be `int32`, throwing errors on anything else. To get around this, false IDs will be created from the `int64` true IDs using `np.arange`. This allows indexing into the ID locations whilst having the underlying structure remain an `int32`.

Unfortunately, attempts to store the original, 64-bit values in the netCDF lead to `ESMF.Mesh` throwing an error. Because of this, the gpkg->nc conversion will now be done every time instead of using an existing file so the original IDs can be returned from the generation function.

## Additions

-

## Removals

-

## Changes

- A netCDF file will always be generated fresh each time the BMI is initialized.
- A set of false IDs will be generated in the netCDF file to allow the `ESMF.Mesh` to be used.
- Functions used to create the netCDF file from a geopackage will return the true IDs as a numpy array.
- BMI `get_value_ptr` will not attempt to validate or modify the original CAT-ID `dtype`

## Testing

1. Jeff Wade has verified that these changes address problems that were encountered when testing NHF 1.2

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

