### PR TITLE
add traceback for historical forcing

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -435,9 +435,9 @@ class AORCConusProcessor(BaseProcessor):
                     .load()
                 )
         except Exception as e:
-            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}. This may indicate a broken comunication with s3 or missing/corupts data from the source. | Error: {e} | Traceback: {traceback.format_exc()}"
+            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}. This may indicate a broken comunication with s3 or missing/corupts data from the source. | Error: {e}"
             LOG.critical(error_message)
-            raise ValueError(error_message)
+            raise ValueError(error_message).with_traceback(e)
 
 
 class AORCAlaskaProcessor(BaseProcessor):

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -20,6 +20,7 @@ import zarr
 from dotenv import find_dotenv, load_dotenv
 from pyproj import CRS
 from zarr.storage import ObjectStore
+import traceback
 
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.config import (
     ConfigOptions,
@@ -434,7 +435,7 @@ class AORCConusProcessor(BaseProcessor):
                     .load()
                 )
         except Exception as e:
-            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}: {e}\n"
+            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}. This may indicate a broken comunication with s3 or missing/corupts data from the source. | Error: {e} | Traceback: {traceback.format_exc()}"
             LOG.critical(error_message)
             raise ValueError(error_message)
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -435,9 +435,9 @@ class AORCConusProcessor(BaseProcessor):
                     .load()
                 )
         except Exception as e:
-            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}. This may indicate a broken comunication with s3 or missing/corupts data from the source. | Error: {e}"
+            error_message = f"Error opening {self.dataset_name} data from {self.url(current_year)}. This may indicate a broken comunication with s3 or missing/corupts data from the source. | Error: {e} | Traceback: {traceback.format_exc()}"
             LOG.critical(error_message)
-            raise ValueError(error_message).with_traceback(e)
+            raise ValueError(error_message)
 
 
 class AORCAlaskaProcessor(BaseProcessor):


### PR DESCRIPTION
Add more robust error message (include traceback) to better understand why the method that reads zarr data is happening on the clusters as it is not reproducible on the AWS workspaces with RTE dev environment. 

Jira bug ticket: https://jira.nextgenwaterprediction.com/browse/NGWPC-10173
## Additions

-

## Removals

-

## Changes

-

## Testing

1. Tested with RTE runs. -only effects AORC CONUS calibration runs at the moment.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

