### PR TITLE
Debian Deps: Add ecFlow Python Client

### DIFF
--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -84,8 +84,8 @@ LABEL org.opencontainers.image.base.name="${DEPS_IMAGE}" \
 # Re-expose the shared Python virtual environment created by the dependency
 # image. Do not recreate it here; forcing, ngen, and downstream images should
 # all install into and reuse the same venv.
-ENV VIRTUAL_ENV="/ngen-app/ngen-python" \
-    PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV VIRTUAL_ENV="/ngen-app/ngen-python"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 ############################################################################
 # Optional EWTS Python package

--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -1,15 +1,15 @@
-# syntax=docker/dockerfile:1.4
-
 ############################################################################
 # Change/Verify these values when adopting this Dockerfile into another org:
 #   GH_ORG, GHCR_ORG, IMAGE_NAMESPACE,
 #   EWTS_ORG, EWTS_REF
 ############################################################################
 
+# Ownership / branding overrides
 ARG GH_ORG=NGWPC
 ARG GHCR_ORG=ngwpc
 ARG IMAGE_NAMESPACE=ngwpc
 
+# External repository sources (org and ref/branch overrides)
 ARG USE_EWTS=ON
 ARG EWTS_ORG=${GH_ORG}
 ARG EWTS_REF=development
@@ -19,22 +19,22 @@ ARG EWTS_REF=development
 ############################################################################
 
 # Use the compiled dependencies image. This already includes the slow-moving
-# Rocky-based FOSS/compiled stack: WGRIB2, ESMF, SZIP, HDF5, NetCDF-C,
-# NetCDF-Fortran, Boost, and GDAL.
+# Bookworm-based FOSS/compiled stack: WGRIB2, ESMF, ESMPy, HDF5, NetCDF-C,
+# NetCDF-Fortran, Boost, GDAL, UDUNITS2, and stable Python dependencies.
 #
 # Default build:
 #   docker build -t ngen-bmi-forcing .
 #
 # Build from a different published dependency image:
 #   docker build \
-#     --build-arg DEPS_IMAGE=ghcr.io/ngwpc/ngen-dependencies-rocky \
+#     --build-arg DEPS_IMAGE=ghcr.io/ngwpc/ngen-dependencies-bookworm \
 #     -t ngen-bmi-forcing .
 #
 # Build from a locally built dependency image:
 #   docker build \
-#     --build-arg DEPS_IMAGE=ngen-dependencies-rocky \
+#     --build-arg DEPS_IMAGE=ngen-dependencies-bookworm \
 #     -t ngen-bmi-forcing .
-ARG DEPS_IMAGE=ghcr.io/${GHCR_ORG}/ngen-dependencies-rocky8
+ARG DEPS_IMAGE=ghcr.io/${GHCR_ORG}/ngen-dependencies-bookworm
 
 FROM ${DEPS_IMAGE}
 
@@ -45,13 +45,18 @@ ARG IMAGE_NAMESPACE
 ARG USE_EWTS=ON
 ARG EWTS_ORG
 ARG EWTS_REF
+ARG DEPS_IMAGE
+
+# Optional cache-bust args.
+# Leave this at 0 for normal builds. Override only when you intentionally want
+# the EWTS layer rebuilt even though the Dockerfile inputs did not change.
 ARG EWTS_CACHE_BUST=0
 
 # OCI Metadata Arguments
-ARG DEPS_IMAGE
-ARG DEPS_IMAGE_NAME="${DEPS_IMAGE}"
-ARG DEPS_IMAGE_DIGEST="unknown"
-ARG DEPS_IMAGE_REVISION="unknown"
+#
+# BASE_IMAGE_* refers to the dependency image this image is built FROM.
+ARG BASE_IMAGE_DIGEST="unknown"
+ARG BASE_IMAGE_REVISION="unknown"
 ARG IMAGE_SOURCE="unknown"
 ARG IMAGE_VENDOR="unknown"
 ARG IMAGE_VERSION="unknown"
@@ -59,40 +64,44 @@ ARG IMAGE_REVISION="unknown"
 ARG EWTS_REVISION="unknown"
 
 # Image Labels: OCI-spec annotations followed by custom source-repo metadata.
-LABEL org.opencontainers.image.base.name="${DEPS_IMAGE_NAME}" \
-    org.opencontainers.image.base.digest="${DEPS_IMAGE_DIGEST}" \
-    org.opencontainers.image.source="${IMAGE_SOURCE}" \
-    org.opencontainers.image.vendor="${IMAGE_VENDOR}" \
-    org.opencontainers.image.version="${IMAGE_VERSION}" \
-    org.opencontainers.image.revision="${IMAGE_REVISION}" \
-    org.opencontainers.image.title="NGEN BMI Forcing" \
-    org.opencontainers.image.description="Docker image for the NGEN BMI Forcings application" \
-    io.${IMAGE_NAMESPACE}.image.base.revision="${DEPS_IMAGE_REVISION}" \
-    io.${IMAGE_NAMESPACE}.ewts.org="${EWTS_ORG}" \
-    io.${IMAGE_NAMESPACE}.ewts.ref="${EWTS_REF}" \
-    io.${IMAGE_NAMESPACE}.ewts.revision="${EWTS_REVISION}"
+LABEL org.opencontainers.image.base.name="${DEPS_IMAGE}" \
+      org.opencontainers.image.base.digest="${BASE_IMAGE_DIGEST}" \
+      org.opencontainers.image.source="${IMAGE_SOURCE}" \
+      org.opencontainers.image.vendor="${IMAGE_VENDOR}" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.revision="${IMAGE_REVISION}" \
+      org.opencontainers.image.title="NGEN BMI Forcing" \
+      org.opencontainers.image.description="Docker image for the NGEN BMI Forcings application" \
+      io.${IMAGE_NAMESPACE}.image.base.revision="${BASE_IMAGE_REVISION}" \
+      io.${IMAGE_NAMESPACE}.ewts.org="${EWTS_ORG}" \
+      io.${IMAGE_NAMESPACE}.ewts.ref="${EWTS_REF}" \
+      io.${IMAGE_NAMESPACE}.ewts.revision="${EWTS_REVISION}"
 
 ############################################################################
-# Python environment inherited from dependency image
+# Python environment inherited from dependencies image
 ############################################################################
 
-# Reuse the shared venv created by ngen-dependencies-bookworm. Do not recreate it
-# here; forcing, ngen, and downstream images should all install into the same env.
+# Re-expose the shared Python virtual environment created by the dependency
+# image. Do not recreate it here; forcing, ngen, and downstream images should
+# all install into and reuse the same venv.
 ENV VIRTUAL_ENV="/ngen-app/ngen-python" \
-    PATH="${VIRTUAL_ENV}/bin:${PATH}" \
-    PYTHONPATH="${VIRTUAL_ENV}/lib/python3.14/site-packages:/usr/local/lib/python3.14/site-packages:${PYTHONPATH}"
-
-ENV WGRIB2=/usr/local/bin/wgrib2
-ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
-
-SHELL ["/bin/bash", "-c"]
+    PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 ############################################################################
 # Optional EWTS Python package
 ############################################################################
 
