### PR TITLE
Fix for Calibration Mesh Load Error (NGWPC-11011)

### DIFF
--- a/ESMF_Mesh_Domain_Configuration_Production/NextGen_hyfab_to_ESMF_Mesh.py
+++ b/ESMF_Mesh_Domain_Configuration_Production/NextGen_hyfab_to_ESMF_Mesh.py
@@ -33,15 +33,15 @@ def convert_hyfab_to_esmf(hyfab_gpkg: pathlib.Path, esmf_mesh_output: pathlib.Pa
     # for orientation properties since there are issues
     # with geopandas for converting crs and translating
     # orientation of polygon from original dataset
-    hyfab = gpd.read_file(hyfab_gpkg, layer='divides')
-    hyfab_cart = hyfab
-    # convert hydrofabric data to spherical coordiantes
-    hyfab = hyfab.to_crs('WGS84')
+    hyfab_cart = gpd.read_file(hyfab_gpkg, layer='divides')
+    hyfab_cart = hyfab_cart.sort_values(by=["div_id"])
+    hyfab = hyfab_cart.to_crs("WGS84")
 
     # Eventually, we'll add code to slice catchment ids
     # but for now just use feature ids
     # just use the default dtype for the values instead of trying to specify in the code
-    element_ids = np.array(hyfab.div_id.values, copy=True)
+    element_ids = np.array(hyfab.div_id.values, copy=True, dtype=np.int64)
+
     # generate 32-bit false IDs that are required for ESMF meshes
     # access to the IDs should be through indexes into the return of this function,
     # so it doesn't matter what these IDs are as long as they're int32

--- a/NextGen_Forcings_Engine_BMI/esmf_creation.py
+++ b/NextGen_Forcings_Engine_BMI/esmf_creation.py
@@ -1,6 +1,8 @@
 import argparse
 from pathlib import Path
 from types import SimpleNamespace
+import numpy as np
+import geopandas as gpd
 
 import yaml
 from NextGen_Forcings_Engine.core.config import ConfigOptions
@@ -21,10 +23,14 @@ def create_mesh(cfg: ConfigOptions):
     hyfab_name = cfg.geopackage
     mesh_out_path = Path(cfg.geogrid)
 
-    # Check if the mesh file already exists and remake if it does.
-    # The remake is necessary to ensure the same true catchment IDs will be generated.
     if mesh_out_path.is_file():
-        mesh_out_path.unlink()
+        # If the mesh netCDF file already exists,
+        # read the true catchment IDs off the divides.
+        # The generation will sort the IDs,
+        # so return the sorted IDs from the geopackage
+        # to maintain the true->false ID indexing
+        hyfab = gpd.read_file(hyfab_name, layer='divides')
+        return np.sort(hyfab.div_id.values, copy=True, dtype=np.int64)
     return convert_hyfab_to_esmf(hyfab_gpkg=hyfab_name, esmf_mesh_output=mesh_out_path)
 
 


### PR DESCRIPTION
The update to accommodate NHF 1.2 broke calibration runs where multiple processes would use the same derived netCDF file for the ESMF mesh. This update aims to address this problem.

When generating the netCDF file, an array of true catchment IDs is returned to allow indexing into the forcing values by NGEN. To ensure this was generated properly, the file was getting recreated for each BMI, including deleting an existing file. Now, if the netCDF file already exists, the catchment IDs will be read from the geopackage with the assumption that the netCDF file is based on those IDs. The IDs are sorted on read and netCDF file generation to ensure indexes are maintained.

## Additions

-

## Removals

-

## Changes

- If the geogrid netCDF file exists in the function responsible for creating it, the geopackage will be read to get the IDs.
- The catchments layer's values will be sorted by `div_id` before generating the netCDF file to ensure reading the source geopackage is enough to properly index into values.

## Testing

1. Run with RTE on Amazong Workspace machine with no output difference after implementation.

## Screenshots


## Notes

- An attempt was made to store the true IDs in the netCDF file, but all attempts to do so lead to errors when ESMPy tried to read the file.

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

