### PR TITLE
Rocky Deps: Add ecFlow Python Client

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -109,6 +109,14 @@ on:
         description: 'Deps image: GDAL version (blank = Dockerfile default; forces a deps rebuild)'
         required: false
         type: string
+      ECFLOW_VERSION:
+        description: 'Deps image: ecFlow version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
+      ECBUILD_VERSION:
+        description: 'Deps image: ecbuild version (blank = Dockerfile default; forces a deps rebuild)'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -248,7 +256,7 @@ jobs:
         run: |
           # if any dependency version input was provided, force a deps rebuild so
           # the override actually takes effect
-          if [ -n "${{ inputs.SZIP_VERSION }}${{ inputs.HDF5_VERSION }}${{ inputs.NETCDF_C_VERSION }}${{ inputs.NETCDF_FORTRAN_VERSION }}${{ inputs.BOOST_VERSION }}${{ inputs.ESMF_VERSION }}${{ inputs.GDAL_VERSION }}" ]; then
+          if [ -n "${{ inputs.SZIP_VERSION }}${{ inputs.HDF5_VERSION }}${{ inputs.NETCDF_C_VERSION }}${{ inputs.NETCDF_FORTRAN_VERSION }}${{ inputs.BOOST_VERSION }}${{ inputs.ESMF_VERSION }}${{ inputs.GDAL_VERSION }}${{ inputs.ECFLOW_VERSION }}${{ inputs.ECBUILD_VERSION }}" ]; then
             echo "set=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -272,6 +280,8 @@ jobs:
       boost_version: ${{ inputs.BOOST_VERSION }}
       esmf_version: ${{ inputs.ESMF_VERSION }}
       gdal_version: ${{ inputs.GDAL_VERSION }}
+      ecflow_version: ${{ inputs.ECFLOW_VERSION }}
+      ecbuild_version: ${{ inputs.ECBUILD_VERSION }}
 
   # CodeQL scan
   codeql-scan:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -71,6 +71,16 @@ on:
         required: false
         type: string
         default: ''
+      ecflow_version:
+        description: 'ecFlow version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
+      ecbuild_version:
+        description: 'ecbuild version (blank = Dockerfile.dependencies default)'
+        required: false
+        type: string
+        default: ''
     outputs:
       image:
         description: 'Published deps image repo (no tag)'
@@ -190,6 +200,8 @@ jobs:
           add BOOST_VERSION "${{ inputs.boost_version }}"
           add ESMF_VERSION "${{ inputs.esmf_version }}"
           add GDAL_VERSION "${{ inputs.gdal_version }}"
+          add ECFLOW_VERSION "${{ inputs.ecflow_version }}"
+          add ECBUILD_VERSION "${{ inputs.ecbuild_version }}"
 
           # Publish step outputs. $GITHUB_OUTPUT is a FILE the runner provides;
           # every line appended to it becomes `steps.vars.outputs.<name>`,

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -13,6 +13,7 @@
 #   - Boost
 #   - GDAL
 #   - UDUNITS2
+#   - ecFlow Python client
 ############################################################################
 
 ARG BASE_IMAGE=rockylinux:8
@@ -35,6 +36,8 @@ ARG NETCDF_FORTRAN_VERSION=4.5.4
 ARG BOOST_VERSION=1.86.0
 ARG ESMF_VERSION=8.8.0
 ARG GDAL_VERSION=3.7.3
+ARG ECFLOW_VERSION=5.15.2
+ARG ECBUILD_VERSION=3.14.2
 
 # Image Labels: OCI-spec base annotations first, then the compiled library
 # versions baked into this image.
@@ -47,7 +50,9 @@ LABEL org.opencontainers.image.base.name="${BASE_IMAGE_NAME}" \
     io.ngwpc.netcdf-fortran.version="${NETCDF_FORTRAN_VERSION}" \
     io.ngwpc.boost.version="${BOOST_VERSION}" \
     io.ngwpc.esmf.version="${ESMF_VERSION}" \
-    io.ngwpc.gdal.version="${GDAL_VERSION}"
+    io.ngwpc.gdal.version="${GDAL_VERSION}" \
+    io.ngwpc.ecflow.version="${ECFLOW_VERSION}" \
+    io.ngwpc.ecbuild.version="${ECBUILD_VERSION}"
 
 ENV LANG="C.UTF-8"
 ENV PATH="/usr/local/bin:${PATH}"
@@ -286,6 +291,8 @@ RUN set -eux; \
 # Boost
 ############################################################################
 
+# The sed call removes Boost.NumPy. ecFlow Python client does need --with-python (does need Boost.Python) but does not need Boost.Numpy, and including numpy here can be problematic.
+# Boost libs added 2026-06-25 are required by ecFlow Python client build. See: https://github.com/ecmwf/ecflow/blob/master/cmake/Dependencies.cmake
 RUN set -eux; \
     mkdir -p /tmp/build-boost; \
     cd /tmp/build-boost; \
@@ -295,7 +302,8 @@ RUN set -eux; \
     tar --extract --directory boost --strip-components=1 --file boost.tar.gz; \
     cd boost; \
     ./bootstrap.sh; \