-# ngen-bmi-forcing only needs the EWTS Python package. Full EWTS C/C++/Fortran
-# libraries are built later in the ngen image and inherited by downstream images.
+SHELL ["/bin/bash", "-c"]
+
+# ngen-bmi-forcing only needs the EWTS Python package, not the C/C++/Fortran
+# libraries or ngen bridge that the full ngen image requires.
+#
+# Ensures an unset or empty USE_EWTS defaults to ON.
+#
+# USE_EWTS accepted ON values:
+#   ON, YES, TRUE, 1
+#
+# Everything else is treated as OFF.
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux && \
     USE_EWTS="${USE_EWTS:-ON}" && \
@@ -100,12 +109,12 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     USE_EWTS_NORMALIZED="$(echo "${USE_EWTS}" | tr '[:lower:]' '[:upper:]')" && \
     if [[ "${USE_EWTS_NORMALIZED}" =~ ^(ON|YES|TRUE|1)$ ]]; then \
         echo "Installing EWTS Python package"; \
-        rm -rf /tmp/nwm-ewts; \
+        rm -rf /tmp/nwm-ewts && \
         (git clone --depth 1 -b "${EWTS_REF}" \
             "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts \
          || (git clone "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts && \
-             cd /tmp/nwm-ewts && git checkout "${EWTS_REF}")); \
-        cd /tmp/nwm-ewts; \
+             cd /tmp/nwm-ewts && git checkout "${EWTS_REF}")) && \
+        cd /tmp/nwm-ewts && \
         jq -n \
           --arg commit_hash "$(git rev-parse HEAD)" \
           --arg branch "$(git branch -r --contains HEAD 2>/dev/null | grep -v '\->' | sed 's|origin/||' | head -n1 | xargs || echo "${EWTS_REF}")" \
@@ -115,9 +124,9 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
           --arg message "$(git log -1 --pretty=format:'%s' | tr '\n' ';')" \
           --arg build_date "$(date -u +'%Y-%m-%d %H:%M:%S UTC')" \
           '{"nwm-ewts": {commit_hash: $commit_hash, branch: $branch, tags: $tags, author: $author, commit_date: $commit_date, message: $message, build_date: $build_date}}' \
-          > /ngen-app/nwm-ewts_git_info.json; \
-        python -m pip install /tmp/nwm-ewts/runtime/python/ewts; \
-        cd /; \
+          > /ngen-app/nwm-ewts_git_info.json && \
+        python -m pip install /tmp/nwm-ewts/runtime/python/ewts && \
+        cd / && \
         rm -rf /tmp/nwm-ewts; \
     else \
         echo "EWTS disabled; ensuring ewts package is absent"; \
@@ -126,16 +135,18 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     fi
 
 ############################################################################
-# ngen-bmi-forcing
+# ngen-bmi-forcing - most frequently changing layer
 ############################################################################
 
+# Keep COPY near the end. Source changes should invalidate only this section
+# and the git-info section below, not the inherited compiled dependencies,
+# ESMPy, mpi4py, or EWTS.
 COPY . /ngen-app/ngen-forcing/
 
 WORKDIR /ngen-app/ngen-forcing
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
-    python -m pip install .; \
-    python -m pip cache purge
+    python -m pip install .
 
 ARG CI_COMMIT_REF_NAME
 
@@ -162,4 +173,5 @@ RUN set -eux; \
     fi
 
 WORKDIR /
-ENTRYPOINT ["/bin/bash"]
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/Dockerfile.bmi-forcings
+++ b/Dockerfile.bmi-forcings
@@ -1,15 +1,15 @@
+# syntax=docker/dockerfile:1.4
+
 ############################################################################
 # Change/Verify these values when adopting this Dockerfile into another org:
 #   GH_ORG, GHCR_ORG, IMAGE_NAMESPACE,
 #   EWTS_ORG, EWTS_REF
 ############################################################################
 
-# Ownership / branding overrides
 ARG GH_ORG=NGWPC
 ARG GHCR_ORG=ngwpc
 ARG IMAGE_NAMESPACE=ngwpc
 
-# External repository sources (org and ref/branch overrides)
 ARG USE_EWTS=ON
 ARG EWTS_ORG=${GH_ORG}
 ARG EWTS_REF=development
@@ -45,10 +45,6 @@ ARG IMAGE_NAMESPACE
 ARG USE_EWTS=ON
 ARG EWTS_ORG
 ARG EWTS_REF
-
-# Optional cache-bust args.
-# Leave this at 0 for normal builds. Override only when you intentionally want
-# the EWTS layer rebuilt even though the Dockerfile inputs did not change.
 ARG EWTS_CACHE_BUST=0
 
 # OCI Metadata Arguments
@@ -77,45 +73,39 @@ LABEL org.opencontainers.image.base.name="${DEPS_IMAGE_NAME}" \
     io.${IMAGE_NAMESPACE}.ewts.revision="${EWTS_REVISION}"
 
 ############################################################################
-# Python environment inherited from dependencies image
+# Python environment inherited from dependency image
 ############################################################################
 
-# Re-expose the shared Python virtual environment created by the dependency
-# image. Do not recreate it here; forcing, ngen, and downstream images should
-# all install into and reuse the same venv.
-ENV VIRTUAL_ENV="/ngen-app/ngen-python"
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}" \
-    PYTHONPATH="${VIRTUAL_ENV}/lib/python3.11/site-packages:/usr/local/lib64/python3.11/site-packages:${PYTHONPATH}"
+# Reuse the shared venv created by ngen-dependencies-bookworm. Do not recreate it
+# here; forcing, ngen, and downstream images should all install into the same env.
+ENV VIRTUAL_ENV="/ngen-app/ngen-python" \
+    PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+    PYTHONPATH="${VIRTUAL_ENV}/lib/python3.14/site-packages:/usr/local/lib/python3.14/site-packages:${PYTHONPATH}"
 
+ENV WGRIB2=/usr/local/bin/wgrib2
+ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH}"
+
+SHELL ["/bin/bash", "-c"]
 
 ############################################################################
 # Optional EWTS Python package
 ############################################################################
 
-SHELL ["/bin/bash", "-c"]
-
-# ngen-bmi-forcing only needs the EWTS Python package, not the C/C++/Fortran
-# libraries or ngen bridge that the full ngen image requires.
-#
-# Ensures an unset or empty USE_EWTS defaults to ON.
-#
-# USE_EWTS accepted ON values:
-#   ON, YES, TRUE, 1
-#
-# Everything else is treated as OFF.
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
+# ngen-bmi-forcing only needs the EWTS Python package. Full EWTS C/C++/Fortran
+# libraries are built later in the ngen image and inherited by downstream images.
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux && \
     USE_EWTS="${USE_EWTS:-ON}" && \
     echo "USE_EWTS=${USE_EWTS}; EWTS org: ${EWTS_ORG}; ref: ${EWTS_REF}; cache bust: ${EWTS_CACHE_BUST}" && \
     USE_EWTS_NORMALIZED="$(echo "${USE_EWTS}" | tr '[:lower:]' '[:upper:]')" && \
     if [[ "${USE_EWTS_NORMALIZED}" =~ ^(ON|YES|TRUE|1)$ ]]; then \
         echo "Installing EWTS Python package"; \
