### PR TITLE
Remove EWTS lazy binding, update Dockerfile for local builds

### DIFF
--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -1,11 +1,12 @@
 ############################################################################
 # Change/Verify these values when adopting this Dockerfile into another org:
-#   GH_ORG, IMAGE_NAMESPACE,
+#   GH_ORG, GHCR_ORG, IMAGE_NAMESPACE,
 #   EWTS_ORG, EWTS_REF
 ############################################################################
 
 # Ownership / branding overrides
 ARG GH_ORG=NGWPC
+ARG GHCR_ORG=ngwpc
 ARG IMAGE_NAMESPACE=ngwpc
 
 # External repository sources (org and ref/branch overrides)
@@ -20,16 +21,26 @@ ARG EWTS_REF=development
 # Use the compiled dependencies image. This already includes the slow-moving
 # Rocky-based FOSS/compiled stack: WGRIB2, ESMF, SZIP, HDF5, NetCDF-C,
 # NetCDF-Fortran, Boost, and GDAL.
-ARG BMI_BASE_REPO=ghcr.io/ngwpc/ngen-dependencies-rocky8
-ARG BMI_BASE_TAG=latest
+#
+# Default build:
+#   docker build -t ngen-bmi-forcing .
+#
+# Build from a different published dependency image:
+#   docker build \
+#     --build-arg DEPS_IMAGE=ghcr.io/ngwpc/ngen-dependencies \
+#     -t ngen-bmi-forcing .
+#
+# Build from a locally built dependency image:
+#   docker build \
+#     --build-arg DEPS_IMAGE=ngen-dependencies \
+#     -t ngen-bmi-forcing .
+ARG DEPS_IMAGE=ghcr.io/${GHCR_ORG}/ngen-dependencies-rocky8
 
-FROM ${BMI_BASE_REPO}:${BMI_BASE_TAG}
-
-# Uncomment when building locally
-# FROM ngen-dependencies-rocky8
+FROM ${DEPS_IMAGE}
 
 # Re-expose args after FROM for the remaining build stage.
 ARG GH_ORG
+ARG GHCR_ORG
 ARG IMAGE_NAMESPACE
 ARG USE_EWTS=ON
 ARG EWTS_ORG
@@ -41,11 +52,10 @@ ARG EWTS_REF
 ARG EWTS_CACHE_BUST=0
 
 # OCI Metadata Arguments
-ARG BMI_BASE_REPO
-ARG BMI_BASE_TAG
-ARG BMI_BASE_NAME="${BMI_BASE_REPO}:${BMI_BASE_TAG}"
-ARG BMI_BASE_DIGEST="unknown"
-ARG BMI_BASE_REVISION="unknown"
+ARG DEPS_IMAGE
+ARG DEPS_IMAGE_NAME="${DEPS_IMAGE}"
+ARG DEPS_IMAGE_DIGEST="unknown"
+ARG DEPS_IMAGE_REVISION="unknown"
 ARG IMAGE_SOURCE="unknown"
 ARG IMAGE_VENDOR="unknown"
 ARG IMAGE_VERSION="unknown"
@@ -53,15 +63,15 @@ ARG IMAGE_REVISION="unknown"
 ARG EWTS_REVISION="unknown"
 
 # Image Labels: OCI-spec annotations followed by custom source-repo metadata.
-LABEL org.opencontainers.image.base.name="${BMI_BASE_NAME}" \
-    org.opencontainers.image.base.digest="${BMI_BASE_DIGEST}" \
+LABEL org.opencontainers.image.base.name="${DEPS_IMAGE_NAME}" \
+    org.opencontainers.image.base.digest="${DEPS_IMAGE_DIGEST}" \
     org.opencontainers.image.source="${IMAGE_SOURCE}" \
     org.opencontainers.image.vendor="${IMAGE_VENDOR}" \
     org.opencontainers.image.version="${IMAGE_VERSION}" \
     org.opencontainers.image.revision="${IMAGE_REVISION}" \
     org.opencontainers.image.title="NGEN BMI Forcing" \
     org.opencontainers.image.description="Docker image for the NGEN BMI Forcings application" \
-    io.${IMAGE_NAMESPACE}.image.base.revision="${BMI_BASE_REVISION}" \
+    io.${IMAGE_NAMESPACE}.image.base.revision="${DEPS_IMAGE_REVISION}" \
     io.${IMAGE_NAMESPACE}.ewts.org="${EWTS_ORG}" \
     io.${IMAGE_NAMESPACE}.ewts.ref="${EWTS_REF}" \
     io.${IMAGE_NAMESPACE}.ewts.revision="${EWTS_REVISION}"

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -12,21 +12,20 @@
 #   - NetCDF-Fortran
 #   - Boost
 #   - GDAL
+#   - UDUNITS2
 ############################################################################
 
-ARG DEPS_BASE_REPO=rockylinux
-ARG DEPS_BASE_TAG=8
+ARG BASE_IMAGE=rockylinux:8
 
-FROM ${DEPS_BASE_REPO}:${DEPS_BASE_TAG}
+FROM ${BASE_IMAGE}
 
 # Re-expose the base args after FROM (an ARG declared before FROM is only in
 # scope for the FROM line) so they can populate the OCI base.* image labels.
 # DEPS_BASE_NAME is composed here; DEPS_BASE_DIGEST defaults to "unknown" and is
 # overridden by the build-arg dependencies.yml resolves with skopeo at build time.