-    ./b2 install --prefix=/usr/local --without-python; \
+    sed -i 's/boost-install boost_python boost_numpy/boost-install boost_python/' libs/python/build/Jamfile; \
+    CPLUS_INCLUDE_PATH="/usr/include/python3.11" ./b2 install --prefix=/usr/local --with-python --with-system --with-filesystem --with-thread --with-regex --with-date_time --with-program_options --with-process; \
     rm -rf /opt/boost; \
     mkdir --parents /opt/boost; \
     cp -a /tmp/build-boost/boost/. /opt/boost/; \
@@ -322,6 +330,35 @@ RUN set -eux && \
     cmake --build build --target install && \
     ldconfig && \
     rm -rf /tmp/build-gdal
+
+
+############################################################################
+# ecFLow python client (requires build from source)
+############################################################################
+
+RUN mkdir -p /tmp/build-ecflow && cd /tmp/build-ecflow && \
+    python -m pip install "pybind11>=2.10.3" && \
+    git clone --depth 1 --branch "${ECFLOW_VERSION}" https://github.com/ecmwf/ecflow.git && \
+    git clone --depth 1 --branch "${ECBUILD_VERSION}" https://github.com/ecmwf/ecbuild.git && \
+    PYBIND11_CMAKE_DIR="$(python -c 'import pybind11; print(pybind11.get_cmake_dir())')" && \
+    cmake -B ecflow/build -S ecflow \
+        -DCMAKE_INSTALL_PREFIX="${VIRTUAL_ENV}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="${PYBIND11_CMAKE_DIR}" \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_SERVER=OFF \
+        -DENABLE_UI=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_SSL=ON \
+        -DENABLE_STATIC_BOOST_LIBS=OFF \
+        -DBOOST_ROOT=/usr/local \
+        -DBoost_NO_SYSTEM_PATHS=on \
+        -DPython3_EXECUTABLE="$(which python)" && \
+    cmake --build ecflow/build --parallel "$(( $(nproc) < 4 ? $(nproc) : 4 ))" && \
+    cmake --install ecflow/build && \
+    python -c "import ecflow; print(f'ecflow Python client version {ecflow.__version__} installed successfully')" && \
+    rm -r /tmp/build-ecflow
 
 ############################################################################
 # Runtime environment

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -292,7 +292,8 @@ RUN set -eux; \
 ############################################################################
 
 # The sed call removes Boost.NumPy. ecFlow Python client does need --with-python (does need Boost.Python) but does not need Boost.Numpy, and including numpy here can be problematic.
-# Boost libs added 2026-06-25 are required by ecFlow Python client build. See: https://github.com/ecmwf/ecflow/blob/master/cmake/Dependencies.cmake
+# Boost libraries added 2026-06-25 are required by the ecFlow Python client.
+# See: https://github.com/ecmwf/ecflow/blob/5.15.2/cmake/Dependencies.cmake
 RUN set -eux; \
     mkdir -p /tmp/build-boost; \
     cd /tmp/build-boost; \

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -292,8 +292,7 @@ RUN set -eux; \
 ############################################################################
 
 # The sed call removes Boost.NumPy. ecFlow Python client does need --with-python (does need Boost.Python) but does not need Boost.Numpy, and including numpy here can be problematic.
-# Boost libraries added 2026-06-25 are required by the ecFlow Python client.
-# See: https://github.com/ecmwf/ecflow/blob/5.15.2/cmake/Dependencies.cmake
+# Boost Python is required by the ecFlow Python client.
 RUN set -eux; \
     mkdir -p /tmp/build-boost; \
     cd /tmp/build-boost; \
@@ -304,7 +303,7 @@ RUN set -eux; \
     cd boost; \
     ./bootstrap.sh; \
     sed -i 's/boost-install boost_python boost_numpy/boost-install boost_python/' libs/python/build/Jamfile; \
-    CPLUS_INCLUDE_PATH="/usr/include/python3.11" ./b2 install --prefix=/usr/local --with-python --with-system --with-filesystem --with-thread --with-regex --with-date_time --with-program_options --with-process; \
+    CPLUS_INCLUDE_PATH="/usr/include/python3.11" ./b2 install --prefix=/usr/local; \
     rm -rf /opt/boost; \
     mkdir --parents /opt/boost; \
     cp -a /tmp/build-boost/boost/. /opt/boost/; \
@@ -358,6 +357,7 @@ RUN mkdir -p /tmp/build-ecflow && cd /tmp/build-ecflow && \
         -DPython3_EXECUTABLE="$(which python)" && \
     cmake --build ecflow/build --parallel "$(( $(nproc) < 4 ? $(nproc) : 4 ))" && \
     cmake --install ecflow/build && \
+    python -m pip uninstall -y pybind11 && \
     python -c "import ecflow; print(f'ecflow Python client version {ecflow.__version__} installed successfully')" && \
     rm -r /tmp/build-ecflow
 


### PR DESCRIPTION
Update the Rocky dependencies image: add ecFlow Python client. This must be built from source using:

https://github.com/ecmwf/ecflow

and

https://github.com/ecmwf/ecbuild


This PR is analogous to https://github.com/NGWPC/ngen-forcing/pull/187. ~~and uses the same cross-OS `install_ecflow_python_client.sh`.~~

## Additions

- ecFlow Python client installation inside the existing `Dockerfile.dependencies`. ~~via new shell script that builds on Rocky or Debuntu (Debian / Ubuntu), called near the bottom of the dependencies Dockerfile.~~

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