-        rm -rf /tmp/nwm-ewts && \
+        rm -rf /tmp/nwm-ewts; \
         (git clone --depth 1 -b "${EWTS_REF}" \
             "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts \
          || (git clone "https://github.com/${EWTS_ORG}/nwm-ewts.git" /tmp/nwm-ewts && \
-             cd /tmp/nwm-ewts && git checkout "${EWTS_REF}")) && \
-        cd /tmp/nwm-ewts && \
+             cd /tmp/nwm-ewts && git checkout "${EWTS_REF}")); \
+        cd /tmp/nwm-ewts; \
         jq -n \
           --arg commit_hash "$(git rev-parse HEAD)" \
           --arg branch "$(git branch -r --contains HEAD 2>/dev/null | grep -v '\->' | sed 's|origin/||' | head -n1 | xargs || echo "${EWTS_REF}")" \
@@ -125,9 +115,9 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
           --arg message "$(git log -1 --pretty=format:'%s' | tr '\n' ';')" \
           --arg build_date "$(date -u +'%Y-%m-%d %H:%M:%S UTC')" \
           '{"nwm-ewts": {commit_hash: $commit_hash, branch: $branch, tags: $tags, author: $author, commit_date: $commit_date, message: $message, build_date: $build_date}}' \
-          > /ngen-app/nwm-ewts_git_info.json && \
-        python -m pip install /tmp/nwm-ewts/runtime/python/ewts && \
-        cd / && \
+          > /ngen-app/nwm-ewts_git_info.json; \
+        python -m pip install /tmp/nwm-ewts/runtime/python/ewts; \
+        cd /; \
         rm -rf /tmp/nwm-ewts; \
     else \
         echo "EWTS disabled; ensuring ewts package is absent"; \
@@ -136,18 +126,16 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
     fi
 
 ############################################################################
-# ngen-bmi-forcing - most frequently changing layer
+# ngen-bmi-forcing
 ############################################################################
 
-# Keep COPY near the end. Source changes should invalidate only this section
-# and the git-info section below, not the inherited compiled dependencies,
-# ESMPy, mpi4py, or EWTS.
 COPY . /ngen-app/ngen-forcing/
 
 WORKDIR /ngen-app/ngen-forcing
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-rocky \
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
-    python -m pip install .
+    python -m pip install .; \
+    python -m pip cache purge
 
 ARG CI_COMMIT_REF_NAME
 
@@ -174,5 +162,4 @@ RUN set -eux; \
     fi
 
 WORKDIR /
-
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT ["/bin/bash"]

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -16,7 +16,7 @@
 #   - ESMF + ESMPy
 ############################################################################
 
-ARG BASE_IMAGE=python:3.14-slim-bookworm
+ARG BASE_IMAGE=python:3.12-slim-bookworm
 
 FROM ${BASE_IMAGE}
 
@@ -54,8 +54,6 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locke
         ccache \
         cmake \
         curl \
-        file \
-        findutils \
         gfortran \
         git \
         jq \
@@ -65,10 +63,8 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locke
         libffi-dev \
         libgdal-dev \
         libhdf5-dev \
-        liblapack-dev \
         libnetcdf-dev \
         libnetcdff-dev \
-        libopenblas-dev \
         libopenjp2-7-dev \
         libopenmpi-dev \
         libpng-dev \
@@ -82,9 +78,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locke
         pkg-config \
         proj-bin \
         proj-data \
-        rsync \
         uuid-dev \
-        wget \
         xz-utils \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
@@ -95,17 +89,41 @@ RUN update-ccache-symlinks
 
 ENV PATH="/usr/lib/ccache:${PATH}:/usr/lib/x86_64-linux-gnu/openmpi/bin" \
     CCACHE_DIR="/root/.cache/ccache" \
-    CCACHE_MAXSIZE="10G"
+    CCACHE_MAXSIZE="5G" \
+    CCACHE_COMPRESS="true"
 
 # Create the shared Python virtual environment early so Python packages built by
 # compiled dependencies, including ESMPy and mpi4py, install into the same venv
 # reused later by forcing, ngen, and downstream images.
-ENV VIRTUAL_ENV="/ngen-app/ngen-python" \
-    PATH="${VIRTUAL_ENV}/bin:${PATH}"
+#
+# These must be separate ENV instructions. Docker expands references in an ENV
+# instruction using values defined before that instruction, so VIRTUAL_ENV is not
+# available when expanding PATH if both variables are first defined together.
+# Defining VIRTUAL_ENV first ensures PATH includes the venv's bin directory and
+# subsequent `python` and `pip` commands use the shared virtual environment.
+ENV VIRTUAL_ENV="/ngen-app/ngen-python"
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN set -eux; \
     mkdir -p /ngen-app; \
     python -m venv "${VIRTUAL_ENV}"
+
+# Install the shared Python packaging and build tools before building ESMPy or
+# installing any other Python packages. Python 3.12 virtual environments do not
+# include setuptools by default, and source-based package installations require
+# current versions of setuptools, wheel, and the PEP 517 build tooling.
+#
+# These tools are installed into the shared virtual environment so they are also
+# available to the forcing, ngen, and downstream images that inherit it.
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
+    set -eux; \
+    python -m pip install --upgrade \
+        pip \
+        setuptools \
+        wheel \
+        build \
+        pyproject_hooks \
+        packaging
 
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64"
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
@@ -117,7 +135,7 @@ ENV OMPI_MCA_btl_base_warn_component_unused=0
 # WGRIB2
 ############################################################################
 
-RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
     set -eux; \
     mkdir -p /tmp/build-wgrib2; \
     cd /tmp/build-wgrib2; \
@@ -143,37 +161,8 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=loc
 
 ENV WGRIB2=/usr/local/bin/wgrib2
 
-############################################################################
-# NumPy 1.26.4
-#
-# NumPy 1.26.4 is built from source because no compatible prebuilt wheel is
-# available for Python 3.14. The build is explicitly linked against OpenBLAS
-# for BLAS and LAPACK operations used by NumPy, SciPy, and t-route.
-#
-# NumPy is installed before other Python packages so their dependency
-# resolution uses this build instead of installing or building another NumPy
-# version. The constraints file created below pins later pip installations to
-# NumPy 1.26.4 without causing NumPy to be installed again.
-############################################################################
-
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
-    --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
-    set -eux; \
-    python -m pip install --upgrade \
-        pip \
-        setuptools \
-        wheel \
-        build \
-        pyproject_hooks \
-        packaging; \
-    python -m pip install \
-        --no-binary=numpy \
-        -Csetup-args=-Dblas=openblas \
-        -Csetup-args=-Dlapack=openblas \
-        "numpy==1.26.4"
-
-# Prevent later pip installations from replacing the custom NumPy build with
-# another version while resolving their transitive dependencies.
+# Prevent pip installations in this image and downstream images from replacing
+# NumPy 1.26.4 while resolving transitive dependencies.
 RUN printf '%s\n' \
         'numpy==1.26.4' \
         > /ngen-app/python-constraints.txt
@@ -183,14 +172,6 @@ RUN printf '%s\n' \
 # image and downstream images. A downstream installation that requires an
 # incompatible NumPy version will fail rather than replace NumPy 1.26.4.
 ENV PIP_CONSTRAINT="/ngen-app/python-constraints.txt"
-
-# Verify that NumPy is linked against OpenBLAS and that a LAPACK operation
-# executes successfully.
-RUN set -eux && \
-    SP="$(python -c 'import numpy, os; print(os.path.dirname(numpy.__file__))')" && \
-    ldd "$(find "$SP" -name '_multiarray_umath*.so' | head -1)" | grep -q openblas && \
-    ldd "$(find "$SP/linalg" -name '_umath_linalg*.so' | head -1)" | grep -q openblas && \
-    python -c "import numpy as np; np.linalg.svd(np.eye(8)); print('numpy', np.__version__, 'BLAS+LAPACK -> OpenBLAS OK')"
 
 ############################################################################
 # ESMF + ESMPy
