### PR TITLE
silence crs warning

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -19,6 +19,7 @@ import xarray as xr
 import zarr
 from dotenv import find_dotenv, load_dotenv
 from pyproj import CRS
+import warnings
 from zarr.storage import ObjectStore
 import traceback
 
@@ -27,7 +28,7 @@ from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.config import (
 )
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.core.parallel import MpiConfig
 from NextGen_Forcings_Engine_BMI.NextGen_Forcings_Engine.general_utils import rand_str
-
+warnings.filterwarnings("ignore", module="geopandas")
 LOG = logging.getLogger("FORCING")
 
 zarr.config.set({"async.concurrency": 100})


### PR DESCRIPTION
A small PR to silence a geopandas warning about buffering with a geographic CRS. Since it is a buffer, accuracy isn't a primary concern; i.e., if we buffer 1 mile or 1.2 miles, it is sufficient either way. 

## Additions

-

## Removals

-

## Changes

-

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

