### PR TITLE
Fix MPI Type Error (NGWPC-11089)

### DIFF
--- a/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
+++ b/NextGen_Forcings_Engine_BMI/NextGen_Forcings_Engine/historical_forcing.py
@@ -250,8 +250,9 @@ class BaseProcessor:
         if self.mpi_config.rank == 0:
             with self.timing_block("computing dataset", LOG.info):
                 ds = self.sliced_ds.rio.write_crs(self.src_crs)
-        self.mpi_config.comm.barrier()
-        ds = self.mpi_config.comm.bcast(ds, root=0)
+        if self.mpi_config.size > 1:
+            self.mpi_config.comm.barrier()
+            ds = self.mpi_config.comm.bcast(ds, root=0)
         if self.mpi_config.rank == 0:
             if not os.path.exists(self.nc_path):
                 tmp_file = (


### PR DESCRIPTION
Calibration runs were failing when there was only one catchment. The problem seems to be resolved by only broadcasting the AORC dataset slice when MPI has positively detected that there are other processes running. I'm unsure why this makes a difference based on documentation of how MPI should work, but testing shows it addresses the issue.

## Additions

-

## Removals

-

## Changes

- Check if there are multiple processes before broadcasting AORC data slice.

## Testing

1. Ian and Jeff both confirmed this addresses the issue using RTE calibration runs.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Linux