@@ -202,7 +183,7 @@ RUN set -eux && \
 # /usr/local NetCDF at runtime.
 ############################################################################
 
-RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
     set -eux; \
     mkdir -p /tmp/build-esmf; \
     cd /tmp/build-esmf; \
@@ -245,7 +226,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
 # so downstream CMake builds can use -DBOOST_ROOT=/opt/boost.
 ############################################################################
 
-RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
     set -eux; \
     mkdir -p /tmp/build-boost; \
     cd /tmp/build-boost; \
@@ -265,30 +246,42 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=loc
 
 ############################################################################
 # Stable Python dependencies
+#
+# mpi4py is built from source so it links against the same Bookworm OpenMPI
+# installation used by ESMF, ESMPy, and ngen.
 ############################################################################
 
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
     python -m pip install \
-        --no-binary=mpi4py \
-        mpi4py; \
-    python -m pip install \
+        "numpy==1.26.4" \
         netcdf4 \
         bmipy \
         pandas \
         pyyml; \
     python -m pip install \
+        --no-binary=mpi4py \
+        mpi4py; \
+    python -m pip install \
         --index-url https://download.pytorch.org/whl/cpu \
         torch \
         torchvision
 
-# Verify that all installed Python packages have compatible dependencies and
-# that later installations did not replace NumPy 1.26.4.
+# Verify the configured NumPy constraint, package compatibility, and the
+# installed NumPy version after all Python dependencies have been installed.
 RUN set -eux; \
+    test "$(command -v python)" = "${VIRTUAL_ENV}/bin/python"; \
     test "${PIP_CONSTRAINT}" = "/ngen-app/python-constraints.txt"; \
     grep -qx 'numpy==1.26.4' "${PIP_CONSTRAINT}"; \
     python -m pip check; \
-    python -c "import numpy as np; assert np.__version__ == '1.26.4', np.__version__; np.linalg.svd(np.eye(8)); print('Final NumPy version:', np.__version__)"
+    python -c "import sys, setuptools, wheel, build, pyproject_hooks, packaging; \
+assert sys.executable == '${VIRTUAL_ENV}/bin/python', sys.executable; \
+print('Python:', sys.executable); \
+print('setuptools:', setuptools.__version__)"; \
+    python -c "import numpy as np; \
+assert np.__version__ == '1.26.4', np.__version__; \
+np.linalg.svd(np.eye(8)); \
+print('NumPy version:', np.__version__)"
 
 WORKDIR /
 

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -1,128 +1,111 @@
 # syntax=docker/dockerfile:1.4
 
 ############################################################################
-# Rocky compiled dependency base image for ngen-bmi-forcing / ngen
+# Bookworm dependency base image for ngen-bmi-forcing / ngen
 #
-# Contains slow-moving compiled dependencies:
-#   - WGRIB2
-#   - ESMF
-#   - SZIP
+# Uses Debian packages where practical:
 #   - HDF5
 #   - NetCDF-C
 #   - NetCDF-Fortran
-#   - Boost
 #   - GDAL
-#   - UDUNITS2
-############################################################################
-
-ARG BASE_IMAGE=rockylinux:8
 
 FROM ${BASE_IMAGE}
 
-# Re-expose the base args after FROM (an ARG declared before FROM is only in
-# scope for the FROM line) so they can populate the OCI base.* image labels.
-# DEPS_BASE_NAME is composed here; DEPS_BASE_DIGEST defaults to "unknown" and is
-# overridden by the build-arg dependencies.yml resolves with skopeo at build time.
-ARG BASE_IMAGE
-ARG BASE_IMAGE_NAME="${BASE_IMAGE}"
-ARG BASE_IMAGE_DIGEST="unknown"
-ARG IMAGE_SOURCE="unknown"
+#
+# Builds from source where still needed:
+#   - WGRIB2
+#   - Boost
+#   - ESMF + ESMPy
+############################################################################
 
-ARG SZIP_VERSION=2.1.1
-ARG HDF5_VERSION=1.10.11
-ARG NETCDF_C_VERSION=4.7.4
-ARG NETCDF_FORTRAN_VERSION=4.5.4
-ARG BOOST_VERSION=1.86.0
+ARG DEPS_BASE_REPO=python
+ARG DEPS_BASE_TAG=3.14-slim-bookworm
+
+FROM ${DEPS_BASE_REPO}:${DEPS_BASE_TAG}
+
 ARG ESMF_VERSION=8.8.0
-ARG GDAL_VERSION=3.7.3
+ARG BOOST_VERSION=1.86.0
 
-# Image Labels: OCI-spec base annotations first, then the compiled library
-# versions baked into this image.
-LABEL org.opencontainers.image.base.name="${BASE_IMAGE_NAME}" \
-    org.opencontainers.image.base.digest="${BASE_IMAGE_DIGEST}" \
-    org.opencontainers.image.source="${IMAGE_SOURCE}" \
-    io.ngwpc.szip.version="${SZIP_VERSION}" \
-    io.ngwpc.hdf5.version="${HDF5_VERSION}" \
-    io.ngwpc.netcdf-c.version="${NETCDF_C_VERSION}" \
-    io.ngwpc.netcdf-fortran.version="${NETCDF_FORTRAN_VERSION}" \
-    io.ngwpc.boost.version="${BOOST_VERSION}" \
-    io.ngwpc.esmf.version="${ESMF_VERSION}" \
-    io.ngwpc.gdal.version="${GDAL_VERSION}"
+LABEL io.ngwpc.boost.version="${BOOST_VERSION}" \
+      io.ngwpc.esmf.version="${ESMF_VERSION}"
 
-ENV LANG="C.UTF-8"
-ENV PATH="/usr/local/bin:${PATH}"
+ENV LANG="C.UTF-8" \
+    PATH="/usr/local/bin:${PATH}"
 
 ############################################################################
 # System/FOSS dependencies
 ############################################################################
 
-RUN set -eux; \
-    dnf install -y dnf-plugins-core; \
-    dnf install -y epel-release; \
-    dnf config-manager --set-enabled powertools; \
-    dnf install -y \
-        proj proj-devel \
-        sqlite sqlite-devel \
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,id=apt-lib-bookworm,sharing=locked \
+    set -eux && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
         autoconf \
         automake \
-        bzip2 bzip2-devel \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        ccache \
         cmake \
-        curl curl-devel \
+        curl \
         file \
         findutils \
+        gfortran \
         git \
         jq \
-        gcc-toolset-10 \
-        gcc-toolset-10-libasan-devel \
-        gcc-toolset-10-gcc-gfortran \
-        jasper-libs jasper-devel \
-        libaec libaec-devel \
-        libasan6 \
-        libffi libffi-devel \
-        libpng libpng-devel \
+        libbz2-dev \
+        libcurl4-openssl-dev \
+        libffi-dev \
+        libgdal-dev \
+        libhdf5-dev \
+        libnetcdf-dev \
+        libnetcdff-dev \
+        libopenjp2-7-dev \
+        libopenmpi-dev \
+        libpng-dev \
+        libproj-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        libudunits2-dev \
+        libaec-dev \
         m4 \