-ARG DEPS_BASE_REPO
-ARG DEPS_BASE_TAG
-ARG DEPS_BASE_NAME="${DEPS_BASE_REPO}:${DEPS_BASE_TAG}"
-ARG DEPS_BASE_DIGEST="unknown"
+ARG BASE_IMAGE
+ARG BASE_IMAGE_NAME="${BASE_IMAGE}"
+ARG BASE_IMAGE_DIGEST="unknown"
 ARG IMAGE_SOURCE="unknown"
 
 ARG SZIP_VERSION=2.1.1
@@ -39,8 +38,8 @@ ARG GDAL_VERSION=3.7.3
 
 # Image Labels: OCI-spec base annotations first, then the compiled library
 # versions baked into this image.
-LABEL org.opencontainers.image.base.name="${DEPS_BASE_NAME}" \
-    org.opencontainers.image.base.digest="${DEPS_BASE_DIGEST}" \
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE_NAME}" \
+    org.opencontainers.image.base.digest="${BASE_IMAGE_DIGEST}" \
     org.opencontainers.image.source="${IMAGE_SOURCE}" \
     io.ngwpc.szip.version="${SZIP_VERSION}" \
     io.ngwpc.hdf5.version="${HDF5_VERSION}" \
@@ -89,6 +88,7 @@ RUN set -eux; \
         python3.11-pip \
         python3.11-pyyaml \
         rsync \
+        udunits2 udunits2-devel \
         uuid uuid-devel \
         which \
         xz xz-devel \

--- a/Forcing_Extraction_Scripts/forecast_download_base.py
+++ b/Forcing_Extraction_Scripts/forecast_download_base.py
@@ -8,14 +8,54 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
 from urllib import error, request
 
-# Use the Error, Warning, and Trapping System Package for logging
-import ewts
+# Use the Error and Warning Trapping System Package for logging
 import requests
 from bs4 import BeautifulSoup
 
-LOG = ewts.get_logger(ewts.FORCING_ID)
+LOG = logging.getLogger("FORCING")
 
+try:
+    from ewts.helper import getenv_any
+    from ewts.logger import configure_existing_logger
+    FORCING_USE_EWTS = True
+except ImportError:
+    FORCING_USE_EWTS = False
 
+class StdoutStyleFormatter(logging.Formatter):
+
+    INFO_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s %(message)s"
+    )
+
+    DETAILED_FORMAT = (
+        "%(asctime)s %(name)-8s %(levelname)-7s "
+        "%(message)s "
+        "[%(filename)s.%(funcName)s(L%(lineno)s)]"
+    )
+
+    def format(self, record):
+        if record.levelno == logging.INFO:
+            self._style._fmt = self.INFO_FORMAT
+        else:
+            self._style._fmt = self.DETAILED_FORMAT
+
+        return super().format(record)
+
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    
+
+def _configure_stdout_logging():
+    LOG.setLevel(logging.INFO)
+
+    if not LOG.handlers:
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(StdoutStyleFormatter())
+        LOG.addHandler(handler)
+
+    LOG.propagate = False
 class ForecastDownloader(ABC):
     """Abstract base class for structured forecast data downloads.
 
@@ -55,14 +95,15 @@ class ForecastDownloader(ABC):
         :param ens_number: Ensemble number to fetch (if applicable)
         :param input_horizon: Maximum forecast hour to download (None = download all available timesteps)
         """
-        global LOG
-        if hasattr(LOG, "bind"):
-            # This is required prior to the first log message for the ewts package
-            LOG.bind()
+        if FORCING_USE_EWTS:
+            val = getenv_any("EWTS_USE_NGEN_BRIDGE", "").strip().lower()
+            if val in {"1", "true", "yes", "on"}:
+                configure_existing_logger(LOG)
+            else:
+                _configure_stdout_logging()
+                LOG.warning("ewts package installed but EWTS_USE_NGEN_BRIDGE not on. Falling back to default logging.")
         else:
-            # Fallback to default root logger
-            logging.basicConfig()
-            LOG = logging.getLogger()
+            _configure_stdout_logging()
 
         if lookback_hours <= lagback_hours:
             raise ValueError(

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/err_handler.py
@@ -10,9 +10,8 @@ import numpy as np
 from mpi4py import MPI
 from scipy import spatial
 
-# Use the Error, Warning, and Trapping System Package for logging
-LOG = logging.getLogger("FORCING")
-
+# Use the Error and Warning Trapping System Package for logging
+LOG = ewts.get_logger("FORCING")
 
 def in_exception_context() -> bool:
     if sys.exc_info()[0] is not None:


### PR DESCRIPTION
Remove EWTS lazy binding, update Dockerfile for local builds

## Additions

- Added writing to stdout if ewts is not installed.
- Comments and examples how to use the `DEPS_IMAGE` build argument to specify a different build of `ngen-dependencies`

## Removals

-

## Changes
- Updated `forecast_download_base.py` to use EWTS only if present, otherwise write to stdout.
- Replaced call to `logging.getLogger` in `err_handler.py` with call to `ewts.get_logger` since it will have already been initialized by this point.

## Testing

1. Tested running several calibrations and a forecast in AWS Workspace using ngenCERF UI.



