### PR TITLE
bandaid fix to deal with NWM rainrate being slightly negative in some…

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -236,6 +236,9 @@ class BaseProcessor:
             raise KeyError(
                 f"The time provided ({self.current_time}) is not in the dataset. Please check that you have provided a time span that is valid for the given domain/dataset."
             )
+        if self.dataset_name=="NWM":
+            #NOTE this is a bandaid for NWM Retrospective dataset Hawaii where rainrates appear to be slightly negative.
+            ds["RAINRATE"]=xr.where(ds["RAINRATE"]<0,0,ds["RAINRATE"])
         # if self.mpi_config.rank == 0:
         #     self.plot_precip(ds)
         # self.write_sum_tif(self.computed_ds)


### PR DESCRIPTION
There appears to be an issue with the NWM Retrospective dataset where rain rate values fall very slightly negative. As a band aid fix I've replaced all slightly negative rain rate values with zero when reading the source dataset. 

https://jira.nextgenwaterprediction.com/browse/NGWPC-10972

## Additions

-

## Removals

-

## Changes

-

## Testing

1. Testing performed in RTE. The issue was replicated then the remedy tested. 

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