-        openmpi openmpi-devel \
-        openssl openssl-devel \
-        python3.11 \
-        python3.11-devel \
-        python3.11-pip \
-        python3.11-pyyaml \
+        netcdf-bin \
+        openmpi-bin \
+        pkg-config \
+        proj-bin \
+        proj-data \
         rsync \
-        udunits2 udunits2-devel \
-        uuid uuid-devel \
-        which \
-        xz xz-devel \
-        zlib zlib-devel \
-        hdf5-devel \
-        netcdf-devel \
-        netcdf-fortran-devel \
-    ; \
-    dnf clean all; \
-    rm -rf /var/cache/dnf
+        uuid-dev \
+        wget \
+        xz-utils \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-SHELL ["/usr/bin/scl", "enable", "gcc-toolset-10"]
+SHELL ["/bin/bash", "-c"]
 
-ENV PATH="${PATH}:/usr/lib64/openmpi/bin/"
+ENV PATH="${PATH}:/usr/lib/x86_64-linux-gnu/openmpi/bin"
 
-# Create the shared Python virtual environment early so any Python packages
-# built by compiled dependencies, including ESMPy, install into the same venv
-# reused later by forcing, ngen, and cal-mgr.
+# Create the shared Python virtual environment early so Python packages built by
+# compiled dependencies, including ESMPy and mpi4py, install into the same venv
+# reused later by forcing, ngen, and downstream images.
 ENV VIRTUAL_ENV="/ngen-app/ngen-python"
 ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/bin:${PATH}"
-ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.11/site-packages:/usr/local/lib64/python3.11/site-packages"
+ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.14/site-packages:/usr/local/lib/python3.14/site-packages"
 
 RUN set -eux; \
     mkdir -p /ngen-app; \
-    python3.11 -m venv --system-site-packages "${VIRTUAL_ENV}"; \
-    ln -sf "${VIRTUAL_ENV}/bin/python" /usr/local/bin/python; \
-    python --version; \
+    python -m venv --system-site-packages "${VIRTUAL_ENV}"; \
     python -c "import sys; print(sys.executable)"
+
+ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64"
+ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
+ENV OMPI_MCA_btl=^openib,ofi
+ENV OMPI_MCA_pml=ob1
+ENV OMPI_MCA_btl_base_warn_component_unused=0
 
 ############################################################################
 # WGRIB2
-#
-# Unlike the other compiled dependencies, WGRIB2 is not currently version-pinned.
-# It is built from NOAA's current wgrib2.tgz distribution when this image is rebuilt.
 ############################################################################
 
 RUN set -eux; \
@@ -139,8 +122,8 @@ RUN set -eux; \
         USE_IPOLATES=3 \
         USE_PNG=1 \
         USE_AEC=0 \
-        USE_JASPER=1 \
-        USE_OPENJPEG=0 \
+        USE_JASPER=0 \
+        USE_OPENJPEG=1 \
         USE_G2CLIB=0 \
         PREFIX=/usr/local; \
     make lib; \
@@ -150,14 +133,14 @@ RUN set -eux; \
 
 ENV WGRIB2=/usr/local/bin/wgrib2
 
-
 ############################################################################
-# ESMF
+# ESMF + ESMPy
 #
-# ESMF is built before the source-built SZIP/HDF5/NetCDF stack below so it uses
-# the Rocky-provided hdf5/netcdf/netcdf-fortran packages. This matches the
-# original ngen-bmi-forcing Dockerfile behavior and avoids ESMF linking against
-# the later /usr/local NetCDF install.
+# ESMF is the one large scientific library still built from source in this
+# Bookworm dependency image. Unlike the Rocky transition image, ESMF is built
+# against Bookworm's packaged HDF5/NetCDF stack, and that same stack remains
+# available at runtime. This avoids mixing distro NetCDF at build time with
+# /usr/local NetCDF at runtime.
 ############################################################################
 
 RUN set -eux; \
@@ -172,118 +155,33 @@ RUN set -eux; \
     export ESMF_COMPILER=gfortran; \
     export ESMF_COMM=openmpi; \
     export ESMF_NETCDF="nc-config"; \
-    export ESMF_F90COMPILEPATHS="-I/usr/lib64/gfortran/modules"; \
     export ESMF_BOPT=O; \
     make all; \
-    make install
+    make install; \
+    rm -rf /tmp/build-esmf
 
 ENV ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.mk
 
-############################################################################
-# ESMPy install
-############################################################################
-
-RUN set -eux; \
-    cd "/tmp/build-esmf/esmf-${ESMF_VERSION}"; \
-    export ESMF_DIR="$(pwd)"; \
-    export ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.mk; \
-    cd src/addon/esmpy; \
-    python -m pip install .
-
-RUN rm -rf /tmp/build-esmf
-
-
-############################################################################
-# SZIP / HDF5 / NetCDF-C / NetCDF-Fortran
-#
-# These are source-built after ESMF for compatibility with the original ngen
-# dependency image, where ngen and several submodules expected the compiled
-# dependency stack under /usr/local.
-############################################################################
-
-############################################################################
-# SZIP
-############################################################################
-
-RUN set -eux; \
-    mkdir -p /tmp/build-szip; \
-    cd /tmp/build-szip; \
-    curl --location --output szip.tar.gz \
-        "https://docs.hdfgroup.org/archive/support/ftp/lib-external/szip/${SZIP_VERSION%%[a-z]*}/src/szip-${SZIP_VERSION}.tar.gz"; \
-    mkdir szip; \
-    tar --extract --directory szip --strip-components=1 --file szip.tar.gz; \
-    cd szip; \
-    ./configure --prefix=/usr/local/; \
-    make -j "$(nproc)"; \
-    make install; \
-    strip --strip-debug /usr/local/lib/libsz*.so.* || true; \
-    rm -rf /tmp/build-szip
-
-############################################################################
-# HDF5
-############################################################################
-
-RUN set -eux; \
-    mkdir -p /tmp/build-hdf5; \
-    cd /tmp/build-hdf5; \
-    curl --location --output hdf5.tar.gz \
-        "https://github.com/HDFGroup/hdf5/archive/refs/tags/hdf5-${HDF5_VERSION//./_}.tar.gz"; \
-    mkdir hdf5; \
-    tar --extract --directory hdf5 --strip-components=1 --file hdf5.tar.gz; \
-    cd hdf5; \
-    ./configure --prefix=/usr/local/ --with-szlib=/usr/local/; \
-    make -j "$(nproc)"; \
-    make install; \
-    strip --strip-debug /usr/local/lib/libhdf5*.so.* || true; \
-    rm -f /usr/local/lib/libhdf5*.a; \
-    rm -rf /tmp/build-hdf5
-
-############################################################################
-# NetCDF-C
-############################################################################
-
-RUN set -eux; \
-    mkdir -p /tmp/build-netcdf-c; \
-    cd /tmp/build-netcdf-c; \
-    curl --location --output netcdf-c.tar.gz \
-        "https://github.com/Unidata/netcdf-c/archive/refs/tags/v${NETCDF_C_VERSION%%[a-z]*}.tar.gz"; \
-    mkdir netcdf-c; \
-    tar --extract --directory netcdf-c --strip-components=1 --file netcdf-c.tar.gz; \
-    cd netcdf-c; \
-    cmake -B cmake_build -S . \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DBUILD_SHARED_LIBS=ON \
-        -DENABLE_TESTS=OFF; \
-    cmake --build cmake_build --parallel "$(nproc)"; \
-    cmake --build cmake_build --target install; \
-    ldconfig; \
-    rm -rf /tmp/build-netcdf-c
-
-############################################################################
-# NetCDF-Fortran
-############################################################################
-
-RUN set -eux; \
-    mkdir -p /tmp/build-netcdf-fortran; \
-    cd /tmp/build-netcdf-fortran; \
-    curl --location --output netcdf-fortran.tar.gz \
-        "https://github.com/Unidata/netcdf-fortran/archive/refs/tags/v${NETCDF_FORTRAN_VERSION%%[a-z]*}.tar.gz"; \
-    mkdir netcdf-fortran; \
-    tar --extract --directory netcdf-fortran --strip-components=1 --file netcdf-fortran.tar.gz; \
-    cd netcdf-fortran; \
-    cmake -B cmake_build -S . \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DBUILD_SHARED_LIBS=ON \
-        -DENABLE_TESTS=OFF \
-        -DCMAKE_Fortran_COMPILER=/opt/rh/gcc-toolset-10/root/usr/bin/gfortran; \
-    cmake --build cmake_build --parallel "$(nproc)"; \
-    cmake --build cmake_build --target install; \
-    ldconfig; \
-    rm -rf /tmp/build-netcdf-fortran
+# Install ESMPy from the git tag, matching the original forcing Dockerfile.
+# The source tarball can build the same code, but ESMPy's package versioning
+# depends on git metadata and may otherwise report a beta-looking version.
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
+    set -eux; \
+    python -m pip install --upgrade pip setuptools wheel; \
+    python -m pip install numpy setuptools-git-versioning; \
+    git clone --depth 1 --branch "v${ESMF_VERSION}" https://github.com/esmf-org/esmf.git /tmp/esmf; \
+    cd /tmp/esmf/src/addon/esmpy; \
+    python -m pip install .; \
+    cd /; \
+    rm -rf /tmp/esmf
 
 
 ############################################################################
 # Boost
+#
+# Bookworm provides Boost 1.74, but LASAM requires Boost >= 1.79.
+# Build Boost from source and install a copy of the source tree under /opt/boost
+# so downstream CMake builds can use -DBOOST_ROOT=/opt/boost.
 ############################################################################
 
 RUN set -eux; \
@@ -304,34 +202,16 @@ RUN set -eux; \
     rm -rf /tmp/build-boost
 
 ############################################################################
-# GDAL
+# Stable Python dependencies
 ############################################################################
 
-RUN set -eux && \
-    mkdir -p /tmp/build-gdal && \
-    cd /tmp/build-gdal && \
-    curl --location --output gdal.tar.gz \
-        "https://github.com/OSGeo/gdal/releases/download/v${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz" && \
-    mkdir gdal && \
-    tar --extract --directory gdal --strip-components=1 --file gdal.tar.gz && \
-    cd gdal && \
-    cmake -B build -S . \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX=/usr/local && \
-    cmake --build build --parallel "$(nproc)" && \
-    cmake --build build --target install && \
-    ldconfig && \
-    rm -rf /tmp/build-gdal
-
-############################################################################
-# Runtime environment
-############################################################################
-
-ENV LD_LIBRARY_PATH="/usr/lib64/openmpi/lib:/usr/local/lib:/usr/local/lib64"
-ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
-ENV OMPI_MCA_btl=^openib,ofi
-ENV OMPI_MCA_pml=ob1
-ENV OMPI_MCA_btl_base_warn_component_unused=0
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
+    set -eux; \
+    python -m pip install --upgrade pip setuptools wheel; \
+    python -m pip install --no-binary=mpi4py mpi4py; \
+    python -m pip install netcdf4 bmipy pandas pyyml; \
+    python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; \
+    python -m pip cache purge
 
 WORKDIR /
 

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -99,7 +99,7 @@ ENV VIRTUAL_ENV="/ngen-app/ngen-python" \
 
 RUN set -eux; \
     mkdir -p /ngen-app; \
-    python -m venv "${VIRTUAL_ENV}";
+    python -m venv "${VIRTUAL_ENV}"
 
 
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64"
@@ -211,11 +211,11 @@ RUN set -eux; \
 
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
-    python -m pip install --upgrade pip setuptools wheel; \
+    python -m pip install --upgrade pip setuptools wheel build pyproject_hooks packaging; \
     python -m pip install --no-binary=mpi4py mpi4py; \
     python -m pip install netcdf4 bmipy pandas pyyml; \
-    python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; \
-    python -m pip cache purge
+    python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
 
 WORKDIR /
 

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -8,9 +8,7 @@
 #   - NetCDF-C
 #   - NetCDF-Fortran
 #   - GDAL
-
-FROM ${BASE_IMAGE}
-
+#   - UDUNITS2
 #
 # Builds from source where still needed:
 #   - WGRIB2
@@ -18,15 +16,22 @@ FROM ${BASE_IMAGE}
 #   - ESMF + ESMPy
 ############################################################################
 
-ARG DEPS_BASE_REPO=python
-ARG DEPS_BASE_TAG=3.14-slim-bookworm
+ARG BASE_IMAGE=python:3.14-slim-bookworm
 
-FROM ${DEPS_BASE_REPO}:${DEPS_BASE_TAG}
+FROM ${BASE_IMAGE}
+
+ARG BASE_IMAGE
+ARG BASE_IMAGE_NAME="${BASE_IMAGE}"
+ARG BASE_IMAGE_DIGEST="unknown"
+ARG IMAGE_SOURCE="unknown"
 
 ARG ESMF_VERSION=8.8.0
 ARG BOOST_VERSION=1.86.0
 
-LABEL io.ngwpc.boost.version="${BOOST_VERSION}" \
+LABEL org.opencontainers.image.base.name="${BASE_IMAGE_NAME}" \
+      org.opencontainers.image.base.digest="${BASE_IMAGE_DIGEST}" \
+      org.opencontainers.image.source="${IMAGE_SOURCE}" \
+      io.ngwpc.boost.version="${BOOST_VERSION}" \
       io.ngwpc.esmf.version="${ESMF_VERSION}"
 
 ENV LANG="C.UTF-8" \
@@ -89,14 +94,13 @@ ENV PATH="${PATH}:/usr/lib/x86_64-linux-gnu/openmpi/bin"
 # Create the shared Python virtual environment early so Python packages built by
 # compiled dependencies, including ESMPy and mpi4py, install into the same venv
 # reused later by forcing, ngen, and downstream images.
-ENV VIRTUAL_ENV="/ngen-app/ngen-python"
-ENV PATH="${VIRTUAL_ENV}/bin:/usr/local/bin:${PATH}"
-ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.14/site-packages:/usr/local/lib/python3.14/site-packages"
+ENV VIRTUAL_ENV="/ngen-app/ngen-python" \
+    PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
 RUN set -eux; \
     mkdir -p /ngen-app; \
-    python -m venv --system-site-packages "${VIRTUAL_ENV}"; \
-    python -c "import sys; print(sys.executable)"
+    python -m venv "${VIRTUAL_ENV}";
+
 
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64"
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
@@ -168,7 +172,7 @@ ENV ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.m
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
     python -m pip install --upgrade pip setuptools wheel; \
-    python -m pip install numpy setuptools-git-versioning; \
+    python -m pip install setuptools-git-versioning; \
     git clone --depth 1 --branch "v${ESMF_VERSION}" https://github.com/esmf-org/esmf.git /tmp/esmf; \
     cd /tmp/esmf/src/addon/esmpy; \
     python -m pip install .; \

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -14,6 +14,7 @@
 #   - WGRIB2
 #   - Boost
 #   - ESMF + ESMPy
+#   - ecFlow Python client
 ############################################################################
 
 ARG BASE_IMAGE=python:3.12-slim-bookworm
@@ -27,12 +28,16 @@ ARG IMAGE_SOURCE="unknown"
 
 ARG ESMF_VERSION=8.8.0
 ARG BOOST_VERSION=1.86.0
+ARG ECFLOW_VERSION=5.15.2
+ARG ECBUILD_VERSION=3.14.2
 
 LABEL org.opencontainers.image.base.name="${BASE_IMAGE_NAME}" \
       org.opencontainers.image.base.digest="${BASE_IMAGE_DIGEST}" \
       org.opencontainers.image.source="${IMAGE_SOURCE}" \
       io.ngwpc.boost.version="${BOOST_VERSION}" \
-      io.ngwpc.esmf.version="${ESMF_VERSION}"
+      io.ngwpc.esmf.version="${ESMF_VERSION}" \
+      io.ngwpc.ecflow.version="${ECFLOW_VERSION}" \
+      io.ngwpc.ecbuild.version="${ECBUILD_VERSION}"
 
 ENV LANG="C.UTF-8" \
     PATH="/usr/local/bin:${PATH}"
@@ -224,6 +229,10 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
 # Bookworm provides Boost 1.74, but LASAM requires Boost >= 1.79.
 # Build Boost from source and install a copy of the source tree under /opt/boost
 # so downstream CMake builds can use -DBOOST_ROOT=/opt/boost.
+#
+# The sed call removes Boost.NumPy. The ecFlow Python client needs
+# Boost.Python but does not need Boost.NumPy, which can be problematic here.
+# Boost.Python is required by the ecFlow Python client.
 ############################################################################
 
 RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
@@ -236,7 +245,9 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
     tar --extract --directory boost --strip-components=1 --file boost.tar.gz; \
     cd boost; \
     ./bootstrap.sh; \
-    ./b2 install --prefix=/usr/local --without-python; \
+    sed -i 's/boost-install boost_python boost_numpy/boost-install boost_python/' libs/python/build/Jamfile; \
+    CPLUS_INCLUDE_PATH="/usr/local/include/python3.12" \
+        ./b2 install --prefix=/usr/local; \
     rm -rf /opt/boost; \
     mkdir --parents /opt/boost; \
     cp -a /tmp/build-boost/boost/. /opt/boost/; \
@@ -251,14 +262,14 @@ RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
 # installation used by ESMF, ESMPy, and ngen.
 ############################################################################
 
+# pybind11 is required to build the ecFlow Python client
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
     python -m pip install \
         "numpy==1.26.4" \
         netcdf4 \
         bmipy \
-        pandas \
-        pyyml; \
+        pandas; \
     python -m pip install \
         --no-binary=mpi4py \
         mpi4py; \
@@ -267,8 +278,49 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
         torch \
         torchvision
 
-# Verify the configured NumPy constraint, package compatibility, and the
-# installed NumPy version after all Python dependencies have been installed.
+
+############################################################################
+# ecFlow Python client (requires build from source)
+############################################################################
+
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm \
+    --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
+    set -eux; \
+    mkdir -p /tmp/build-ecflow; \
+    python -m pip install "pybind11>=2.10.3"; \
+    cd /tmp/build-ecflow; \
+    git clone --depth 1 --branch "${ECFLOW_VERSION}" \
+        https://github.com/ecmwf/ecflow.git; \
+    git clone --depth 1 --branch "${ECBUILD_VERSION}" \
+        https://github.com/ecmwf/ecbuild.git; \
+    PYBIND11_CMAKE_DIR="$(python -c \
+        'import pybind11; print(pybind11.get_cmake_dir())')"; \
+    cmake -B ecflow/build -S ecflow \
+        -DCMAKE_INSTALL_PREFIX="${VIRTUAL_ENV}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="${PYBIND11_CMAKE_DIR}" \
+        -DENABLE_PYTHON=ON \
+        -DENABLE_SERVER=OFF \
+        -DENABLE_UI=OFF \
+        -DENABLE_TESTS=OFF \
+        -DENABLE_DOCS=OFF \
+        -DENABLE_SSL=ON \
+        -DENABLE_STATIC_BOOST_LIBS=OFF \
+        -DBOOST_ROOT=/usr/local \
+        -DBoost_NO_SYSTEM_PATHS=on \
+        -DPython3_EXECUTABLE="$(which python)"; \
+    cmake --build ecflow/build \
+        --parallel "$(( $(nproc) < 4 ? $(nproc) : 4 ))"; \
+    cmake --install ecflow/build; \
+    python -m pip uninstall -y pybind11; \
+    python -c "import ecflow; print(f'ecFlow Python client version {ecflow.__version__} installed successfully')"; \
+    rm -rf /tmp/build-ecflow
+
+WORKDIR /
+
+
+# Verify that all installed Python packages have compatible dependencies and
+# that later installations did not replace NumPy 1.26.4.
 RUN set -eux; \
     test "$(command -v python)" = "${VIRTUAL_ENV}/bin/python"; \
     test "${PIP_CONSTRAINT}" = "/ngen-app/python-constraints.txt"; \

--- a/Dockerfile.dependencies
+++ b/Dockerfile.dependencies
@@ -59,13 +59,16 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locke
         gfortran \
         git \
         jq \
+        libaec-dev \
         libbz2-dev \
         libcurl4-openssl-dev \
         libffi-dev \
         libgdal-dev \
         libhdf5-dev \
+        liblapack-dev \
         libnetcdf-dev \
         libnetcdff-dev \
+        libopenblas-dev \
         libopenjp2-7-dev \
         libopenmpi-dev \
         libpng-dev \
@@ -73,7 +76,6 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locke
         libsqlite3-dev \
         libssl-dev \
         libudunits2-dev \
-        libaec-dev \
         m4 \
         netcdf-bin \
         openmpi-bin \
@@ -89,7 +91,11 @@ RUN --mount=type=cache,target=/var/cache/apt,id=apt-cache-bookworm,sharing=locke
 
 SHELL ["/bin/bash", "-c"]
 
-ENV PATH="${PATH}:/usr/lib/x86_64-linux-gnu/openmpi/bin"
+RUN update-ccache-symlinks
+
+ENV PATH="/usr/lib/ccache:${PATH}:/usr/lib/x86_64-linux-gnu/openmpi/bin" \
+    CCACHE_DIR="/root/.cache/ccache" \
+    CCACHE_MAXSIZE="10G"
 
 # Create the shared Python virtual environment early so Python packages built by
 # compiled dependencies, including ESMPy and mpi4py, install into the same venv
@@ -101,7 +107,6 @@ RUN set -eux; \
     mkdir -p /ngen-app; \
     python -m venv "${VIRTUAL_ENV}"
 
-
 ENV LD_LIBRARY_PATH="/usr/lib/x86_64-linux-gnu/openmpi/lib:/usr/local/lib:/usr/local/lib64"
 ENV OMPI_MCA_btl_vader_single_copy_mechanism=none
 ENV OMPI_MCA_btl=^openib,ofi
@@ -112,7 +117,8 @@ ENV OMPI_MCA_btl_base_warn_component_unused=0
 # WGRIB2
 ############################################################################
 
-RUN set -eux; \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+    set -eux; \
     mkdir -p /tmp/build-wgrib2; \
     cd /tmp/build-wgrib2; \
     curl --location --output wgrib2.tgz \
@@ -138,6 +144,55 @@ RUN set -eux; \
 ENV WGRIB2=/usr/local/bin/wgrib2
 
 ############################################################################
+# NumPy 1.26.4
+#
+# NumPy 1.26.4 is built from source because no compatible prebuilt wheel is
+# available for Python 3.14. The build is explicitly linked against OpenBLAS
+# for BLAS and LAPACK operations used by NumPy, SciPy, and t-route.
+#
+# NumPy is installed before other Python packages so their dependency
+# resolution uses this build instead of installing or building another NumPy
+# version. The constraints file created below pins later pip installations to
+# NumPy 1.26.4 without causing NumPy to be installed again.
+############################################################################
+
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
+    --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+    set -eux; \
+    python -m pip install --upgrade \
+        pip \
+        setuptools \
+        wheel \
+        build \
+        pyproject_hooks \
+        packaging; \
+    python -m pip install \
+        --no-binary=numpy \
+        -Csetup-args=-Dblas=openblas \
+        -Csetup-args=-Dlapack=openblas \
+        "numpy==1.26.4"
+
+# Prevent later pip installations from replacing the custom NumPy build with
+# another version while resolving their transitive dependencies.
+RUN printf '%s\n' \
+        'numpy==1.26.4' \
+        > /ngen-app/python-constraints.txt
+
+
+# Apply the NumPy pin automatically to subsequent pip installations in this
+# image and downstream images. A downstream installation that requires an
+# incompatible NumPy version will fail rather than replace NumPy 1.26.4.
+ENV PIP_CONSTRAINT="/ngen-app/python-constraints.txt"
+
+# Verify that NumPy is linked against OpenBLAS and that a LAPACK operation
+# executes successfully.
+RUN set -eux && \
+    SP="$(python -c 'import numpy, os; print(os.path.dirname(numpy.__file__))')" && \
+    ldd "$(find "$SP" -name '_multiarray_umath*.so' | head -1)" | grep -q openblas && \
+    ldd "$(find "$SP/linalg" -name '_umath_linalg*.so' | head -1)" | grep -q openblas && \
+    python -c "import numpy as np; np.linalg.svd(np.eye(8)); print('numpy', np.__version__, 'BLAS+LAPACK -> OpenBLAS OK')"
+
+############################################################################
 # ESMF + ESMPy
 #
 # ESMF is the one large scientific library still built from source in this
@@ -147,7 +202,8 @@ ENV WGRIB2=/usr/local/bin/wgrib2
 # /usr/local NetCDF at runtime.
 ############################################################################
 
-RUN set -eux; \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+    set -eux; \
     mkdir -p /tmp/build-esmf; \
     cd /tmp/build-esmf; \
     curl --location --output "esmf-${ESMF_VERSION}.tar.gz" \
@@ -171,14 +227,15 @@ ENV ESMFMKFILE=/usr/local/esmf/lib/libO/Linux.gfortran.64.openmpi.default/esmf.m
 # depends on git metadata and may otherwise report a beta-looking version.
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
-    python -m pip install --upgrade pip setuptools wheel; \
-    python -m pip install setuptools-git-versioning; \
-    git clone --depth 1 --branch "v${ESMF_VERSION}" https://github.com/esmf-org/esmf.git /tmp/esmf; \
+    python -m pip install \
+        setuptools-git-versioning; \
+    git clone --depth 1 --branch "v${ESMF_VERSION}" \
+        https://github.com/esmf-org/esmf.git /tmp/esmf; \
     cd /tmp/esmf/src/addon/esmpy; \
-    python -m pip install .; \
+    python -m pip install \
+        .; \
     cd /; \
     rm -rf /tmp/esmf
-
 
 ############################################################################
 # Boost
@@ -188,7 +245,8 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
 # so downstream CMake builds can use -DBOOST_ROOT=/opt/boost.
 ############################################################################
 
-RUN set -eux; \
+RUN --mount=type=cache,target=/root/.cache/ccache,id=ccache-bookworm,sharing=locked \
+    set -eux; \
     mkdir -p /tmp/build-boost; \
     cd /tmp/build-boost; \
     curl --location --output boost.tar.gz \
@@ -211,11 +269,26 @@ RUN set -eux; \
 
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache-bookworm \
     set -eux; \
-    python -m pip install --upgrade pip setuptools wheel build pyproject_hooks packaging; \
-    python -m pip install --no-binary=mpi4py mpi4py; \
-    python -m pip install netcdf4 bmipy pandas pyyml; \
-    python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+    python -m pip install \
+        --no-binary=mpi4py \
+        mpi4py; \
+    python -m pip install \
+        netcdf4 \
+        bmipy \
+        pandas \
+        pyyml; \
+    python -m pip install \
+        --index-url https://download.pytorch.org/whl/cpu \
+        torch \
+        torchvision
 
+# Verify that all installed Python packages have compatible dependencies and
+# that later installations did not replace NumPy 1.26.4.
+RUN set -eux; \
+    test "${PIP_CONSTRAINT}" = "/ngen-app/python-constraints.txt"; \
+    grep -qx 'numpy==1.26.4' "${PIP_CONSTRAINT}"; \
+    python -m pip check; \
+    python -c "import numpy as np; assert np.__version__ == '1.26.4', np.__version__; np.linalg.svd(np.eye(8)); print('Final NumPy version:', np.__version__)"
 
 WORKDIR /
 

--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/mpi_utils.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/core/mpi_utils.py
@@ -17,15 +17,10 @@ def get_new_broadcasted_uid() -> str:
     if MPI.COMM_WORLD.rank == 0:
         rng = np.random.default_rng()
         rand_uint64 = rng.integers(0, 2**64, dtype=np.uint64)
-    else:
-        rand_uint64 = None
 
     rand_uint64 = MPI.COMM_WORLD.bcast(rand_uint64, root=0)
 
-    # Convert the NumPy uint64 to a built-in Python int. Python 3.14's uuid
-    # implementation expects a native int internally, while this remains fully
-    # compatible with earlier Python versions.
+    # uuid.UUID expects a built-in Python int. Convert the NumPy uint64
     uid_64bit_hex = uuid.UUID(int=int(rand_uint64)).hex
     assert len(uid_64bit_hex) == 32
-    uid64 = uid_64bit_hex[16:]
-    return uid64
+    return uid_64bit_hex[16:]


### PR DESCRIPTION
Update the Debian dependencies image: add ecFlow Python client. This must be built from source using:

https://github.com/ecmwf/ecflow

and

https://github.com/ecmwf/ecbuild

This PR is analogous to https://github.com/NGWPC/ngen-forcing/pull/186. ~~and uses the same cross-OS `install_ecflow_python_client.sh`.~~

## Additions

- ecFlow Python client installation inside the existing `Dockerfile.dependencies`. ~~via new shell script that builds on Rocky or Debuntu (Debian / Ubuntu), called near the bottom of the dependencies Dockerfile.~~

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

